### PR TITLE
Add public Calavera config schema and rename check script to quality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+- _Always_ ensure that we have the latest changes from the remote repository.
+- _Always_ ensure that no feature work is started from main. Always use a feature branch.
+- Do _not_ write types for the sake of types in TypeScript. Only define types when TypeScript cannot cleanly infer from usage.

--- a/GOAL.md
+++ b/GOAL.md
@@ -71,7 +71,8 @@ Calavera helps web developers compose, apply, inspect, and refresh repeatable pr
 
 The current project centers on the recipe-driven CLI, the shared integration catalog, and the Vite-based Calavera Composer. Near-term work should preserve parity between the CLI and composer, improve generated tooling quality, and keep automation-friendly outputs stable.
 
+The public draft 2020-12 recipe schema is maintained in `web/public/calavera.config.schema.json` and published with the composer at `https://calavera.schalkneethling.com/calavera.config.schema.json`.
+
 ## Open Questions
 
-- A public configuration schema does not exist yet. Implement a draft 2020-12 JSON Schema for Calavera recipes and publish it with the web composer so it is accessible at `https://calavera.schalkneethling.com/calavera.config.schema.json`. Tracked in [issue #131](https://github.com/schalkneethling/create-project-calavera/issues/131).
 - Several older installer modules remain under `src/installers/` while the main CLI now generates files directly from `src/index.js` and `src/catalog.js`. Decide whether those modules are legacy code to remove, future extraction points, or part of a planned public API. Tracked in [issue #130](https://github.com/schalkneethling/create-project-calavera/issues/130).

--- a/calavera.config.json
+++ b/calavera.config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://calavera.dev/schema/calavera.config.schema.json",
+  "$schema": "https://calavera.schalkneethling.com/calavera.config.schema.json",
   "version": 1,
   "profile": "modern",
   "packageManager": "pnpm",
@@ -25,6 +25,6 @@
     "format": true,
     "format:check": true,
     "typecheck": true,
-    "check": true
+    "quality": true
   }
 }

