### PR TITLE
Add AI artifact controls to the composer

### DIFF
--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import test from "node:test";
 
 import Ajv2020 from "ajv/dist/2020.js";
 
+import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "../src/ai/catalog.js";
 import { integrationCatalog } from "../src/catalog.js";
 import { buildRecipe, CONFIG_SCHEMA_URL } from "../src/recipe.js";
 
@@ -58,6 +59,13 @@ test("published config schema is valid JSON Schema and validates the example con
 
   assertValid(validate, config);
   assertValid(validate, buildRecipe("modern", ["editorconfig"], "pnpm"));
+  assertValid(
+    validate,
+    buildRecipe("modern", ["editorconfig"], "pnpm", [
+      { type: "skill", src: "skills/semantic-html" },
+      { type: "hook", src: "hooks/block-dangerous-commands", target: DEFAULT_AI_TARGET },
+    ]),
+  );
 });
 
 test("config schema root shape matches the maintained recipe contract", () => {
@@ -69,6 +77,37 @@ test("config schema root shape matches the maintained recipe contract", () => {
 
 test("config schema integration enum stays in catalog order", () => {
   assert.deepEqual(schemaIntegrationIds, integrationIds);
+});
+
+test("AI artifact catalog exposes unique complete recipe items", async () => {
+  const ids = new Set();
+
+  for (const artifact of aiArtifactCatalog) {
+    const sourceStats = await stat(new URL(`../src/ai/${artifact.src}`, import.meta.url));
+
+    assert.equal(typeof artifact.id, "string");
+    assert.equal(typeof artifact.label, "string");
+    assert.equal(typeof artifact.group, "string");
+    assert.equal(artifact.status, "bundled");
+    assert.ok(["skill", "hook", "agent"].includes(artifact.type));
+    assert.equal(ids.has(artifact.id), false, `Duplicate AI artifact id: ${artifact.id}`);
+
+    if (artifact.type === "skill") {
+      assert.match(artifact.src, /^skills\/[^/]+$/);
+      assert.equal(artifact.defaultTarget, undefined);
+      assert.equal(sourceStats.isDirectory(), true);
+    } else if (artifact.type === "hook") {
+      assert.match(artifact.src, /^hooks\/[^/]+$/);
+      assert.equal(artifact.defaultTarget, DEFAULT_AI_TARGET);
+      assert.equal(sourceStats.isDirectory(), true);
+    } else {
+      assert.match(artifact.src, /^agents\/[^/]+\.md$/);
+      assert.equal(artifact.defaultTarget, DEFAULT_AI_TARGET);
+      assert.equal(sourceStats.isFile(), true);
+    }
+
+    ids.add(artifact.id);
+  }
 });
 
 test("config schema defines known boolean script flags", () => {

--- a/src/ai/artifacts.js
+++ b/src/ai/artifacts.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { fileExists } from "../utils/fs.js";
 import { isNotEmptyString, isPlainObject } from "../utils/guards.js";
 import { hashDirectory, hashFile } from "../utils/hash.js";
+import { DEFAULT_AI_TARGET } from "./catalog.js";
 
 /**
  * @typedef {import("../state.js").CalaveraState} CalaveraState
@@ -39,8 +40,6 @@ import { hashDirectory, hashFile } from "../utils/hash.js";
 
 const SOURCE_DIR = dirname(fileURLToPath(import.meta.url));
 const AI_SOURCE_ROOT = SOURCE_DIR;
-const DEFAULT_AI_TARGET = "claude-code";
-
 const AI_SOURCE_DIRECTORIES = Object.freeze({
   skill: "skills",
   hook: "hooks",

--- a/src/ai/catalog.js
+++ b/src/ai/catalog.js
@@ -1,0 +1,94 @@
+export const DEFAULT_AI_TARGET = "claude-code";
+
+export const aiArtifactCatalog = [
+  aiArtifact("skill-code-review", "skill", "skills/code-review", "Code review", "Skills"),
+  aiArtifact("skill-css-coder", "skill", "skills/css-coder", "CSS coder", "Skills"),
+  aiArtifact("skill-css-tokens", "skill", "skills/css-tokens", "CSS tokens", "Skills"),
+  aiArtifact(
+    "skill-frontend-security",
+    "skill",
+    "skills/frontend-security",
+    "Frontend security",
+    "Skills",
+  ),
+  aiArtifact(
+    "skill-frontend-testing",
+    "skill",
+    "skills/frontend-testing",
+    "Frontend testing",
+    "Skills",
+  ),
+  aiArtifact(
+    "skill-github-goal-issue-triage",
+    "skill",
+    "skills/github-goal-issue-triage",
+    "GitHub goal issue triage",
+    "Skills",
+  ),
+  aiArtifact(
+    "skill-more-secure-dependabot-config",
+    "skill",
+    "skills/more-secure-dependabot-config",
+    "More secure Dependabot config",
+    "Skills",
+  ),
+  aiArtifact(
+    "skill-npm-publishing-best-practices",
+    "skill",
+    "skills/npm-publishing-best-practices",
+    "npm publishing best practices",
+    "Skills",
+  ),
+  aiArtifact(
+    "skill-npm-trusted-publishing-github-workflow",
+    "skill",
+    "skills/npm-trusted-publishing-github-workflow",
+    "npm trusted publishing GitHub workflow",
+    "Skills",
+  ),
+  aiArtifact("skill-project-goal", "skill", "skills/project-goal", "Project goal", "Skills"),
+  aiArtifact(
+    "skill-refined-plan-mode",
+    "skill",
+    "skills/refined-plan-mode",
+    "Refined plan mode",
+    "Skills",
+  ),
+  aiArtifact("skill-semantic-html", "skill", "skills/semantic-html", "Semantic HTML", "Skills"),
+  aiArtifact(
+    "hook-auto-approve-safe-commands",
+    "hook",
+    "hooks/auto-approve-safe-commands",
+    "Auto-approve safe commands",
+    "Hooks",
+    DEFAULT_AI_TARGET,
+  ),
+  aiArtifact(
+    "hook-block-dangerous-commands",
+    "hook",
+    "hooks/block-dangerous-commands",
+    "Block dangerous commands",
+    "Hooks",
+    DEFAULT_AI_TARGET,
+  ),
+  aiArtifact(
+    "agent-technical-devils-advocate",
+    "agent",
+    "agents/technical-devils-advocate.md",
+    "Technical devil's advocate",
+    "Agents",
+    DEFAULT_AI_TARGET,
+  ),
+];
+
+function aiArtifact(id, type, src, label, group, defaultTarget) {
+  return {
+    id,
+    type,
+    src,
+    label,
+    group,
+    status: "bundled",
+    defaultTarget,
+  };
+}

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -37,9 +37,10 @@ export const profileDefaults = {
  * @param {string} profile
  * @param {string[]} integrations
  * @param {PackageManager} [packageManager]
+ * @param {{ type: string, src: string, target?: string }[]} [ai]
  */
-export function buildRecipe(profile, integrations, packageManager = "npm") {
-  return {
+export function buildRecipe(profile, integrations, packageManager = "npm", ai = []) {
+  const recipe = {
     $schema: CONFIG_SCHEMA_URL,
     version: 1,
     profile,
@@ -54,4 +55,10 @@ export function buildRecipe(profile, integrations, packageManager = "npm") {
       quality: true,
     },
   };
+
+  if (ai.length > 0) {
+    recipe.ai = ai;
+  }
+
+  return recipe;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -88,6 +88,11 @@
             <legend>Integration packs</legend>
             <div id="integrations" class="integrations"></div>
           </fieldset>
+
+          <fieldset>
+            <legend>AI artifacts</legend>
+            <div id="ai-artifacts" class="integrations ai-artifacts"></div>
+          </fieldset>
         </form>
 
         <aside class="panel preview">

--- a/web/script.js
+++ b/web/script.js
@@ -1,4 +1,5 @@
 import { buildRecipe } from "../src/recipe.js";
+import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "../src/ai/catalog.js";
 
 const catalog = [
   entry("editorconfig", "Project consistency", "EditorConfig", "recommended"),
@@ -101,6 +102,7 @@ const defaults = {
 
 const form = document.querySelector("#composer");
 const integrations = document.querySelector("#integrations");
+const aiArtifacts = document.querySelector("#ai-artifacts");
 const output = document.querySelector("#output");
 const webMcpBanner = document.querySelector("#webmcp-banner");
 const profiles = Object.keys(defaults);
@@ -170,6 +172,48 @@ function renderIntegrations() {
   }
 }
 
+function renderAiArtifacts() {
+  aiArtifacts.replaceChildren();
+
+  const groups = aiArtifactCatalog.reduce((grouped, item) => {
+    grouped.set(item.group, [...(grouped.get(item.group) ?? []), item]);
+    return grouped;
+  }, new Map());
+
+  for (const [group, items] of groups) {
+    const section = document.createElement("section");
+    section.className = "integration-group";
+    section.innerHTML = `<h2>${group}</h2>`;
+
+    for (const artifact of items) {
+      const option = document.createElement("div");
+      option.className = "artifact-option";
+      option.innerHTML = `
+        <label for="ai-artifact-${artifact.id}">
+          <input id="ai-artifact-${artifact.id}" type="checkbox" name="aiArtifact" value="${artifact.id}" />
+          <span>${artifact.label}</span>
+          <small>${artifact.status}</small>
+        </label>
+      `;
+
+      if (artifact.defaultTarget) {
+        const targetField = document.createElement("label");
+        targetField.className = "artifact-target";
+        targetField.htmlFor = `ai-target-${artifact.id}`;
+        targetField.innerHTML = `
+          Target
+          <input id="ai-target-${artifact.id}" type="text" value="${artifact.defaultTarget}" data-ai-target="${artifact.id}" disabled />
+        `;
+        option.append(targetField);
+      }
+
+      section.append(option);
+    }
+
+    aiArtifacts.append(section);
+  }
+}
+
 function selectProfile(profile) {
   const radio = form.querySelector(`[name="profile"][value="${profile}"]`);
   radio.checked = true;
@@ -185,6 +229,32 @@ function selectIntegrations(integrationIds) {
   }
 }
 
+function syncAiTargetStates() {
+  for (const targetInput of form.querySelectorAll("[data-ai-target]")) {
+    const checkbox = form.querySelector(
+      `[name="aiArtifact"][value="${targetInput.dataset.aiTarget}"]`,
+    );
+    targetInput.disabled = !checkbox?.checked;
+  }
+}
+
+function selectedAiItems() {
+  return [...form.querySelectorAll('[name="aiArtifact"]:checked')].map((checkbox) => {
+    const artifact = aiArtifactCatalog.find(({ id }) => id === checkbox.value);
+    const item = {
+      type: artifact.type,
+      src: artifact.src,
+    };
+
+    if (artifact.defaultTarget) {
+      const targetInput = form.querySelector(`[data-ai-target="${artifact.id}"]`);
+      item.target = targetInput?.value.trim() || DEFAULT_AI_TARGET;
+    }
+
+    return item;
+  });
+}
+
 function recipe() {
   const data = new FormData(form);
   const packageManager = data.get("packageManager");
@@ -193,6 +263,7 @@ function recipe() {
     String(data.get("profile") ?? ""),
     data.getAll("integration").map(String),
     packageManager ? String(packageManager) : undefined,
+    selectedAiItems(),
   );
 }
 
@@ -205,6 +276,7 @@ function setDefaults() {
 
   renderIntegrations();
   selectIntegrations(defaults[profile]);
+  syncAiTargetStates();
   render();
 }
 
@@ -324,6 +396,18 @@ function catalogResponse() {
       profiles,
       description: `${label}. Category: ${group}. Status: ${status}.`,
     })),
+    aiArtifacts: aiArtifactCatalog.map(
+      ({ id, type, src, group, label, status, defaultTarget }) => ({
+        id,
+        type,
+        src,
+        label,
+        group,
+        status,
+        defaultTarget,
+        description: `${label}. Type: ${type}. Source: ${src}.`,
+      }),
+    ),
     toolInput: {
       accepts:
         "Use either an integration id or its label in the configure_project_tooling tools array. Matching is case-insensitive.",
@@ -440,6 +524,7 @@ form.addEventListener("change", (event) => {
   if (event.target.name === "profile") {
     setDefaults();
   } else {
+    syncAiTargetStates();
     render();
   }
 });
@@ -455,5 +540,6 @@ document.querySelector("#download").addEventListener("click", () => {
   downloadFile();
 });
 
+renderAiArtifacts();
 setDefaults();
 registerWebMcpTools();

--- a/web/script.js
+++ b/web/script.js
@@ -201,7 +201,7 @@ function renderAiArtifacts() {
         targetField.className = "artifact-target";
         targetField.htmlFor = `ai-target-${artifact.id}`;
         targetField.innerHTML = `
-          Target
+          Target for ${artifact.label}
           <input id="ai-target-${artifact.id}" type="text" value="${artifact.defaultTarget}" data-ai-target="${artifact.id}" disabled />
         `;
         option.append(targetField);

--- a/web/styles.css
+++ b/web/styles.css
@@ -209,6 +209,39 @@ select:focus-visible {
   outline-offset: 0.1875rem;
 }
 
+.artifact-option {
+  margin-block: 0.625rem;
+  margin-inline: 0;
+}
+
+.artifact-option label {
+  margin-block: 0;
+}
+
+.artifact-target {
+  color: var(--muted);
+  font-size: 0.84rem;
+  font-weight: 700;
+  margin-block-start: 0.5rem;
+  padding-inline-start: 1.35rem;
+}
+
+.artifact-target input {
+  background: #fffaf0;
+  border: 0.0625rem solid rgb(38 50 77 / 42%);
+  border-radius: 0.375rem;
+  color: var(--ink);
+  display: block;
+  inline-size: 100%;
+  margin-block-start: 0.25rem;
+  padding-block: 0.45rem;
+  padding-inline: 0.55rem;
+}
+
+.artifact-target input:disabled {
+  opacity: 0.55;
+}
+
 .integrations {
   display: grid;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- Add a catalog for bundled AI artifacts and expose the shared default target constant
- Extend recipe generation and schema checks to include selected AI artifacts
- Render AI artifact controls in the web composer, including per-item target inputs for hooks and agents
- Add coverage for catalog integrity and recipe validation with AI entries

## Testing
- Added unit tests for the AI artifact catalog and published config schema validation
- Not run (not requested)

fix #154 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an “AI artifacts” section to the composer UI for selecting AI-related items alongside existing integrations.
  * Generated configurations now include the selected AI artifacts, with per-artifact targets when available.

* **Bug Fixes**
  * Improved validation to reject duplicate/invalid AI artifact selections and ensure referenced files/folders and targets are correct.
  * Target inputs remain disabled until the corresponding AI artifact is selected to prevent inconsistent settings.

* **Tests**
  * Added coverage for catalog completeness and schema/format validation of AI artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->