### PR TITLE
Add Calavera accent styling and update composer copy

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -19,7 +19,10 @@
       property="og:image"
       content="https://calavera.schalkneethling.com/calavera-social-share.png"
     />
-    <meta property="og:image:alt" content="Calavera Composer tooling recipe builder" />
+    <meta
+      property="og:image:alt"
+      content="Calavera Composer tooling recipe builder"
+    />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
@@ -32,7 +35,10 @@
       name="twitter:image"
       content="https://calavera.schalkneethling.com/calavera-social-share.png"
     />
-    <meta name="twitter:image:alt" content="Calavera Composer tooling recipe builder" />
+    <meta
+      name="twitter:image:alt"
+      content="Calavera Composer tooling recipe builder"
+    />
     <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="shortcut icon" href="/favicon.ico" />
@@ -44,14 +50,16 @@
   <body>
     <main class="shell">
       <aside class="webmcp-banner" id="webmcp-banner" hidden>
-        WebMCP available: agents can compose and download recipes from this page.
+        WebMCP available: agents can compose and download recipes from this
+        page.
       </aside>
 
       <section class="intro">
         <p class="eyebrow">Calavera</p>
         <h1>Compose a tooling recipe for any project.</h1>
         <p>
-          Choose a modern or classic workflow, add integration packs, then save a
+          Choose a modern or classic workflow, add integration packs, then save
+          a
           <code>calavera.config.json</code> for the CLI to apply.
         </p>
       </section>
@@ -61,15 +69,31 @@
           <fieldset>
             <legend>Profile</legend>
             <label for="profile-modern">
-              <input id="profile-modern" type="radio" name="profile" value="modern" checked />
+              <input
+                id="profile-modern"
+                type="radio"
+                name="profile"
+                value="modern"
+                checked
+              />
               Modern: Oxlint, Oxfmt, Stylelint
             </label>
             <label for="profile-classic">
-              <input id="profile-classic" type="radio" name="profile" value="classic" />
+              <input
+                id="profile-classic"
+                type="radio"
+                name="profile"
+                value="classic"
+              />
               Classic: ESLint, Prettier, Stylelint
             </label>
             <label for="profile-minimal">
-              <input id="profile-minimal" type="radio" name="profile" value="minimal" />
+              <input
+                id="profile-minimal"
+                type="radio"
+                name="profile"
+                value="minimal"
+              />
               Minimal: EditorConfig only
             </label>
           </fieldset>
@@ -95,6 +119,13 @@
             <button id="save" type="button">Save file</button>
             <button id="download" type="button">Download JSON</button>
           </div>
+          <p>
+            Once you have your configuration saved, head to
+            <a href="https://github.com/schalkneethling/create-project-calavera"
+              >the Project Calvera repository</a
+            >
+            to learn how to apply and manage your configuration.
+          </p>
           <pre><code id="output"></code></pre>
         </aside>
       </section>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,6 +1,8 @@
 @import url("https://fonts.googleapis.com/css2?family=Kablammo&display=swap");
 
 :root {
+  /* stylelint-disable-next-line plugin/use-baseline */
+  accent-color: var(--teal-deep);
   background: var(--paper);
   color: var(--ink);
   color-scheme: light;
@@ -65,6 +67,19 @@ button,
 input,
 select {
   font: inherit;
+}
+
+a {
+  color: var(--teal-deep);
+  font-weight: 700;
+  text-decoration-color: var(--marigold);
+  text-decoration-thickness: 0.125rem;
+  text-underline-offset: 0.1875rem;
+}
+
+a:hover {
+  color: var(--coral-deep);
+  text-decoration-color: currentcolor;
 }
 
 .shell {
@@ -170,6 +185,8 @@ label {
 
 input[type="radio"],
 input[type="checkbox"] {
+  /* stylelint-disable-next-line plugin/use-baseline */
+  accent-color: var(--teal-deep);
   block-size: 0.95rem;
   inline-size: 0.95rem;
 }
@@ -184,6 +201,12 @@ select {
   margin-block-start: 0.5rem;
   padding-block: 0.625rem;
   padding-inline: 0.75rem;
+}
+
+input:focus-visible,
+select:focus-visible {
+  outline: 0.1875rem solid var(--marigold);
+  outline-offset: 0.1875rem;
 }
 
 .integrations {
@@ -247,6 +270,12 @@ button + button {
 button:hover {
   box-shadow: 0.25rem 0.25rem 0 var(--coral);
   transform: translate(-0.0625rem, -0.0625rem);
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 0.1875rem solid var(--marigold);
+  outline-offset: 0.1875rem;
 }
 
 pre {


### PR DESCRIPTION
## Summary
- Apply the Calavera accent color to native radio and checkbox controls with targeted Stylelint suppressions.
- Style links and focus states to match the existing palette instead of the browser default blue.
- Update composer copy and metadata formatting in the web UI for a cleaner presentation.

## Testing
- Stylelint passed for the web stylesheet.
- Rebuilt the Vite web bundle to refresh the preview output.