### PR TITLE
feat: enable use-baseline for eslint-html

### DIFF
--- a/src/installers/eslint.js
+++ b/src/installers/eslint.js
@@ -49,13 +49,13 @@ export default [
     .replace(
       /%HTML_CONFIG%/,
       withHTML
-        ? '{...html.configs["flat/recommended"],files: ["**/*.html"], rules: { "@html-eslint/indent": "off" },},'
+        ? '{...html.configs["flat/recommended"],files: ["**/*.html"], rules: { "@html-eslint/indent": "off", "@html-eslint/use-baseline": "warn", },},'
         : "",
     );
 
   try {
     const packageJSON = JSON.parse(await readFile(packageJSONPath));
-    packageJSON.scripts["lint:js"] = "eslint .";
+    packageJSON.scripts["lint:eslint"] = "eslint .";
 
     logger.info("🧶 Adding ESLint to the project...");
 

--- a/src/installers/ts-eslint.js
+++ b/src/installers/ts-eslint.js
@@ -64,13 +64,13 @@ export default tseslint.config(
     .replace(
       /%HTML_CONFIG%/,
       withHTML
-        ? '{...html.configs["flat/recommended"],files: ["**/*.html"], rules: { "@html-eslint/indent": "off" },},'
+        ? '{...html.configs["flat/recommended"],files: ["**/*.html"], rules: { "@html-eslint/indent": "off", "@html-eslint/use-baseline": "warn", },},'
         : "",
     );
 
   try {
     const packageJSON = JSON.parse(await readFile(packageJSONPath));
-    packageJSON.scripts["lint:ts"] = "eslint .";
+    packageJSON.scripts["lint:eslint"] = "eslint .";
 
     logger.info("🧶 Adding typescript-eslint to the project...");
 


### PR DESCRIPTION
Adds `use-baseline` as a warning for ESLint HTML linting. 
https://html-eslint.org/docs/rules/use-baseline

fix #56