### PR TITLE
Respect devEngines package manager detection for Bun projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,29 @@ npm create project-calavera doctor --json
 npm create project-calavera apply --dry-run --json
 ```
 
+### Bun-managed projects and npm `devEngines`
+
+Some starters declare Bun in `devEngines.packageManager`. npm 11 fails before
+Calavera can run when `npm create` is used from one of those projects:
+
+```text
+Invalid devEngines.packageManager
+Invalid name "bun" does not match "npm" for "packageManager"
+```
+
+Use the package manager declared by the project instead:
+
+```bash
+bunx create-project-calavera apply
+```
+
+If you intentionally want to launch through npm anyway, npm requires `--force`
+to bypass its own `devEngines` preflight:
+
+```bash
+npm --force create project-calavera apply
+```
+
 ## Common Flags
 
 - `--config calavera.config.json`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-project-calavera",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Compose and apply modern tooling recipes for JavaScript and TypeScript projects.",
   "keywords": [
     "cli",

--- a/src/index.js
+++ b/src/index.js
@@ -197,6 +197,18 @@ function detectPackageManager(packageJSON = {}) {
     return "bun";
   }
 
+  const devPackageManagers = [packageJSON.devEngines?.packageManager]
+    .flat()
+    .filter(Boolean)
+    .map((packageManager) => packageManager.name);
+  const devPackageManager = devPackageManagers.find((packageManager) =>
+    supportedPackageManagers.includes(packageManager),
+  );
+
+  if (devPackageManager) {
+    return devPackageManager;
+  }
+
   if (existsSync("pnpm-lock.yaml") || existsSync("shrinkwrap.yaml")) {
     return "pnpm";
   }


### PR DESCRIPTION
## Summary
- Detect `devEngines.packageManager` and prefer the declared package manager when it matches a supported option
- Avoid npm 11 preflight failures when starters declare Bun in `devEngines.packageManager`
- Document the Bun-specific invocation path and the npm `--force` workaround
- Bump the package version to `1.0.1`

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved package manager detection so projects can respect the package manager declared in their configuration before falling back to lockfile-based detection.
  * Added CLI guidance for Bun-managed projects, including a recommended command and an npm workaround when needed.

* **Bug Fixes**
  * Clarified how to avoid failures caused by npm preflight checks in Bun-managed projects.

* **Chores**
  * Bumped the package version to 1.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->