### PR TITLE
Fix release tarball publish path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,4 +84,16 @@ jobs:
           name: package
           path: package
       - name: Publish package
-        run: npm publish package/*.tgz --provenance --access public
+        run: |
+          mapfile -t tarballs < <(find package -maxdepth 1 -name "*.tgz" -print)
+          if [ "${#tarballs[@]}" -eq 0 ]; then
+            echo "No package tarball found in package/."
+            exit 1
+          fi
+          if [ "${#tarballs[@]}" -gt 1 ]; then
+            echo "Expected exactly one package tarball in package/, found ${#tarballs[@]}."
+            printf '%s\n' "${tarballs[@]}"
+            exit 1
+          fi
+          tarball="${tarballs[0]}"
+          npm publish "$(realpath "$tarball")" --provenance --access public


### PR DESCRIPTION
## Summary
- resolve the packed tarball path before calling `npm publish`
- publish the absolute `.tgz` filesystem path so npm does not treat it as a package spec

## Validation
- pnpm workflow:check
- pnpm publish:check
- pnpm pack --dry-run

fix #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the release publishing workflow to automatically locate the generated package archive.
  * Added safeguards to fail clearly when no archive is found or when multiple archives are detected.
  * Publishing now targets the single resolved archive path and enables provenance with public access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->