### PR TITLE
fix: move prettier to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,26 @@
 {
   "name": "create-project-calavera",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-project-calavera",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.8.2",
         "chalk": "^5.3.0",
-        "execa": "^9.5.2"
+        "execa": "^9.5.2",
+        "prettier": "^3.4.2"
+      },
+      "bin": {
+        "create-project-calavera": "src/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
         "eslint": "^9.17.0",
         "globals": "^15.13.0",
-        "prettier": "^3.4.2",
         "stylelint": "^16.11.0",
         "stylelint-config-standard": "^36.0.1",
         "stylelint-order": "^6.0.4"
@@ -1940,7 +1943,6 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-project-calavera",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A simple starting skeleton for common web projects.",
   "exports": "./src/index.js",
   "bin": {
@@ -36,13 +36,13 @@
   "dependencies": {
     "@clack/prompts": "^0.8.2",
     "chalk": "^5.3.0",
-    "execa": "^9.5.2"
+    "execa": "^9.5.2",
+    "prettier": "^3.4.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "eslint": "^9.17.0",
     "globals": "^15.13.0",
-    "prettier": "^3.4.2",
     "stylelint": "^16.11.0",
     "stylelint-config-standard": "^36.0.1",
     "stylelint-order": "^6.0.4"


### PR DESCRIPTION
I believe the reason the CLI is breaking at the moment is because prettier is in devDependencies instead of dependencies. This fixes that so let us see.