### PR TITLE
feat: add tsconfig and tsconfig noEmit variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-project-calavera",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A simple starting skeleton for common web projects.",
   "exports": "./src/index.js",
   "bin": {
@@ -8,7 +8,6 @@
   },
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "prettier:lint": "prettier .",
     "prettier:format": "prettier --write .",
     "lint:js": "eslint .",

--- a/src/installers/ts-eslint.js
+++ b/src/installers/ts-eslint.js
@@ -1,0 +1,3 @@
+const configureTSESLint = async () => {};
+
+export default configureTSESLint;

--- a/src/installers/tsconfig.js
+++ b/src/installers/tsconfig.js
@@ -1,0 +1,86 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { FileWriteError } from "../utils/file-write-error.js";
+import { logger } from "../utils/logger.js";
+
+const configureTSConfig = async (noEmit = false) => {
+  const dependencies = ["typescript"];
+  const packageJSONPath = resolve("package.json");
+
+  const rootTSConfig = {
+    extends: "./.project-calavera/tsconfig.json",
+  };
+
+  const baseConfig = {
+    include: ["src/**/*.ts*"],
+    exclude: ["node_modules"],
+  };
+
+  const tsConfig = {
+    ...baseConfig,
+    compilerOptions: {
+      allowImportingTsExtensions: true,
+      allowJs: true, // Allow JavaScript files to be imported
+      esModuleInterop: true, // Properly support importing CJS modules in ESM
+      forceConsistentCasingInFileNames: true,
+      module: "ESNext",
+      target: "ESNext",
+      moduleResolution: "node",
+      noUncheckedIndexedAccess: true, // https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess
+      resolveJsonModule: true, // Enable JSON imports.
+      skipLibCheck: true,
+      sourceMap: true,
+      strict: true,
+    },
+  };
+
+  const tsConfigNoEmit = {
+    ...baseConfig,
+    compilerOptions: {
+      noEmit: true,
+      allowImportingTsExtensions: true,
+      allowJs: true, // Allow JavaScript files to be imported
+      esModuleInterop: true, // Properly support importing CJS modules in ESM
+      forceConsistentCasingInFileNames: true,
+      target: "ESNext",
+      moduleResolution: "bundler",
+      noUncheckedIndexedAccess: true, // https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess
+      resolveJsonModule: true, // Enable JSON imports.
+      skipLibCheck: true,
+      strict: true,
+      isolatedModules: true,
+      verbatimModuleSyntax: true,
+    },
+  };
+
+  const config = noEmit ? tsConfigNoEmit : tsConfig;
+
+  try {
+    const packageJSON = JSON.parse(await readFile(packageJSONPath));
+    packageJSON.scripts["build:ts"] = "tsc";
+
+    logger.info("🧶 Adding TypeScript to the project...");
+
+    const tsConfigString = JSON.stringify(config, null, 2);
+
+    await mkdir(".project-calavera", { recursive: true });
+    await writeFile(".project-calavera/tsconfig.json", `${tsConfigString}\n`);
+
+    await writeFile(
+      "tsconfig.json",
+      `${JSON.stringify(rootTSConfig, null, 2)}\n`,
+    );
+
+    const updatedPackageJSON = JSON.stringify(packageJSON, null, 2);
+    await writeFile(packageJSONPath, `${updatedPackageJSON}\n`);
+  } catch (error) {
+    throw new FileWriteError("Failed to add TypeScript configuration.", {
+      cause: error,
+    });
+  }
+
+  return dependencies;
+};
+
+export default configureTSConfig;


### PR DESCRIPTION
This adds two new options.

TSConfig and TSConfig noEmit. 

The first is when writing TypeScript without a bundler and the second is when you need a tsconfig but you are also using a bundler.

It is likely that the second scenario will be less needed by users of Project Calabera, but it does not add much of a maintenance burden so I added it.

Also fixes an Emoji and uses the Spinner during dependency installation.

fix #5