### PR TITLE
fix missing executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "create-project-calavera",
   "version": "0.0.1",
   "description": "A simple starting skeleton for common web projects.",
-  "main": "src/index.js",
+  "exports": "./src/index.js",
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Fix missing executable. I believe I need to use `exports` and not `main` in `package.json`.