### PR TITLE
Refactor recipe composition into shared core

### DIFF
--- a/docs/contributing-calavera-integration-varlock.md
+++ b/docs/contributing-calavera-integration-varlock.md
@@ -82,10 +82,9 @@ The matching recipe entry a project developer would write is intentionally small
 }
 ```
 
-That recipe should be enough for the CLI to resolve Varlock from the catalog.
-Today the composer still has its own compact browser catalog, so contributor
-changes may need to update `web/script.js` too. A future improvement should make
-the composer derive from the shared catalog so this duplication disappears.
+That recipe should be enough for the CLI and web composer to resolve Varlock
+from the shared catalog. The composer now derives integration options from the
+shared recipe core instead of carrying a browser-only catalog copy.
 
 ## Add Dependencies Through Metadata
 
@@ -367,27 +366,21 @@ restore the starter file.
 ## Expose the Integration in the Composer
 
 The web composer should not drift from the CLI catalog model. When a new
-integration should be available in the composer, expose it in
-[`web/script.js`](../web/script.js) with the same ID, label, group, and status
-language used by the CLI.
+integration should be available in the composer, add it to
+[`src/catalog.js`](../src/catalog.js) and make sure
+[`src/recipe.js`](../src/recipe.js) exposes it for the intended profile or
+profiles through the shared recipe core.
 
 For Varlock, that meant adding it to the Environment variables group so a project
 developer could include it in a generated `calavera.config.json` without
-hand-editing the recipe. This currently duplicates the shared catalog entry in
-the compact helper format used by the browser UI:
+hand-editing the recipe.
 
-```js
-entry("varlock", "Environment variables", "Varlock", "optional");
-```
-
-If the composer exports a schema or static catalog artifact for the browser,
-update the matching test or drift check. Calavera's public recipe schema lives at
+If the integration changes recipe shape, profile scoping, schema behavior, or
+the shared catalog response exposed to WebMCP, update the matching test or drift
+check. Calavera's public recipe schema lives at
 [`web/public/calavera.config.schema.json`](../web/public/calavera.config.schema.json),
 and repository drift checks live in
 [`scripts/check-config-schema.test.mjs`](../scripts/check-config-schema.test.mjs).
-
-Longer term, the right shape is for the composer to consume the shared catalog
-instead of requiring contributors to update both places by hand.
 
 ## Test the Contribution
 

--- a/docs/vite-plus-template-research.md
+++ b/docs/vite-plus-template-research.md
@@ -232,12 +232,12 @@ later publishes a Vite+ org manifest for `vp create @schalkneethling`.
 
 ## MCP And WebMCP Composition Surface
 
-Recipe composition should be extracted into shared project logic first, not
+Recipe composition now lives in shared project logic rather than being
 duplicated between the web UI, WebMCP tools, future MCP server, and rich CLI.
 That shared core is the main dependency for keeping the agent-first, CLI, and
 Web UI paths in parity.
 
-The shared surface should be able to power:
+The shared surface in `src/recipe.js` powers or should power:
 
 - existing web composer controls;
 - existing WebMCP tools in `web/script.js`;
@@ -245,7 +245,10 @@ The shared surface should be able to power:
 - the rich interactive CLI composer;
 - CLI commands that need recipe inspection or validation.
 
-Candidate shared operations:
+Shared operations already include catalog listing, composition, validation, AI
+artifact normalization, integration explanation, and WebMCP-ready response
+helpers. Future MCP and rich CLI work should build on those entry points before
+adding more operations such as:
 
 - `list_profiles`
 - `list_integrations`

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -8,7 +8,25 @@ import { buildAiApplyResult, createCodexAgentToml } from "../src/ai/artifacts.js
 import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "../src/ai/catalog.js";
 import { integrationCatalog } from "../src/catalog.js";
 import { createEmptyState } from "../src/state.js";
-import { buildRecipe, CONFIG_SCHEMA_URL } from "../src/recipe.js";
+import {
+  assertKnownValue,
+  assertObjectArray,
+  assertString,
+  assertStringArray,
+} from "../src/utils/assertions.js";
+import {
+  aiArtifactRecipeItems,
+  buildRecipe,
+  catalogResponse,
+  composeRecipe,
+  CONFIG_SCHEMA_URL,
+  explainRecipeIntegrations,
+  listIntegrationOptions,
+  normalizeAiArtifactInputs,
+  profileDefaults,
+  validateRecipe,
+  validateRecipeCompositionInput,
+} from "../src/recipe.js";
 
 const schemaUrl = CONFIG_SCHEMA_URL;
 const rootProperties = [
@@ -151,6 +169,118 @@ test("generated recipes reference the published schema URL", () => {
   const recipe = buildRecipe("modern", ["editorconfig"], "pnpm");
 
   assert.equal(recipe.$schema, schemaUrl);
+});
+
+test("shared composition uses profile defaults when tools are omitted", () => {
+  assert.deepEqual(composeRecipe({ profile: "minimal" }), buildRecipe("minimal", ["editorconfig"]));
+  assert.deepEqual(composeRecipe({ profile: "modern" }).integrations, profileDefaults.modern);
+});
+
+test("shared composition normalizes explicit tool labels and package managers", () => {
+  const input = validateRecipeCompositionInput({
+    profile: "classic",
+    packageManager: "pnpm",
+    tools: ["TypeScript type checking", "ESLint flat config", "Prettier"],
+  });
+
+  assert.deepEqual(input, {
+    profile: "classic",
+    packageManager: "pnpm",
+    tools: ["typescript", "eslint", "prettier"],
+    aiArtifacts: undefined,
+  });
+});
+
+test("shared composition normalizes AI artifact inputs into recipe items", () => {
+  const input = normalizeAiArtifactInputs([
+    { id: "Semantic HTML" },
+    { id: "hooks/block-dangerous-commands", target: "codex" },
+    { id: "Technical devil's advocate" },
+  ]);
+
+  assert.deepEqual(input, [
+    { id: "skill-semantic-html", target: undefined },
+    { id: "hook-block-dangerous-commands", target: "codex" },
+    { id: "agent-technical-devils-advocate", target: DEFAULT_AI_TARGET },
+  ]);
+  assert.deepEqual(aiArtifactRecipeItems(input), [
+    { type: "skill", src: "skills/semantic-html" },
+    { type: "hook", src: "hooks/block-dangerous-commands", target: "codex" },
+    {
+      type: "agent",
+      src: "agents/technical-devils-advocate.md",
+      target: DEFAULT_AI_TARGET,
+    },
+  ]);
+});
+
+test("shared composition rejects whitespace-padded unsafe AI artifact targets", () => {
+  for (const target of [" .. ", " . ", " nested/path ", " nested\\path "]) {
+    assert.throws(
+      () => normalizeAiArtifactInputs([{ id: "hooks/block-dangerous-commands", target }]),
+      /Targets must be a single directory name/,
+    );
+  }
+});
+
+test("shared composition output validates against the published schema", () => {
+  const validate = ajv.compile(schema);
+  const recipe = composeRecipe({
+    profile: "modern",
+    packageManager: "bun",
+    tools: ["Oxlint", "Oxc React best practices", "Stylelint"],
+    aiArtifacts: [{ id: "skill-semantic-html" }],
+  });
+
+  assertValid(validate, recipe);
+  assert.equal(validateRecipe(recipe), recipe);
+});
+
+test("shared catalog helpers expose WebMCP-ready profile scoped options", () => {
+  const modernToolIds = listIntegrationOptions("modern").map(({ id }) => id);
+  const classicToolIds = listIntegrationOptions("classic").map(({ id }) => id);
+  const response = catalogResponse(composeRecipe({ profile: "minimal" }));
+
+  assert.ok(modernToolIds.includes("oxlint-react"));
+  assert.equal(modernToolIds.includes("eslint-react"), false);
+  assert.ok(classicToolIds.includes("eslint-react"));
+  assert.equal(classicToolIds.includes("oxlint-react"), false);
+  assert.deepEqual(
+    response.profiles.map(({ id }) => id),
+    profiles,
+  );
+  assert.deepEqual(response.defaults, profileDefaults);
+});
+
+test("shared explanation helpers include selected and included integration reasons", () => {
+  const explanation = explainRecipeIntegrations(
+    buildRecipe("modern", ["oxlint-react", "stylelint-standard"]),
+  );
+
+  assert.deepEqual(
+    explanation.map(({ id }) => id),
+    ["oxlint", "oxlint-react", "stylelint", "stylelint-standard"],
+  );
+  assert.match(explanation.find(({ id }) => id === "oxlint").reason, /requires it/);
+  assert.match(explanation.find(({ id }) => id === "oxlint-react").reason, /Explicitly selected/);
+});
+
+test("shared assertion helpers reject unexpected value shapes", () => {
+  assert.doesNotThrow(() => assertString("name", "value"));
+  assert.doesNotThrow(() => assertStringArray("items", ["one", "two"]));
+  assert.doesNotThrow(() => assertStringArray("items", []));
+  assert.doesNotThrow(() => assertObjectArray("objects", [{ id: "one" }]));
+  assert.doesNotThrow(() => assertObjectArray("objects", []));
+  assert.doesNotThrow(() => assertKnownValue("profile", "modern", profiles));
+
+  assert.throws(() => assertString("name", 1), /name must be a string/);
+  assert.throws(() => assertStringArray("items", "one"), /items must be an array of strings/);
+  assert.throws(() => assertStringArray("items", ["one", 2]), /items must be an array of strings/);
+  assert.throws(() => assertObjectArray("objects", "one"), /objects must be an array of objects/);
+  assert.throws(() => assertObjectArray("objects", [null]), /objects must be an array of objects/);
+  assert.throws(() => assertObjectArray("objects", [[]]), /objects must be an array of objects/);
+  assert.throws(() => assertKnownValue("profile", 1, profiles), /profile must be a string/);
+  assert.throws(() => assertKnownValue("profile", "future", profiles), /Invalid profile: future/);
 });
 
 test("Codex agent adapter emits required TOML fields without Claude model metadata", async () => {

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -23,7 +23,9 @@ import {
   explainRecipeIntegrations,
   listIntegrationOptions,
   normalizeAiArtifactInputs,
+  normalizeIntegrationInputs,
   profileDefaults,
+  resolveRecipeIntegrations,
   validateRecipe,
   validateRecipeCompositionInput,
 } from "../src/recipe.js";
@@ -191,6 +193,19 @@ test("shared composition normalizes explicit tool labels and package managers", 
   });
 });
 
+test("shared composition resolves duplicate tool labels within the active profile", () => {
+  assert.deepEqual(normalizeIntegrationInputs(["Accessibility"], "modern"), ["oxlint-jsx-a11y"]);
+  assert.deepEqual(normalizeIntegrationInputs(["Accessibility"], "classic"), ["eslint-jsx-a11y"]);
+});
+
+test("shared composition copies profile defaults before returning recipes", () => {
+  const recipe = composeRecipe({ profile: "minimal" });
+  recipe.integrations.push("mutated");
+
+  assert.deepEqual(profileDefaults.minimal, ["editorconfig"]);
+  assert.notEqual(composeRecipe({ profile: "modern" }).integrations, profileDefaults.modern);
+});
+
 test("shared composition normalizes AI artifact inputs into recipe items", () => {
   const input = normalizeAiArtifactInputs([
     { id: "Semantic HTML" },
@@ -263,6 +278,48 @@ test("shared explanation helpers include selected and included integration reaso
   );
   assert.match(explanation.find(({ id }) => id === "oxlint").reason, /requires it/);
   assert.match(explanation.find(({ id }) => id === "oxlint-react").reason, /Explicitly selected/);
+});
+
+test("shared integration resolution expands nested includes without catalog-order coupling", () => {
+  const fixtures = [
+    {
+      id: "test-grandchild",
+      label: "Test grandchild",
+      group: "Test",
+      platform: "test",
+      status: "optional",
+      dependencies: [],
+    },
+    {
+      id: "test-child",
+      label: "Test child",
+      group: "Test",
+      platform: "test",
+      status: "optional",
+      dependencies: [],
+      includes: ["test-grandchild"],
+    },
+    {
+      id: "test-parent",
+      label: "Test parent",
+      group: "Test",
+      platform: "test",
+      status: "optional",
+      dependencies: [],
+      includes: ["test-child"],
+    },
+  ];
+
+  integrationCatalog.unshift(...fixtures);
+
+  try {
+    assert.deepEqual(
+      resolveRecipeIntegrations({ integrations: ["test-parent"] }).map(({ id }) => id),
+      ["test-grandchild", "test-child", "test-parent"],
+    );
+  } finally {
+    integrationCatalog.splice(0, fixtures.length);
+  }
 });
 
 test("shared assertion helpers reject unexpected value shapes", () => {

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ import {
   normalizeState,
   optionalStringArray,
 } from "./state.js";
-import { buildRecipe, profileDefaults } from "./recipe.js";
+import { buildRecipe, profileDefaults, resolveRecipeIntegrations } from "./recipe.js";
 import { FileWriteError } from "./utils/file-write-error.js";
 import { fileExists, readJSON, writeJSON } from "./utils/fs.js";
 import { isNotEmptyString, isPlainObject } from "./utils/guards.js";
@@ -261,26 +261,6 @@ async function readStateIfPresent() {
   }
 
   return normalizeState(await readJSON(STATE_FILE));
-}
-
-/**
- * @param {Recipe} recipe
- * @returns {Integration[]}
- */
-function resolveIntegrations(recipe) {
-  const selected = new Set(recipe.integrations ?? []);
-
-  for (const integration of /** @type {Integration[]} */ (integrationCatalog)) {
-    if (selected.has(integration.id)) {
-      for (const includes of integration.includes ?? []) {
-        selected.add(includes);
-      }
-    }
-  }
-
-  return /** @type {Integration[]} */ (integrationCatalog).filter((integration) =>
-    selected.has(integration.id),
-  );
 }
 
 /**
@@ -904,7 +884,7 @@ async function applyRecipe(options) {
   const configPath = resolve(options.config);
   const recipe = await readRecipe(configPath);
   const previousState = await readStateIfPresent();
-  const integrations = resolveIntegrations(recipe);
+  const integrations = resolveRecipeIntegrations(recipe);
   const dependencyList = unique(
     integrations.flatMap((integration) => integration.dependencies ?? []),
   );
@@ -1185,7 +1165,7 @@ async function doctor(options) {
 
   if (hasConfig) {
     const recipe = await readRecipe(options.config);
-    const integrations = resolveIntegrations(recipe);
+    const integrations = resolveRecipeIntegrations(recipe);
     const aiArtifacts = resolveAiArtifacts(recipe);
     const expectedFiles = [
       integrations.some((integration) => integration.id === "editorconfig")
@@ -1272,7 +1252,7 @@ async function clean(options) {
   const recipe = (await fileExists(options.config))
     ? await readRecipe(options.config)
     : { integrations: [] };
-  const integrations = resolveIntegrations(recipe);
+  const integrations = resolveRecipeIntegrations(recipe);
   const expectedAiPaths = new Set(resolveAiArtifacts(recipe).map((artifact) => artifact.path));
   const expectedFiles = new Set(expectedManagedFiles(integrations));
   const staleFiles = managedFilesFromState(state).filter((file) => !expectedFiles.has(file.path));

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -141,9 +141,9 @@ function integrationProfiles(id) {
   return profileSpecificIntegrations[id] ?? profileIds;
 }
 
-function integrationIdForInput(value) {
+function integrationIdForInput(value, integrationOptions = integrationCatalog) {
   const token = normalizedToken(value);
-  const match = integrationCatalog.find(
+  const match = integrationOptions.find(
     ({ id, label }) => normalizedToken(id) === token || normalizedToken(label) === token,
   );
 
@@ -162,7 +162,7 @@ function aiArtifactIdForInput(value) {
   return match?.id;
 }
 
-function normalizeAiTarget(target, index) {
+export function normalizeAiTarget(target, index) {
   assertString(`aiArtifacts[${index}].target`, target);
 
   const normalizedTarget = target.trim();
@@ -212,10 +212,14 @@ export function listAiArtifactOptions() {
   }));
 }
 
-export function normalizeIntegrationInputs(integrationInputs) {
+export function normalizeIntegrationInputs(integrationInputs, profile) {
   assertStringArray("tools", integrationInputs);
 
-  return integrationInputs.map((value) => integrationIdForInput(value) ?? value);
+  const integrationOptions = profile ? listIntegrationOptions(profile) : integrationCatalog;
+
+  return integrationInputs.map(
+    (value) => integrationIdForInput(value, integrationOptions) ?? value,
+  );
 }
 
 export function normalizeAiArtifactInputs(artifactInputs = []) {
@@ -276,7 +280,9 @@ export function validateRecipeCompositionInput({
   assertKnownValue("packageManager", packageManager, packageManagerIds);
 
   const allowedIntegrationIds = listIntegrationOptions(profile).map(({ id }) => id);
-  const integrationIds = tools ? normalizeIntegrationInputs(tools) : profileDefaults[profile];
+  const integrationIds = tools
+    ? normalizeIntegrationInputs(tools, profile)
+    : [...profileDefaults[profile]];
   const invalidIntegrationIds = integrationIds.filter((id) => !allowedIntegrationIds.includes(id));
 
   if (invalidIntegrationIds.length > 0) {
@@ -307,11 +313,15 @@ export function composeRecipe(configurationInput = {}) {
 
 export function resolveRecipeIntegrations(recipe) {
   const selected = new Set(recipe.integrations ?? []);
+  const queue = [...selected];
 
-  for (const integration of integrationCatalog) {
-    if (selected.has(integration.id)) {
-      for (const includes of integration.includes ?? []) {
-        selected.add(includes);
+  for (let index = 0; index < queue.length; index += 1) {
+    const integration = integrationCatalog.find(({ id }) => id === queue[index]);
+
+    for (const includedId of integration?.includes ?? []) {
+      if (!selected.has(includedId)) {
+        selected.add(includedId);
+        queue.push(includedId);
       }
     }
   }

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -1,8 +1,60 @@
+import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "./ai/catalog.js";
+import { integrationCatalog } from "./catalog.js";
+import {
+  assertKnownValue,
+  assertObjectArray,
+  assertString,
+  assertStringArray,
+} from "./utils/assertions.js";
+
 export const CONFIG_SCHEMA_URL = "https://calavera.schalkneethling.com/calavera.config.schema.json";
 
 /**
  * @typedef {"npm" | "pnpm" | "yarn" | "bun"} PackageManager
  */
+
+export const profileCatalog = [
+  {
+    id: "modern",
+    label: "modern",
+    description: "Newer, faster JavaScript, TypeScript, CSS linting, and formatting defaults.",
+  },
+  {
+    id: "classic",
+    label: "classic",
+    description: "Widely used JavaScript, TypeScript, CSS linting, and formatting defaults.",
+  },
+  {
+    id: "minimal",
+    label: "minimal",
+    description: "Only basic editor consistency settings.",
+  },
+];
+
+export const packageManagerCatalog = [
+  {
+    id: "npm",
+    label: "npm",
+    description: "npm, the default Node.js package manager.",
+  },
+  {
+    id: "pnpm",
+    label: "pnpm",
+    description: "pnpm, a fast disk-efficient package manager.",
+  },
+  {
+    id: "yarn",
+    label: "yarn",
+    description: "Yarn package manager.",
+  },
+  {
+    id: "bun",
+    label: "bun",
+    description: "Bun package manager and runtime.",
+  },
+];
+
+export const aiArtifactTypes = ["skill", "hook", "agent"];
 
 /** @type {Record<string, string[]>} */
 export const profileDefaults = {
@@ -33,6 +85,339 @@ export const profileDefaults = {
   minimal: ["editorconfig"],
 };
 
+const profileIds = profileCatalog.map(({ id }) => id);
+const packageManagerIds = packageManagerCatalog.map(({ id }) => id);
+
+const profileSpecificIntegrations = {
+  oxlint: ["modern"],
+  "oxlint-eslint": ["modern"],
+  "oxlint-typescript": ["modern"],
+  "oxlint-unicorn": ["modern"],
+  "oxlint-oxc": ["modern"],
+  "oxlint-import": ["modern"],
+  "oxlint-react": ["modern"],
+  "oxlint-jsx-a11y": ["modern"],
+  "oxlint-node": ["modern"],
+  "oxlint-promise": ["modern"],
+  "oxlint-vitest": ["modern"],
+  "oxlint-jest": ["modern"],
+  "oxlint-nextjs": ["modern"],
+  "oxlint-vue": ["modern"],
+  "oxlint-jsdoc": ["modern"],
+  oxfmt: ["modern"],
+  "react-doctor": ["modern", "classic"],
+  eslint: ["classic"],
+  "typescript-eslint": ["classic"],
+  "eslint-config-prettier": ["classic"],
+  "eslint-react": ["classic"],
+  "eslint-jsx-a11y": ["classic"],
+  "eslint-import": ["classic"],
+  "eslint-n": ["classic"],
+  "eslint-promise": ["classic"],
+  "eslint-unicorn": ["classic"],
+  "eslint-sonarjs": ["classic"],
+  "eslint-vitest": ["classic"],
+  "eslint-jest": ["classic"],
+  prettier: ["classic"],
+  "prettier-tailwind": ["classic"],
+  "prettier-svelte": ["classic"],
+  "prettier-astro": ["classic"],
+};
+
+export const defaultScriptFlags = {
+  lint: true,
+  "lint:fix": true,
+  format: true,
+  "format:check": true,
+  typecheck: true,
+  quality: true,
+};
+
+function normalizedToken(value) {
+  return value.trim().toLowerCase();
+}
+
+function integrationProfiles(id) {
+  return profileSpecificIntegrations[id] ?? profileIds;
+}
+
+function integrationIdForInput(value) {
+  const token = normalizedToken(value);
+  const match = integrationCatalog.find(
+    ({ id, label }) => normalizedToken(id) === token || normalizedToken(label) === token,
+  );
+
+  return match?.id;
+}
+
+function aiArtifactIdForInput(value) {
+  const token = normalizedToken(value);
+  const match = aiArtifactCatalog.find(
+    ({ id, label, src }) =>
+      normalizedToken(id) === token ||
+      normalizedToken(label) === token ||
+      normalizedToken(src) === token,
+  );
+
+  return match?.id;
+}
+
+function normalizeAiTarget(target, index) {
+  assertString(`aiArtifacts[${index}].target`, target);
+
+  const normalizedTarget = target.trim();
+
+  if (
+    normalizedTarget === "." ||
+    normalizedTarget === ".." ||
+    normalizedTarget.includes("/") ||
+    normalizedTarget.includes("\\")
+  ) {
+    throw new Error(
+      `Invalid aiArtifacts[${index}].target: ${normalizedTarget}. Targets must be a single directory name without path separators or traversal.`,
+    );
+  }
+
+  return normalizedTarget;
+}
+
+export function profileIdsForRecipe() {
+  return [...profileIds];
+}
+
+export function packageManagerIdsForRecipe() {
+  return [...packageManagerIds];
+}
+
+export function listIntegrationOptions(profile) {
+  return integrationCatalog
+    .map((integration) => ({
+      ...integration,
+      profiles: integrationProfiles(integration.id),
+      description: `${integration.label}. Category: ${integration.group}. Status: ${integration.status}.`,
+    }))
+    .filter((integration) => !profile || integration.profiles.includes(profile));
+}
+
+export function listAiArtifactOptions() {
+  return aiArtifactCatalog.map(({ id, type, src, group, label, status, defaultTarget }) => ({
+    id,
+    type,
+    src,
+    label,
+    group,
+    status,
+    defaultTarget,
+    description: `${label}. Type: ${type}. Source: ${src}.`,
+  }));
+}
+
+export function normalizeIntegrationInputs(integrationInputs) {
+  assertStringArray("tools", integrationInputs);
+
+  return integrationInputs.map((value) => integrationIdForInput(value) ?? value);
+}
+
+export function normalizeAiArtifactInputs(artifactInputs = []) {
+  assertObjectArray("aiArtifacts", artifactInputs);
+
+  return artifactInputs.map((item, index) => {
+    assertString(`aiArtifacts[${index}].id`, item.id);
+
+    const id = aiArtifactIdForInput(item.id) ?? item.id;
+    const artifact = aiArtifactCatalog.find((candidate) => candidate.id === id);
+
+    if (!artifact) {
+      throw new Error(
+        `Invalid aiArtifacts[${index}].id: ${item.id}. Use artifact IDs, labels, or sources from get_ai_artifact_options.`,
+      );
+    }
+
+    let target;
+
+    if (item.target !== undefined) {
+      target = normalizeAiTarget(item.target, index);
+    }
+
+    if (artifact.type === "skill" && item.target !== undefined) {
+      throw new Error(`Invalid aiArtifacts[${index}].target: skill artifacts do not use target.`);
+    }
+
+    return {
+      id,
+      target: artifact.defaultTarget ? target || artifact.defaultTarget : undefined,
+    };
+  });
+}
+
+export function aiArtifactRecipeItems(artifactInputs = []) {
+  return normalizeAiArtifactInputs(artifactInputs).map(({ id, target }) => {
+    const artifact = aiArtifactCatalog.find((candidate) => candidate.id === id);
+    const item = {
+      type: artifact.type,
+      src: artifact.src,
+    };
+
+    if (artifact.defaultTarget) {
+      item.target = target ?? artifact.defaultTarget;
+    }
+
+    return item;
+  });
+}
+
+export function validateRecipeCompositionInput({
+  profile,
+  packageManager = "npm",
+  tools,
+  aiArtifacts,
+} = {}) {
+  assertKnownValue("profile", profile, profileIds);
+  assertKnownValue("packageManager", packageManager, packageManagerIds);
+
+  const allowedIntegrationIds = listIntegrationOptions(profile).map(({ id }) => id);
+  const integrationIds = tools ? normalizeIntegrationInputs(tools) : profileDefaults[profile];
+  const invalidIntegrationIds = integrationIds.filter((id) => !allowedIntegrationIds.includes(id));
+
+  if (invalidIntegrationIds.length > 0) {
+    throw new Error(
+      `Invalid tools for the ${profile} profile: ${invalidIntegrationIds.join(", ")}. Use tool IDs or labels from get_project_tooling_options. Allowed IDs: ${allowedIntegrationIds.join(", ")}.`,
+    );
+  }
+
+  return {
+    profile,
+    packageManager,
+    tools: integrationIds,
+    aiArtifacts: aiArtifacts ? normalizeAiArtifactInputs(aiArtifacts) : undefined,
+  };
+}
+
+export function composeRecipe(configurationInput = {}) {
+  const { profile, packageManager, tools, aiArtifacts } =
+    validateRecipeCompositionInput(configurationInput);
+
+  return buildRecipe(
+    profile,
+    tools,
+    packageManager,
+    aiArtifacts ? aiArtifactRecipeItems(aiArtifacts) : [],
+  );
+}
+
+export function resolveRecipeIntegrations(recipe) {
+  const selected = new Set(recipe.integrations ?? []);
+
+  for (const integration of integrationCatalog) {
+    if (selected.has(integration.id)) {
+      for (const includes of integration.includes ?? []) {
+        selected.add(includes);
+      }
+    }
+  }
+
+  return integrationCatalog.filter((integration) => selected.has(integration.id));
+}
+
+export function explainRecipeIntegrations(recipe) {
+  const selected = new Set(recipe.integrations ?? []);
+  const defaults = new Set(profileDefaults[recipe.profile] ?? []);
+  const reasons = new Map();
+
+  for (const id of selected) {
+    reasons.set(
+      id,
+      defaults.has(id)
+        ? `Included by the ${recipe.profile} profile defaults.`
+        : "Explicitly selected in the recipe.",
+    );
+  }
+
+  for (const integration of integrationCatalog) {
+    if (!selected.has(integration.id)) {
+      continue;
+    }
+
+    for (const includedId of integration.includes ?? []) {
+      if (!reasons.has(includedId)) {
+        reasons.set(includedId, `Included because ${integration.label} requires it.`);
+      }
+    }
+  }
+
+  return resolveRecipeIntegrations(recipe).map(({ id, label, group, status }) => ({
+    id,
+    label,
+    group,
+    status,
+    reason: reasons.get(id) ?? "Selected by the composed recipe.",
+  }));
+}
+
+export function validateRecipe(recipe) {
+  if (recipe === null || typeof recipe !== "object" || Array.isArray(recipe)) {
+    throw new TypeError("Recipe must be an object.");
+  }
+
+  assertKnownValue("profile", recipe.profile, profileIds);
+  assertKnownValue("packageManager", recipe.packageManager, packageManagerIds);
+  assertStringArray("integrations", recipe.integrations);
+
+  const knownIntegrationIds = integrationCatalog.map(({ id }) => id);
+  const unknownIntegrationIds = recipe.integrations.filter(
+    (id) => !knownIntegrationIds.includes(id),
+  );
+
+  if (unknownIntegrationIds.length > 0) {
+    throw new Error(`Unknown integrations: ${unknownIntegrationIds.join(", ")}.`);
+  }
+
+  if (Object.hasOwn(recipe, "ai")) {
+    assertObjectArray("ai", recipe.ai);
+  }
+
+  return recipe;
+}
+
+export function catalogResponse(currentConfiguration) {
+  return {
+    profiles: profileCatalog.map(({ id, label, description }) => ({
+      id,
+      label,
+      description,
+      defaultIntegrations: profileDefaults[id],
+    })),
+    packageManagers: packageManagerCatalog,
+    integrations: listIntegrationOptions(),
+    aiArtifacts: listAiArtifactOptions(),
+    toolInput: {
+      accepts:
+        "Use either an integration id or its label in the configure_project_tooling tools array. Matching is case-insensitive.",
+      examples: ["typescript", "Stylelint", "Oxc JSX accessibility rules"],
+    },
+    defaults: profileDefaults,
+    currentConfiguration,
+  };
+}
+
+export function aiArtifactsResponse(currentConfiguration = []) {
+  return {
+    defaultTarget: DEFAULT_AI_TARGET,
+    artifactTypes: aiArtifactTypes,
+    artifacts: listAiArtifactOptions(),
+    input: {
+      accepts:
+        "Use artifact IDs, labels, or sources in configure_ai_artifacts. Add target for hook and agent artifacts when the default target is not correct.",
+      examples: [
+        { id: "skill-semantic-html" },
+        { id: "hooks/block-dangerous-commands", target: "claude-code" },
+        { id: "Technical devil's advocate", target: "claude-code" },
+      ],
+    },
+    currentConfiguration,
+  };
+}
+
 /**
  * @param {string} profile
  * @param {string[]} integrations
@@ -46,14 +431,7 @@ export function buildRecipe(profile, integrations, packageManager = "npm", ai = 
     profile,
     packageManager,
     integrations,
-    scripts: {
-      lint: true,
-      "lint:fix": true,
-      format: true,
-      "format:check": true,
-      typecheck: true,
-      quality: true,
-    },
+    scripts: { ...defaultScriptFlags },
   };
 
   if (ai.length > 0) {

--- a/src/utils/assertions.js
+++ b/src/utils/assertions.js
@@ -1,0 +1,51 @@
+// @ts-check
+
+/**
+ * @param {string} name
+ * @param {unknown} value
+ * @returns {asserts value is string}
+ */
+export function assertString(name, value) {
+  if (typeof value !== "string") {
+    throw new TypeError(`${name} must be a string.`);
+  }
+}
+
+/**
+ * @param {string} name
+ * @param {unknown} value
+ * @returns {asserts value is string[]}
+ */
+export function assertStringArray(name, value) {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new TypeError(`${name} must be an array of strings.`);
+  }
+}
+
+/**
+ * @param {string} name
+ * @param {unknown} value
+ * @returns {asserts value is Record<string, unknown>[]}
+ */
+export function assertObjectArray(name, value) {
+  if (
+    !Array.isArray(value) ||
+    value.some((item) => item === null || typeof item !== "object" || Array.isArray(item))
+  ) {
+    throw new TypeError(`${name} must be an array of objects.`);
+  }
+}
+
+/**
+ * @param {string} name
+ * @param {unknown} value
+ * @param {string[]} allowedValues
+ * @returns {asserts value is string}
+ */
+export function assertKnownValue(name, value, allowedValues) {
+  assertString(name, value);
+
+  if (!allowedValues.includes(value)) {
+    throw new Error(`Invalid ${name}: ${value}. Allowed values: ${allowedValues.join(", ")}.`);
+  }
+}

--- a/web/script.js
+++ b/web/script.js
@@ -1,160 +1,32 @@
-import { buildRecipe } from "../src/recipe.js";
-import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "../src/ai/catalog.js";
-
-const catalog = [
-  entry("editorconfig", "Project consistency", "EditorConfig", "recommended"),
-  entry("typescript", "Type checking", "TypeScript type checking", "recommended"),
-  entry("oxlint", "Modern JS/TS linting", "Oxlint", "recommended", ["modern"]),
-  entry("oxlint-eslint", "Modern JS/TS linting", "Oxc ESLint compatibility rules", "recommended", [
-    "modern",
-  ]),
-  entry("oxlint-typescript", "Modern JS/TS linting", "Oxc TypeScript rules", "recommended", [
-    "modern",
-  ]),
-  entry("oxlint-unicorn", "Modern JS/TS linting", "Oxc Unicorn rules", "recommended", ["modern"]),
-  entry("oxlint-oxc", "Modern JS/TS linting", "Oxc native rules", "recommended", ["modern"]),
-  entry("oxlint-import", "Imports and modules", "Oxc import rules", "optional", ["modern"]),
-  entry("oxlint-react", "React best practices", "Oxc React rules", "framework-specific", [
-    "modern",
-  ]),
-  entry("react-doctor", "React best practices", "React Doctor", "framework-specific", [
-    "modern",
-    "classic",
-  ]),
-  entry("oxlint-jsx-a11y", "Accessibility", "Oxc JSX accessibility rules", "optional", ["modern"]),
-  entry("oxlint-node", "Node package rules", "Oxc Node rules", "optional", ["modern"]),
-  entry("oxlint-promise", "Promise safety", "Oxc Promise rules", "optional", ["modern"]),
-  entry("oxlint-vitest", "Test rules", "Oxc Vitest rules", "optional", ["modern"]),
-  entry("oxlint-jest", "Test rules", "Oxc Jest rules", "optional", ["modern"]),
-  entry("oxlint-nextjs", "Framework rules", "Oxc Next.js rules", "framework-specific", ["modern"]),
-  entry("oxlint-vue", "Framework rules", "Oxc Vue rules", "framework-specific", ["modern"]),
-  entry("oxlint-jsdoc", "Documentation rules", "Oxc JSDoc rules", "optional", ["modern"]),
-  entry("oxfmt", "Formatting", "Oxfmt", "experimental", ["modern"]),
-  entry("eslint", "Classic JS/TS linting", "ESLint flat config", "recommended", ["classic"]),
-  entry("typescript-eslint", "Classic JS/TS linting", "TypeScript ESLint", "recommended", [
-    "classic",
-  ]),
-  entry("eslint-config-prettier", "Formatting", "Prettier compatibility", "recommended", [
-    "classic",
-  ]),
-  entry("eslint-react", "React best practices", "ESLint React rules", "framework-specific", [
-    "classic",
-  ]),
-  entry("eslint-jsx-a11y", "Accessibility", "ESLint JSX accessibility rules", "optional", [
-    "classic",
-  ]),
-  entry("eslint-import", "Imports and modules", "ESLint import rules", "optional", ["classic"]),
-  entry("eslint-n", "Node package rules", "ESLint Node rules", "optional", ["classic"]),
-  entry("eslint-promise", "Promise safety", "ESLint Promise rules", "optional", ["classic"]),
-  entry("eslint-unicorn", "Classic JS/TS linting", "Unicorn rules", "optional", ["classic"]),
-  entry("eslint-sonarjs", "Classic JS/TS linting", "SonarJS rules", "optional", ["classic"]),
-  entry("eslint-vitest", "Test rules", "ESLint Vitest rules", "optional", ["classic"]),
-  entry("eslint-jest", "Test rules", "ESLint Jest rules", "optional", ["classic"]),
-  entry("stylelint", "CSS linting", "Stylelint", "recommended"),
-  entry("stylelint-standard", "CSS linting", "Stylelint standard config", "recommended"),
-  entry("stylelint-order", "CSS property ordering", "CSS property ordering", "optional"),
-  entry("stylelint-baseline", "CSS Baseline", "CSS Baseline", "recommended"),
-  entry("stylelint-scss", "CSS linting", "SCSS support", "framework-specific"),
-  entry("stylelint-stylistic", "CSS linting", "Stylelint stylistic rules", "optional"),
-  entry(
-    "css-property-type-validator",
-    "CSS property type validation",
-    "CSS property type validation",
-    "experimental",
-  ),
-  entry("prettier", "Formatting", "Prettier", "recommended", ["classic"]),
-  entry("prettier-tailwind", "Formatting", "Tailwind class sorting", "optional", ["classic"]),
-  entry("prettier-svelte", "Formatting", "Svelte formatting", "framework-specific", ["classic"]),
-  entry("prettier-astro", "Formatting", "Astro formatting", "framework-specific", ["classic"]),
-];
-
-function entry(id, group, label, status, profiles = ["modern", "classic", "minimal"]) {
-  return { id, group, label, status, profiles };
-}
-
-const defaults = {
-  modern: [
-    "editorconfig",
-    "typescript",
-    "oxlint",
-    "oxlint-eslint",
-    "oxlint-typescript",
-    "oxlint-unicorn",
-    "oxlint-oxc",
-    "oxfmt",
-    "stylelint",
-    "stylelint-standard",
-    "stylelint-baseline",
-  ],
-  classic: [
-    "editorconfig",
-    "typescript",
-    "eslint",
-    "typescript-eslint",
-    "eslint-config-prettier",
-    "prettier",
-    "stylelint",
-    "stylelint-standard",
-    "stylelint-baseline",
-  ],
-  minimal: ["editorconfig"],
-};
+import {
+  aiArtifactsResponse as buildAiArtifactsResponse,
+  buildRecipe,
+  catalogResponse as buildCatalogResponse,
+  listAiArtifactOptions,
+  listIntegrationOptions,
+  normalizeAiArtifactInputs,
+  packageManagerIdsForRecipe,
+  profileDefaults,
+  profileIdsForRecipe,
+  validateRecipeCompositionInput,
+} from "../src/recipe.js";
+import { DEFAULT_AI_TARGET } from "../src/ai/catalog.js";
 
 const form = document.querySelector("#composer");
 const integrations = document.querySelector("#integrations");
 const aiArtifacts = document.querySelector("#ai-artifacts");
 const output = document.querySelector("#output");
 const webMcpBanner = document.querySelector("#webmcp-banner");
-const profiles = Object.keys(defaults);
-const packageManagers = ["npm", "pnpm", "yarn", "bun"];
-const aiArtifactTypes = ["skill", "hook", "agent"];
-const profileDescriptions = {
-  modern: "Newer, faster JavaScript, TypeScript, CSS linting, and formatting defaults.",
-  classic: "Widely used JavaScript, TypeScript, CSS linting, and formatting defaults.",
-  minimal: "Only basic editor consistency settings.",
-};
-const packageManagerDescriptions = {
-  npm: "npm, the default Node.js package manager.",
-  pnpm: "pnpm, a fast disk-efficient package manager.",
-  yarn: "Yarn package manager.",
-  bun: "Bun package manager and runtime.",
-};
+const profiles = profileIdsForRecipe();
+const packageManagers = packageManagerIdsForRecipe();
+const aiArtifactOptions = listAiArtifactOptions();
 
 function selectedProfile() {
   return new FormData(form).get("profile");
 }
 
 function visibleCatalog(profile = selectedProfile()) {
-  return catalog.filter(({ profiles }) => profiles.includes(profile));
-}
-
-function integrationIdsForProfile(profile) {
-  return visibleCatalog(profile).map(({ id }) => id);
-}
-
-function normalizedToolToken(value) {
-  return value.trim().toLowerCase();
-}
-
-function integrationIdForTool(value) {
-  const token = normalizedToolToken(value);
-  const match = catalog.find(
-    ({ id, label }) => normalizedToolToken(id) === token || normalizedToolToken(label) === token,
-  );
-
-  return match?.id;
-}
-
-function aiArtifactIdForInput(value) {
-  const token = normalizedToolToken(value);
-  const match = aiArtifactCatalog.find(
-    ({ id, label, src }) =>
-      normalizedToolToken(id) === token ||
-      normalizedToolToken(label) === token ||
-      normalizedToolToken(src) === token,
-  );
-
-  return match?.id;
+  return listIntegrationOptions(profile);
 }
 
 function renderIntegrations() {
@@ -188,7 +60,7 @@ function renderIntegrations() {
 function renderAiArtifacts() {
   aiArtifacts.replaceChildren();
 
-  const groups = aiArtifactCatalog.reduce((grouped, item) => {
+  const groups = aiArtifactOptions.reduce((grouped, item) => {
     grouped.set(item.group, [...(grouped.get(item.group) ?? []), item]);
     return grouped;
   }, new Map());
@@ -268,7 +140,7 @@ function syncAiTargetStates() {
 
 function selectedAiItems() {
   return [...form.querySelectorAll('[name="aiArtifact"]:checked')].map((checkbox) => {
-    const artifact = aiArtifactCatalog.find(({ id }) => id === checkbox.value);
+    const artifact = aiArtifactOptions.find(({ id }) => id === checkbox.value);
     const item = {
       type: artifact.type,
       src: artifact.src,
@@ -303,110 +175,18 @@ function setDefaults() {
   const profile = selectedProfile();
 
   renderIntegrations();
-  selectIntegrations(defaults[profile]);
+  selectIntegrations(profileDefaults[profile]);
   syncAiTargetStates();
   render();
 }
 
-function assertString(name, value) {
-  if (typeof value !== "string") {
-    throw new TypeError(`${name} must be a string.`);
-  }
-}
-
-function assertStringArray(name, value) {
-  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
-    throw new TypeError(`${name} must be an array of strings.`);
-  }
-}
-
-function assertObjectArray(name, value) {
-  if (
-    !Array.isArray(value) ||
-    value.some((item) => item === null || typeof item !== "object" || Array.isArray(item))
-  ) {
-    throw new TypeError(`${name} must be an array of objects.`);
-  }
-}
-
-function assertKnownValue(name, value, allowedValues) {
-  assertString(name, value);
-
-  if (!allowedValues.includes(value)) {
-    throw new Error(`Invalid ${name}: ${value}. Allowed values: ${allowedValues.join(", ")}.`);
-  }
-}
-
-function normalizeIntegrationInputs(integrationInputs) {
-  assertStringArray("tools", integrationInputs);
-
-  return integrationInputs.map((value) => integrationIdForTool(value) ?? value);
-}
-
-function assertValidAiTarget(target, index) {
-  assertString(`aiArtifacts[${index}].target`, target);
-
-  if (target === "." || target === ".." || target.includes("/") || target.includes("\\")) {
-    throw new Error(
-      `Invalid aiArtifacts[${index}].target: ${target}. Targets must be a single directory name without path separators or traversal.`,
-    );
-  }
-}
-
-function normalizeAiArtifactInputs(artifactInputs = []) {
-  assertObjectArray("aiArtifacts", artifactInputs);
-
-  return artifactInputs.map((item, index) => {
-    assertString(`aiArtifacts[${index}].id`, item.id);
-
-    const id = aiArtifactIdForInput(item.id) ?? item.id;
-    const artifact = aiArtifactCatalog.find((candidate) => candidate.id === id);
-
-    if (!artifact) {
-      throw new Error(
-        `Invalid aiArtifacts[${index}].id: ${item.id}. Use artifact IDs, labels, or sources from get_ai_artifact_options.`,
-      );
-    }
-
-    let target;
-
-    if (item.target !== undefined) {
-      assertString(`aiArtifacts[${index}].target`, item.target);
-      target = item.target.trim();
-      assertValidAiTarget(target, index);
-    }
-
-    if (artifact.type === "skill" && item.target !== undefined) {
-      throw new Error(`Invalid aiArtifacts[${index}].target: skill artifacts do not use target.`);
-    }
-
-    return {
-      id,
-      target: artifact.defaultTarget ? target || artifact.defaultTarget : undefined,
-    };
-  });
-}
-
 function validateConfigurationInput({ profile, packageManager = "npm", tools, aiArtifacts } = {}) {
-  assertKnownValue("profile", profile, profiles);
-  assertKnownValue("packageManager", packageManager, packageManagers);
-
-  const allowedIntegrationIds = integrationIdsForProfile(profile);
-  const integrationIds = tools ? normalizeIntegrationInputs(tools) : defaults[profile];
-
-  const invalidIntegrationIds = integrationIds.filter((id) => !allowedIntegrationIds.includes(id));
-
-  if (invalidIntegrationIds.length > 0) {
-    throw new Error(
-      `Invalid tools for the ${profile} profile: ${invalidIntegrationIds.join(", ")}. Use tool IDs or labels from get_project_tooling_options. Allowed IDs: ${allowedIntegrationIds.join(", ")}.`,
-    );
-  }
-
+  const validated = validateRecipeCompositionInput({ profile, packageManager, tools, aiArtifacts });
   return {
-    profile,
-    packageManager,
-    tools: integrationIds,
-    aiArtifacts: aiArtifacts ? normalizeAiArtifactInputs(aiArtifacts) : undefined,
+    profile: validated.profile,
+    packageManager: validated.packageManager,
+    tools: validated.tools,
+    aiArtifacts: validated.aiArtifacts,
   };
 }
 
@@ -466,73 +246,11 @@ function downloadFile(recipeContents = recipe()) {
 }
 
 function catalogResponse() {
-  return {
-    profiles: profiles.map((id) => ({
-      id,
-      label: id,
-      description: profileDescriptions[id],
-      defaultIntegrations: defaults[id],
-    })),
-    packageManagers: packageManagers.map((id) => ({
-      id,
-      label: id,
-      description: packageManagerDescriptions[id],
-    })),
-    integrations: catalog.map(({ id, group, label, status, profiles }) => ({
-      id,
-      label,
-      group,
-      status,
-      profiles,
-      description: `${label}. Category: ${group}. Status: ${status}.`,
-    })),
-    aiArtifacts: aiArtifactCatalog.map(
-      ({ id, type, src, group, label, status, defaultTarget }) => ({
-        id,
-        type,
-        src,
-        label,
-        group,
-        status,
-        defaultTarget,
-        description: `${label}. Type: ${type}. Source: ${src}.`,
-      }),
-    ),
-    toolInput: {
-      accepts:
-        "Use either an integration id or its label in the configure_project_tooling tools array. Matching is case-insensitive.",
-      examples: ["typescript", "Stylelint", "Oxc JSX accessibility rules"],
-    },
-    defaults,
-    currentConfiguration: recipe(),
-  };
+  return buildCatalogResponse(recipe());
 }
 
 function aiArtifactsResponse() {
-  return {
-    defaultTarget: DEFAULT_AI_TARGET,
-    artifactTypes: aiArtifactTypes,
-    artifacts: aiArtifactCatalog.map(({ id, type, src, group, label, status, defaultTarget }) => ({
-      id,
-      type,
-      src,
-      label,
-      group,
-      status,
-      defaultTarget,
-      description: `${label}. Type: ${type}. Source: ${src}.`,
-    })),
-    input: {
-      accepts:
-        "Use artifact IDs, labels, or sources in configure_ai_artifacts. Add target for hook and agent artifacts when the default target is not correct.",
-      examples: [
-        { id: "skill-semantic-html" },
-        { id: "hooks/block-dangerous-commands", target: "claude-code" },
-        { id: "Technical devil's advocate", target: "claude-code" },
-      ],
-    },
-    currentConfiguration: recipe().ai ?? [],
-  };
+  return buildAiArtifactsResponse(recipe().ai ?? []);
 }
 
 function configureProjectTooling({ profile, packageManager, tools, aiArtifacts } = {}) {

--- a/web/script.js
+++ b/web/script.js
@@ -5,6 +5,7 @@ import {
   listAiArtifactOptions,
   listIntegrationOptions,
   normalizeAiArtifactInputs,
+  normalizeAiTarget,
   packageManagerIdsForRecipe,
   profileDefaults,
   profileIdsForRecipe,
@@ -139,7 +140,7 @@ function syncAiTargetStates() {
 }
 
 function selectedAiItems() {
-  return [...form.querySelectorAll('[name="aiArtifact"]:checked')].map((checkbox) => {
+  return [...form.querySelectorAll('[name="aiArtifact"]:checked')].map((checkbox, index) => {
     const artifact = aiArtifactOptions.find(({ id }) => id === checkbox.value);
     const item = {
       type: artifact.type,
@@ -148,7 +149,8 @@ function selectedAiItems() {
 
     if (artifact.defaultTarget) {
       const targetInput = form.querySelector(`[data-ai-target="${artifact.id}"]`);
-      item.target = targetInput?.value.trim() || DEFAULT_AI_TARGET;
+      item.target =
+        normalizeAiTarget(targetInput?.value ?? DEFAULT_AI_TARGET, index) || DEFAULT_AI_TARGET;
     }
 
     return item;


### PR DESCRIPTION
## Summary
- Move recipe composition, validation, catalog responses, and integration resolution into `src/recipe.js`
- Update the web composer and CLI paths to consume the shared helpers
- Expand schema drift coverage with unit tests for composition, normalization, and helper behavior

## Testing
- Added unit tests covering shared composition, AI artifact normalization, catalog exposure, and validation against the published schema
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared recipe-composition experience across the app, with consistent option lists, defaults, and validation for integrations and AI artifacts.
  * Improved configuration responses with clearer, structured guidance and current-state details.

* **Bug Fixes**
  * Tightened input handling to normalize common variations and reject invalid artifact targets.
  * Updated integration selection so dependent items are included consistently across workflows.

* **Documentation**
  * Refreshed contributor and research docs to match the new shared composition flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->