### PR TITLE
Clarify frontend security guidance for CSRF and JWT docs

### DIFF
--- a/src/ai/skills/frontend-security/references/csrf-protection.md
+++ b/src/ai/skills/frontend-security/references/csrf-protection.md
@@ -74,7 +74,10 @@ res.cookie("session", value, { sameSite: "None", secure: true, httpOnly: true })
 
 Validate request origin using Sec-Fetch-\* headers as a layered control. Fetch
 Metadata does not replace CSRF tokens for cookie-authenticated state-changing
-requests.
+requests. `Sec-Fetch-Site: none` usually represents user-initiated browser
+navigations and should be allowed only for safe top-level navigations.
+`same-site` can include sibling subdomains, so allow it only when every same-site
+origin shares the same trust boundary.
 
 ```javascript
 function validateFetchMetadata(req, res, next) {
@@ -83,18 +86,24 @@ function validateFetchMetadata(req, res, next) {
   const dest = req.headers["sec-fetch-dest"];
   const method = req.method;
   const safeMethod = ["GET", "HEAD", "OPTIONS"].includes(method);
+  const trustSameSiteSubdomains = false;
+
+  // Absence is not proof of safety. Continue only to rely on CSRF tokens and
+  // Origin/Referer validation in later middleware.
+  if (!site) return next();
 
   // Allow same-origin requests
   if (site === "same-origin") return next();
 
-  // Allow browser-initiated top-level navigations only for safe methods.
-  if (site === "none" && mode === "navigate" && dest === "document" && safeMethod) {
+  // Same-site can include sibling subdomains. Only allow it where those
+  // subdomains share the same trust boundary, and do not use it to permit
+  // state-changing requests without CSRF token validation.
+  if (site === "same-site" && trustSameSiteSubdomains && safeMethod) {
     return next();
   }
 
-  // Same-site can include sibling subdomains. Only allow it where those
-  // subdomains share the same trust boundary.
-  if (site === "same-site" && safeMethod) {
+  // Allow browser-initiated top-level navigations only for safe methods.
+  if (site === "none" && mode === "navigate" && dest === "document" && safeMethod) {
     return next();
   }
 
@@ -138,6 +147,13 @@ function validateOrigin(req, res, next) {
 ## Framework Integration
 
 ### Express.js with Signed Double-Submit Tokens
+
+This server-rendered variant stores the signed token in an `httpOnly` cookie and
+also injects the same token into the form response. Do not combine this exact
+cookie setting with client libraries that expect JavaScript to read the CSRF
+cookie automatically. For AJAX-only clients, inject the token into the page or
+use a readable signed CSRF cookie only when that exposure is an accepted tradeoff;
+the server must still verify the signature and session binding.
 
 ```javascript
 const crypto = require("crypto");
@@ -320,17 +336,19 @@ function Form({ csrfToken }) {
 
 ## Client-Side CSRF (AJAX)
 
-Protect against CSRF in single-page applications:
+Protect AJAX requests by sending a server-provided CSRF token in a header. Avoid
+using a plain cookie-to-header mirror as the only defense; the token must still
+be signed and session-bound or backed by a server-side synchronizer token.
 
 ```javascript
-// Set up axios defaults
+// If the server intentionally exposes a signed CSRF cookie to JavaScript:
 import axios from "axios";
 
 axios.defaults.xsrfCookieName = "csrf_token";
 axios.defaults.xsrfHeaderName = "X-CSRF-Token";
 axios.defaults.withCredentials = true;
 
-// Or with fetch
+// Prefer server-rendered meta tags or a bootstrap response when using fetch.
 async function secureFetch(url, options = {}) {
   const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
 

--- a/src/ai/skills/frontend-security/references/jwt-security.md
+++ b/src/ai/skills/frontend-security/references/jwt-security.md
@@ -50,7 +50,10 @@ const token = jwt.sign(payload, privateKey, { algorithm: "RS256" });
 
 ## Token Sidejacking Prevention
 
-Add fingerprint to prevent stolen token reuse:
+For browser-held bearer tokens, a hardened fingerprint cookie can reduce reuse
+of a stolen token. Treat it as defense in depth, not a substitute for short
+lifetimes, XSS prevention, revocation, or keeping tokens out of browser storage
+when the architecture allows it.
 
 ```javascript
 const crypto = require("crypto");
@@ -98,7 +101,9 @@ Web Storage as a universal default.
 
 Prefer server-owned sessions or a backend-for-frontend (BFF) that stores tokens
 server-side and sends only `httpOnly`, `Secure`, SameSite cookies to the
-browser. Cookie-based auth needs CSRF protection on state-changing requests.
+browser. Cookie-based auth needs CSRF protection on state-changing requests;
+SameSite is useful defense in depth but does not replace tokens plus
+Origin/Referer checks for sensitive operations.
 
 ```javascript
 // Server sets cookie
@@ -116,7 +121,9 @@ res.cookie("token", jwt, {
 
 For browser-only SPAs, prefer short-lived access tokens kept in memory, refresh
 token rotation where appropriate, and a clear re-authentication path. Avoid
-long-lived bearer tokens in Web Storage.
+long-lived bearer tokens in Web Storage. If refresh tokens are issued to browser
+clients, rotate them, expire them, detect reuse, and avoid storing them in
+`localStorage` or other long-lived JavaScript-readable storage.
 
 ```javascript
 let accessToken = null;
@@ -163,6 +170,11 @@ localStorage.setItem("token", jwt); // Not recommended
 ```
 
 ## Token Expiration
+
+The refresh-token example is a server-side sketch. For browser clients, do not
+pair it with long-lived refresh tokens stored in Web Storage; prefer a BFF,
+server-side session, or refresh-token rotation with storage and replay controls
+chosen for the client architecture.
 
 ```javascript
 // Short-lived access tokens (15-60 minutes)
@@ -261,6 +273,11 @@ const encryptedToken = encrypt(token, encryptionKey);
 
 ## Validation Middleware
 
+This middleware validates bearer tokens after they reach an API. It does not
+recommend where the browser should store those tokens; use the storage guidance
+above before deciding whether a browser should send an `Authorization` header at
+all.
+
 ```javascript
 function authenticateToken(req, res, next) {
   // Get token from header
@@ -306,11 +323,12 @@ function authenticateToken(req, res, next) {
 - [ ] Explicit algorithm specification (never auto-detect)
 - [ ] Strong secret (256+ bits) or RSA keys
 - [ ] Short expiration times (15-60 minutes for access tokens)
-- [ ] Token fingerprint with httpOnly cookie
+- [ ] Fingerprint cookie considered for browser-held bearer tokens where appropriate
 - [ ] Validate issuer (iss) and audience (aud) claims
 - [ ] Implement token revocation mechanism
 - [ ] No sensitive data in payload
 - [ ] Choose storage based on architecture: server-side session/BFF, in-memory SPA token, or constrained sessionStorage fallback
+- [ ] Refresh tokens are rotated, replay-detected, and not kept in long-lived Web Storage
 - [ ] Avoid long-lived bearer tokens in Web Storage
 - [ ] Protect cookie-based auth with CSRF defenses
 - [ ] Use HTTPS only


### PR DESCRIPTION
## Summary
- Tighten CSRF guidance around Fetch Metadata, same-site trust boundaries, and AJAX token handling
- Clarify how signed double-submit tokens and server-rendered variants should be used
- Update JWT guidance to frame fingerprint cookies, storage choices, and refresh-token rotation as defense in depth

## Testing
- Not run (not requested)

fix #149