--- a/docs/claude-toolkit-merge-plan.md
+++ b/docs/claude-toolkit-merge-plan.md
@@ -124,7 +124,7 @@ Defer these until after the merge:
 
 ```json
 {
-  "$schema": "https://calavera.dev/schema/calavera.config.schema.json",
+  "$schema": "https://calavera.schalkneethling.com/calavera.config.schema.json",
   "version": 1,
   "profile": "modern",
   "packageManager": "pnpm",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "web:dev": "vite --host 127.0.0.1",
     "web:build": "vite build",
     "web:preview": "vite preview --host 127.0.0.1",
-    "check": "pnpm lint && pnpm format:check && pnpm typecheck",
+    "quality": "pnpm lint && pnpm format:check && pnpm typecheck",
     "lint": "node .calavera/run-if-files.mjs \"JavaScript/TypeScript\" \"js,jsx,ts,tsx,mjs,cjs\" -- oxlint . && node .calavera/run-if-files.mjs \"CSS\" \"css,scss\" -- stylelint \"**/*.{css,scss}\"",
     "lint:fix": "node .calavera/run-if-files.mjs \"JavaScript/TypeScript\" \"js,jsx,ts,tsx,mjs,cjs\" -- oxlint --fix . && node .calavera/run-if-files.mjs \"CSS\" \"css,scss\" -- stylelint \"**/*.{css,scss}\" --fix",
     "format": "node .calavera/run-if-files.mjs \"JavaScript/TypeScript\" \"js,jsx,ts,tsx,mjs,cjs\" -- oxfmt --write .",

--- a/src/index.js
+++ b/src/index.js
@@ -105,6 +105,7 @@ import { logger } from "./utils/logger.js";
  */
 
 const CONFIG_FILE = "calavera.config.json";
+const CONFIG_SCHEMA_URL = "https://calavera.schalkneethling.com/calavera.config.schema.json";
 const STATE_FILE = ".calavera/state.json";
 const SCRIPT_SOURCE_EXTENSIONS = ["js", "jsx", "ts", "tsx", "mjs", "cjs"];
 const TSC_INCLUDE_PATTERNS = SCRIPT_SOURCE_EXTENSIONS.map((extension) => `src/**/*.${extension}`);
@@ -319,7 +320,7 @@ function resolveIntegrations(recipe) {
  */
 function buildRecipe(profile, integrations, packageManager = "npm") {
   return {
-    $schema: "https://calavera.dev/schema/calavera.config.schema.json",
+    $schema: CONFIG_SCHEMA_URL,
     version: 1,
     profile,
     packageManager,
@@ -330,7 +331,7 @@ function buildRecipe(profile, integrations, packageManager = "npm") {
       format: true,
       "format:check": true,
       typecheck: true,
-      check: true,
+      quality: true,
     },
   };
 }
@@ -535,8 +536,8 @@ function buildScripts(recipe, integrations, packageManager) {
     );
   }
 
-  if (recipe.scripts?.check) {
-    const checkScripts = [
+  if (recipe.scripts?.quality) {
+    const qualityScripts = [
       "lint",
       "format:check",
       usesTypeScript && recipe.scripts?.typecheck ? "typecheck" : null,
@@ -545,7 +546,7 @@ function buildScripts(recipe, integrations, packageManager) {
       .filter(isNotEmptyString)
       .filter((script) => Boolean(scripts[script]));
 
-    scripts.check = checkScripts
+    scripts.quality = qualityScripts
       .map((script) => packageManagerCommands[supportedPackageManager].run(script))
       .join(" && ");
   }

--- a/web/public/calavera.config.schema.json
+++ b/web/public/calavera.config.schema.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://calavera.schalkneethling.com/calavera.config.schema.json",
+  "title": "Calavera configuration recipe",
+  "description": "A repeatable project tooling recipe for create-project-calavera.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "profile", "packageManager", "integrations", "scripts"],
+  "properties": {
+    "$schema": {
+      "description": "The published JSON Schema for Calavera recipe files.",
+      "type": "string",
+      "format": "uri",
+      "const": "https://calavera.schalkneethling.com/calavera.config.schema.json"
+    },
+    "version": {
+      "description": "The Calavera recipe format version.",
+      "type": "integer",
+      "const": 1
+    },
+    "profile": {
+      "description": "The base tooling profile used to compose the recipe.",
+      "type": "string",
+      "enum": ["modern", "classic", "minimal"]
+    },
+    "packageManager": {
+      "description": "The package manager used for dependency installation and generated scripts.",
+      "type": "string",
+      "enum": ["npm", "pnpm", "yarn", "bun"]
+    },
+    "integrations": {
+      "description": "Calavera integration IDs to apply. Some integrations include their required parent integration automatically.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/integrationId"
+      },
+      "uniqueItems": true
+    },
+    "scripts": {
+      "description": "Boolean package script flags. Calavera generates scripts for known enabled flags when the selected integrations support them.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "properties": {
+        "lint": {
+          "type": "boolean",
+          "description": "Generate a lint script when linting integrations are selected."
+        },
+        "lint:fix": {
+          "type": "boolean",
+          "description": "Generate a lint fix script when linting integrations are selected."
+        },
+        "format": {
+          "type": "boolean",
+          "description": "Generate a format script when formatting integrations are selected."
+        },
+        "format:check": {
+          "type": "boolean",
+          "description": "Generate a format check script when formatting integrations are selected."
+        },
+        "typecheck": {
+          "type": "boolean",
+          "description": "Generate a TypeScript typecheck script when the TypeScript integration is selected."
+        },
+        "quality": {
+          "type": "boolean",
+          "description": "Generate a combined quality script from the available lint, format, typecheck, and React Doctor scripts."
+        }
+      }
+    },
+    "ai": {
+      "description": "Optional bundled AI skills, hooks, and agents to install under .agents/.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/aiItem"
+      }
+    }
+  },
+  "$defs": {
+    "integrationId": {
+      "type": "string",
+      "enum": [
+        "editorconfig",
+        "typescript",
+        "oxlint",
+        "oxlint-eslint",
+        "oxlint-typescript",
+        "oxlint-unicorn",
+        "oxlint-oxc",
+        "oxlint-import",
+        "oxlint-react",
+        "react-doctor",
+        "oxlint-jsx-a11y",
+        "oxlint-node",
+        "oxlint-promise",
+        "oxlint-vitest",
+        "oxlint-jest",
+        "oxlint-nextjs",
+        "oxlint-vue",
+        "oxlint-jsdoc",
+        "oxfmt",
+        "eslint",
+        "typescript-eslint",
+        "eslint-config-prettier",
+        "eslint-react",
+        "eslint-jsx-a11y",
+        "eslint-import",
+        "eslint-n",
+        "eslint-promise",
+        "eslint-unicorn",
+        "eslint-sonarjs",
+        "eslint-vitest",
+        "eslint-jest",
+        "stylelint",
+        "stylelint-standard",
+        "stylelint-order",
+        "stylelint-baseline",
+        "stylelint-scss",
+        "stylelint-stylistic",
+        "css-property-type-validator",
+        "prettier",
+        "prettier-tailwind",
+        "prettier-svelte",
+        "prettier-astro"
+      ]
+    },
+    "aiItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "src"],
+      "properties": {
+        "type": {
+          "description": "The bundled AI artifact type.",
+          "type": "string",
+          "enum": ["skill", "hook", "agent"]
+        },
+        "src": {
+          "description": "Path to a bundled artifact under src/ai/.",
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "description": "Output target directory name for hook and agent artifacts. Skill artifacts do not use target.",
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(?!(?:\\.|\\.\\.)$)[^/\\\\]+$"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "skill"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "not": {
+              "required": ["target"]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/web/script.js
+++ b/web/script.js
@@ -101,6 +101,7 @@ const form = document.querySelector("#composer");
 const integrations = document.querySelector("#integrations");
 const output = document.querySelector("#output");
 const webMcpBanner = document.querySelector("#webmcp-banner");
+const configSchemaUrl = "https://calavera.schalkneethling.com/calavera.config.schema.json";
 const profiles = Object.keys(defaults);
 const packageManagers = ["npm", "pnpm", "yarn", "bun"];
 const profileDescriptions = {
@@ -186,7 +187,7 @@ function selectIntegrations(integrationIds) {
 function recipe() {
   const data = new FormData(form);
   return {
-    $schema: "https://calavera.dev/schema/calavera.config.schema.json",
+    $schema: configSchemaUrl,
     version: 1,
     profile: data.get("profile"),
     packageManager: data.get("packageManager"),
@@ -197,7 +198,7 @@ function recipe() {
       format: true,
       "format:check": true,
       typecheck: true,
-      check: true,
+      quality: true,
     },
   };
 }


### PR DESCRIPTION
## Summary
- Add the public draft 2020-12 Calavera config schema at `web/public/calavera.config.schema.json`
- Point generated recipes and the composer to the published schema URL
- Rename the generated aggregate script from `check` to `quality` across the CLI, composer, and package scripts
- Update project docs to reflect the published schema location

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a `quality` script in project configuration and generated setup.
  * Introduced a published configuration schema for validation and editor support.
* **Bug Fixes**
  * Updated generated config references to use the new schema location.
  * Replaced the old `check` script naming with `quality` to match current tooling.
* **Documentation**
  * Refreshed contribution and planning notes to reflect the latest workflow and schema status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->