### PR TITLE
[codex] Harden frontend security guidance

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "provenance": true
   },
   "scripts": {
+    "check": "pnpm quality",
     "prettier:lint": "prettier .",
     "prettier:format": "prettier --write .",
     "lint:js": "eslint .",

--- a/src/ai/skills/frontend-security/SKILL.md
+++ b/src/ai/skills/frontend-security/SKILL.md
@@ -54,6 +54,11 @@ Name the boundary when a finding is outside pure frontend code. For example,
 "package-script supply-chain risk" is clearer than treating every issue as a
 frontend vulnerability.
 
+State scope limits in the report. This skill can identify frontend-triggered
+server/API, upload, auth, or supply-chain risks, but deep backend authorization,
+database, infrastructure, malware, or incident-response review should be routed
+to the appropriate specialist workflow.
+
 ## Evidence Searches
 
 Start with the broad extension set below, then narrow it to the project. Prefer

--- a/src/ai/skills/frontend-security/references/csp-configuration.md
+++ b/src/ai/skills/frontend-security/references/csp-configuration.md
@@ -6,9 +6,12 @@
 
 ```http
 Content-Security-Policy:
-  script-src 'nonce-{random}' 'strict-dynamic';
+  default-src 'self';
+  script-src 'nonce-{per_request_nonce}' 'strict-dynamic';
   object-src 'none';
   base-uri 'none';
+  form-action 'self';
+  frame-ancestors 'none';
 ```
 
 Implementation:
@@ -21,7 +24,14 @@ const nonce = crypto.randomBytes(16).toString("base64");
 // Set header
 res.setHeader(
   "Content-Security-Policy",
-  `script-src 'nonce-${nonce}' 'strict-dynamic'; object-src 'none'; base-uri 'none';`,
+  [
+    "default-src 'self'",
+    `script-src 'nonce-${nonce}' 'strict-dynamic'`,
+    "object-src 'none'",
+    "base-uri 'none'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+  ].join("; "),
 );
 
 // Include nonce in script tags
@@ -32,9 +42,12 @@ res.send(`<script nonce="${nonce}">/* safe code */</script>`);
 
 ```http
 Content-Security-Policy:
+  default-src 'self';
   script-src 'sha256-{hash}' 'strict-dynamic';
   object-src 'none';
   base-uri 'none';
+  form-action 'self';
+  frame-ancestors 'none';
 ```
 
 Generate hash:
@@ -45,19 +58,19 @@ echo -n 'console.log("hello");' | openssl sha256 -binary | openssl base64
 
 ## Essential Directives
 
-| Directive         | Purpose                       | Recommended Value                   |
-| ----------------- | ----------------------------- | ----------------------------------- |
-| `default-src`     | Fallback for other directives | `'self'`                            |
-| `script-src`      | JavaScript sources            | `'nonce-{random}' 'strict-dynamic'` |
-| `style-src`       | CSS sources                   | `'self'` or nonce/hash-based styles |
-| `img-src`         | Image sources                 | `'self' data: https:`               |
-| `font-src`        | Font sources                  | `'self'`                            |
-| `connect-src`     | AJAX/WebSocket/Fetch          | `'self' https://api.example.com`    |
-| `frame-src`       | iframe sources                | `'none'` or specific origins        |
-| `object-src`      | Plugin content                | `'none'`                            |
-| `base-uri`        | Base URL restrictions         | `'none'`                            |
-| `form-action`     | Form submission targets       | `'self'`                            |
-| `frame-ancestors` | Who can embed page            | `'self'` or `'none'`                |
+| Directive         | Purpose                       | Recommended Value                              |
+| ----------------- | ----------------------------- | ---------------------------------------------- |
+| `default-src`     | Fallback for other directives | `'self'`                                       |
+| `script-src`      | JavaScript sources            | `'nonce-{per_request_nonce}' 'strict-dynamic'` |
+| `style-src`       | CSS sources                   | `'self'` or nonce/hash-based styles            |
+| `img-src`         | Image sources                 | `'self' data: https:`                          |
+| `font-src`        | Font sources                  | `'self'`                                       |
+| `connect-src`     | AJAX/WebSocket/Fetch          | `'self' https://api.example.com`               |
+| `frame-src`       | iframe sources                | `'none'` or specific origins                   |
+| `object-src`      | Plugin content                | `'none'`                                       |
+| `base-uri`        | Base URL restrictions         | `'none'`                                       |
+| `form-action`     | Form submission targets       | `'self'`                                       |
+| `frame-ancestors` | Who can embed page            | `'self'` or `'none'`                           |
 
 ## Framework Integration
 
@@ -106,7 +119,7 @@ export default defineConfig({
           server.middlewares.use((req, res, next) => {
             res.setHeader(
               "Content-Security-Policy",
-              "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'none';",
+              "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'none'; form-action 'self'; frame-ancestors 'none';",
             );
             next();
           });
@@ -137,7 +150,11 @@ Test policies without enforcement:
 ```http
 Content-Security-Policy-Report-Only:
   default-src 'self';
-  script-src 'self';
+  script-src 'nonce-{per_request_nonce}' 'strict-dynamic';
+  object-src 'none';
+  base-uri 'none';
+  form-action 'self';
+  frame-ancestors 'none';
   report-uri /csp-report;
 ```
 

--- a/src/ai/skills/frontend-security/references/dom-security.md
+++ b/src/ai/skills/frontend-security/references/dom-security.md
@@ -83,7 +83,10 @@ function normalizeAllowedUrl(input) {
   try {
     const url = new URL(input, window.location.origin);
     if (!["https:", "mailto:"].includes(url.protocol)) return null;
-    if (url.protocol === "https:" && !["example.com", "docs.example.com"].includes(url.hostname)) {
+    if (
+      url.protocol === "https:" &&
+      !["https://example.com", "https://docs.example.com"].includes(url.origin)
+    ) {
       return null;
     }
     return url.href;
@@ -95,6 +98,11 @@ function normalizeAllowedUrl(input) {
 const safeUrl = normalizeAllowedUrl(userInput);
 if (safeUrl) {
   location.assign(safeUrl);
+}
+
+// If opening a separate browsing context, also prevent tabnabbing.
+if (safeUrl) {
+  window.open(safeUrl, "_blank", "noopener,noreferrer");
 }
 ```
 
@@ -232,7 +240,9 @@ const policy = trustedTypes.createPolicy("default", {
   },
   createScriptURL: (input) => {
     const url = new URL(input, location.origin);
-    if (url.origin === location.origin) return input;
+    if (url.origin === location.origin && url.pathname.startsWith("/assets/")) {
+      return url.href;
+    }
     throw new Error("Invalid script URL");
   },
 });

--- a/src/ai/skills/frontend-security/references/framework-patterns.md
+++ b/src/ai/skills/frontend-security/references/framework-patterns.md
@@ -30,7 +30,7 @@ function SafeLink({ href, children }) {
       if (!["https:", "mailto:"].includes(url.protocol)) return "#";
       if (
         url.protocol === "https:" &&
-        !["example.com", "docs.example.com"].includes(url.hostname)
+        !["https://example.com", "https://docs.example.com"].includes(url.origin)
       ) {
         return "#";
       }
@@ -40,7 +40,7 @@ function SafeLink({ href, children }) {
   }, [href]);
 
   return (
-    <a href={safeHref} rel="noopener noreferrer">
+    <a href={safeHref} target="_blank" rel="noopener noreferrer">
       {children}
     </a>
   );

--- a/src/ai/skills/frontend-security/references/xss-prevention.md
+++ b/src/ai/skills/frontend-security/references/xss-prevention.md
@@ -168,6 +168,7 @@ navigation.
 
 ```javascript
 function matchesPathPrefix(pathname, allowedPrefix) {
+  if (allowedPrefix === "/") return pathname.startsWith("/");
   return pathname === allowedPrefix || pathname.startsWith(`${allowedPrefix}/`);
 }
 

--- a/src/ai/skills/frontend-security/references/xss-prevention.md
+++ b/src/ai/skills/frontend-security/references/xss-prevention.md
@@ -67,6 +67,13 @@ function toAllowedInternalUrl(input) {
 
 const safeUrl = toAllowedInternalUrl(userInput);
 if (safeUrl) location.assign(safeUrl);
+
+// New tabs/windows need opener protection when the destination is untrusted or
+// external.
+if (safeUrl) {
+  const opened = window.open(safeUrl, "_blank", "noopener,noreferrer");
+  if (opened) opened.opener = null;
+}
 ```
 
 ## HTML Sanitization
@@ -111,14 +118,14 @@ function toSafeExternalHref(input) {
   try {
     const url = new URL(input, window.location.origin);
     if (!["https:"].includes(url.protocol)) return "#";
-    if (!["example.com", "docs.example.com"].includes(url.hostname)) return "#";
+    if (!["https://example.com", "https://docs.example.com"].includes(url.origin)) return "#";
     return url.href;
   } catch {
     return "#";
   }
 }
 
-<a href={toSafeExternalHref(userInput)} rel="noopener noreferrer">
+<a href={toSafeExternalHref(userInput)} target="_blank" rel="noopener noreferrer">
   Link
 </a>;
 ```
@@ -164,10 +171,13 @@ function matchesPathPrefix(pathname, allowedPrefix) {
   return pathname === allowedPrefix || pathname.startsWith(`${allowedPrefix}/`);
 }
 
-function normalizeAllowedHref(input, { baseUrl, allowedOrigins, allowedPathPrefixes = ["/"] }) {
+function normalizeAllowedHref(
+  input,
+  { baseUrl, allowedOrigins, allowedPathPrefixes = ["/"], allowedProtocols = ["https:"] },
+) {
   try {
     const url = new URL(input, baseUrl);
-    if (!["http:", "https:"].includes(url.protocol)) return null;
+    if (!allowedProtocols.includes(url.protocol)) return null;
     if (!allowedOrigins.includes(url.origin)) return null;
     if (!allowedPathPrefixes.some((prefix) => matchesPathPrefix(url.pathname, prefix))) return null;
     return url.href;
@@ -180,8 +190,13 @@ const href = normalizeAllowedHref(userInput, {
   baseUrl: window.location.origin,
   allowedOrigins: [window.location.origin, "https://docs.example.com"],
   allowedPathPrefixes: ["/docs", "/account"],
+  allowedProtocols: ["https:"],
 });
 ```
+
+For links that open in a new browsing context, pair normalized URLs with
+`rel="noopener noreferrer"` or `window.open(..., "noopener,noreferrer")` so the
+new page cannot control the opener.
 
 ## Content-Type Headers
 


### PR DESCRIPTION
## Summary

- Harden the frontend-security audit scope guidance and issue routing.
- Tighten XSS, URL, DOM, Trusted Types, and CSP examples so they use normalized destinations, opener protection, and strict nonce/hash policy defaults.
- Add a `pnpm check` script so the existing publish workflow test job can run before the next release.

## Validation

- `pnpm check`
- `pnpm publish:check`
- `pnpm pack --dry-run`
- `pnpm workflow:check`

## Release readiness

- Verified npm currently publishes `create-project-calavera@1.0.0`.
- Verified this package packs as `create-project-calavera@1.0.1`, so the next npm version is staged.
- Verified the latest GitHub release is `release/0.2.0`; confirm the intended tag/version naming before publishing the next release.

fix #147
fix #148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `check` script to run the full quality/validation pipeline in one command.

* **Documentation**
  * Strengthened frontend security guidance for safe navigation and external links, including origin-based HTTPS allowlists and safer new-tab behavior.
  * Updated CSP examples for consistent per-request nonce usage and stricter directive sets.
  * Clarified what the frontend-security guidance covers (and when to route deeper backend/security reviews elsewhere).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->