### PR TITLE
feat: Add stylelint-plugin-use-baseline to Stylelint configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-project-calavera",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A simple starting skeleton of linters and formatters for common web projects.",
   "exports": "./src/index.js",
   "bin": {

--- a/src/installers/stylelint.js
+++ b/src/installers/stylelint.js
@@ -9,15 +9,17 @@ const configureStylelint = async () => {
     "stylelint",
     "stylelint-config-standard",
     "stylelint-order",
+    "stylelint-plugin-use-baseline",
   ];
   const packageJSONPath = resolve("package.json");
 
   const stylelintConfig = {
     extends: "stylelint-config-standard",
-    plugins: ["stylelint-order"],
+    plugins: ["stylelint-order", "stylelint-plugin-use-baseline"],
     rules: {
       "order/properties-alphabetical-order": true,
       "custom-property-empty-line-before": null,
+      "plugin/use-baseline": true, // default availability is set to Baseline widely available
     },
   };
 


### PR DESCRIPTION
Adds the `stylelint-plugin-use-baseline` plugin to the Stylelint configuration. 
It uses the default of Baseline widely available. 

fix #54