### PR TITLE
Add shared recipe composition workflow for WebMCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,13 @@ in this order:
 
 1. `list_profiles`
 2. `list_integrations`
-3. `list_ai_artifacts`
-4. `compose_recipe`
-5. `validate_recipe`
-6. `explain_recipe`
-7. `dry_run_apply`
-8. `apply_recipe`
+3. `describe_integration`
+4. `list_ai_artifacts`
+5. `compose_recipe`
+6. `validate_recipe`
+7. `explain_recipe`
+8. `dry_run_apply`
+9. `apply_recipe`
 
 `dry_run_apply` returns structured JSON with the package manager, integrations,
 dependency packages, file changes, and AI artifact changes that would be made.
@@ -264,6 +265,23 @@ Open the printed local URL, choose your packs, then either:
 
 Both options are shown by default so users can choose the flow they are most
 comfortable with.
+
+When the browser exposes WebMCP, the composer registers a browser parity surface
+for the MCP recipe composition workflow:
+
+1. `list_profiles`
+2. `list_integrations`
+3. `describe_integration`
+4. `list_ai_artifacts`
+5. `compose_recipe`
+6. `validate_recipe`
+7. `explain_recipe`
+8. `download_recipe`
+
+WebMCP uses the same shared recipe composition model as the standard MCP server,
+but it cannot inspect, dry-run, or apply files in a local project workspace from
+the browser. Use `download_recipe` to save `calavera.config.json`, then apply it
+with the CLI or standard MCP server from the project root.
 
 Build the composer with:
 

--- a/docs/vite-plus-template-research.md
+++ b/docs/vite-plus-template-research.md
@@ -240,8 +240,8 @@ Web UI paths in parity.
 The shared surface in `src/recipe.js` powers or should power:
 
 - existing web composer controls;
-- existing WebMCP tools in `web/script.js`;
-- future standard MCP tools;
+- WebMCP tools in `web/script.js`;
+- standard MCP tools;
 - the rich interactive CLI composer;
 - CLI commands that need recipe inspection or validation.
 
@@ -261,17 +261,21 @@ adding more operations such as:
 - `dry_run_apply`
 - `doctor_project`
 
-The current WebMCP tools already expose these concepts partially:
+The current WebMCP tools mirror the standard MCP recipe composition concepts:
 
-- `get_project_tooling_options`
-- `get_ai_artifact_options`
-- `configure_project_tooling`
-- `configure_ai_artifacts`
-- `download_configuration_json`
+- `list_profiles`
+- `list_integrations`
+- `describe_integration`
+- `list_ai_artifacts`
+- `compose_recipe`
+- `validate_recipe`
+- `explain_recipe`
+- `download_recipe`
 
-The future standard MCP server should use the same catalog and recipe builders
-as the web composer. It should not teach agents to drive the browser form when
-the same recipe can be composed directly.
+The intentional browser difference is that WebMCP downloads a composed recipe
+instead of previewing or applying project filesystem changes. Standard MCP owns
+`dry_run_apply` and `apply_recipe` because those operations need project-root
+filesystem and process access.
 
 ## Versioning Implications
 

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -26,15 +26,26 @@ import {
   buildRecipe,
   catalogResponse,
   composeRecipe,
+  composeRecipeResponse,
   CONFIG_SCHEMA_URL,
+  describeIntegrationResponse,
   explainRecipeIntegrations,
+  explainRecipeResponse,
   listIntegrationOptions,
+  listIntegrationsResponse,
+  listAiArtifactsResponse,
+  listProfilesResponse,
   normalizeAiArtifactInputs,
   normalizeIntegrationInputs,
   profileDefaults,
+  recipeWorkflow,
+  recipeToolDescriptions,
   resolveRecipeIntegrations,
+  standardMcpToolNames,
   validateRecipe,
   validateRecipeCompositionInput,
+  validateRecipeResponse,
+  webMcpToolNames,
 } from "../src/recipe.js";
 
 const schemaUrl = CONFIG_SCHEMA_URL;
@@ -287,6 +298,80 @@ test("shared explanation helpers include selected and included integration reaso
   assert.match(explanation.find(({ id }) => id === "oxlint-react").reason, /Explicitly selected/);
 });
 
+test("shared composition operation responses expose catalog, recipe, and explanation data", () => {
+  const recipeResponse = composeRecipeResponse({
+    profile: "modern",
+    packageManager: "pnpm",
+    tools: ["Oxlint", "Stylelint"],
+    aiArtifacts: [{ id: "Semantic HTML" }],
+  });
+
+  assert.deepEqual(
+    listProfilesResponse().profiles.map(({ id }) => id),
+    profiles,
+  );
+  assert.deepEqual(
+    listIntegrationsResponse({ profile: "classic" }).integrations.map(({ id }) => id),
+    listIntegrationOptions("classic").map(({ id }) => id),
+  );
+  assert.equal(describeIntegrationResponse("Oxlint").id, "oxlint");
+  assert.equal(
+    listAiArtifactsResponse().artifacts.some(({ id }) => id === "skill-semantic-html"),
+    true,
+  );
+  assert.deepEqual(recipeResponse.recipe.integrations, ["oxlint", "stylelint"]);
+  assert.equal(validateRecipeResponse(recipeResponse.recipe).ok, true);
+  assert.equal(
+    explainRecipeResponse(recipeResponse.recipe).aiArtifacts[0].id,
+    "skill-semantic-html",
+  );
+});
+
+test("standard MCP workflow exposes dry-run and apply tools", () => {
+  assert.deepEqual(recipeWorkflow(), standardMcpToolNames);
+  assert.deepEqual(
+    composeRecipeResponse({
+      profile: "minimal",
+    }).workflow,
+    standardMcpToolNames,
+  );
+});
+
+test("WebMCP workflow exposes browser download instead of filesystem apply tools", () => {
+  assert.deepEqual(recipeWorkflow({ browser: true }), webMcpToolNames);
+  assert.deepEqual(
+    composeRecipeResponse(
+      {
+        profile: "minimal",
+      },
+      { browser: true },
+    ).workflow,
+    webMcpToolNames,
+  );
+  assert.equal(webMcpToolNames.includes("download_recipe"), true);
+  assert.equal(webMcpToolNames.includes("dry_run_apply"), false);
+  assert.equal(webMcpToolNames.includes("apply_recipe"), false);
+});
+
+test("WebMCP registers browser parity tools from the shared contract", async () => {
+  const script = await readProjectFile("web/script.js");
+  const registeredToolNames = [...script.matchAll(/name: "([^"]+)"/g)].map((match) => match[1]);
+
+  for (const name of webMcpToolNames) {
+    assert.equal(registeredToolNames.includes(name), true, `Missing WebMCP tool: ${name}`);
+  }
+
+  for (const legacyName of [
+    "get_project_tooling_options",
+    "get_ai_artifact_options",
+    "configure_project_tooling",
+    "configure_ai_artifacts",
+    "download_configuration_json",
+  ]) {
+    assert.equal(script.includes(legacyName), false, `Legacy WebMCP tool remains: ${legacyName}`);
+  }
+});
+
 test("standard MCP server exposes Calavera recipe composition tools", async () => {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const server = createMcpServer();
@@ -298,19 +383,12 @@ test("standard MCP server exposes Calavera recipe composition tools", async () =
   try {
     const { tools } = await client.listTools();
     const toolNames = tools.map(({ name }) => name).sort();
-    const expectedToolNames = [
-      "list_profiles",
-      "list_integrations",
-      "describe_integration",
-      "list_ai_artifacts",
-      "compose_recipe",
-      "validate_recipe",
-      "explain_recipe",
-      "dry_run_apply",
-      "apply_recipe",
-    ].sort();
 
-    assert.deepEqual(toolNames, expectedToolNames);
+    assert.deepEqual(toolNames, [...standardMcpToolNames].sort());
+    assert.equal(
+      tools.find(({ name }) => name === "compose_recipe")?.description,
+      recipeToolDescriptions.compose_recipe,
+    );
     assert.equal(
       tools.find(({ name }) => name === "apply_recipe")?.annotations?.destructiveHint,
       true,

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -299,6 +299,7 @@ test("shared explanation helpers include selected and included integration reaso
 });
 
 test("shared composition operation responses expose catalog, recipe, and explanation data", () => {
+  const profilesResponse = listProfilesResponse();
   const recipeResponse = composeRecipeResponse({
     profile: "modern",
     packageManager: "pnpm",
@@ -307,8 +308,12 @@ test("shared composition operation responses expose catalog, recipe, and explana
   });
 
   assert.deepEqual(
-    listProfilesResponse().profiles.map(({ id }) => id),
+    profilesResponse.profiles.map(({ id }) => id),
     profiles,
+  );
+  assert.notEqual(
+    profilesResponse.profiles.find(({ id }) => id === "modern").defaultIntegrations,
+    profileDefaults.modern,
   );
   assert.deepEqual(
     listIntegrationsResponse({ profile: "classic" }).integrations.map(({ id }) => id),
@@ -355,20 +360,24 @@ test("WebMCP workflow exposes browser download instead of filesystem apply tools
 
 test("WebMCP registers browser parity tools from the shared contract", async () => {
   const script = await readProjectFile("web/script.js");
-  const registeredToolNames = [...script.matchAll(/name: "([^"]+)"/g)].map((match) => match[1]);
-
-  for (const name of webMcpToolNames) {
-    assert.equal(registeredToolNames.includes(name), true, `Missing WebMCP tool: ${name}`);
-  }
-
-  for (const legacyName of [
+  const registeredToolNames = [...script.matchAll(/registerTool\(\{\s*name: "([^"]+)"/g)].map(
+    (match) => match[1],
+  );
+  const legacyToolNames = [
     "get_project_tooling_options",
     "get_ai_artifact_options",
     "configure_project_tooling",
     "configure_ai_artifacts",
     "download_configuration_json",
-  ]) {
-    assert.equal(script.includes(legacyName), false, `Legacy WebMCP tool remains: ${legacyName}`);
+  ];
+
+  assert.deepEqual(registeredToolNames.sort(), [...webMcpToolNames].sort());
+  for (const legacyName of legacyToolNames) {
+    assert.equal(
+      registeredToolNames.includes(legacyName),
+      false,
+      `Legacy WebMCP tool remains: ${legacyName}`,
+    );
   }
 });
 

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -9,18 +9,18 @@ import * as z from "zod";
 
 import { applyRecipeObject } from "./index.js";
 import {
-  aiArtifactsResponse,
-  composeRecipe,
-  explainRecipeIntegrations,
-  listAiArtifactOptions,
-  listIntegrationOptions,
-  packageManagerCatalog,
+  composeRecipeResponse,
+  describeIntegrationResponse,
+  explainRecipeResponse,
+  listAiArtifactsResponse,
+  listIntegrationsResponse,
+  listProfilesResponse,
   packageManagerIdsForRecipe,
-  profileCatalog,
-  profileDefaults,
   profileIdsForRecipe,
-  resolveRecipeIntegrations,
+  recipeToolDescriptions,
+  recipeToolInputDescriptions,
   validateRecipe,
+  validateRecipeResponse,
 } from "./recipe.js";
 import { assertPlainObject } from "./utils/assertions.js";
 import { writeJSON } from "./utils/fs.js";
@@ -33,14 +33,14 @@ import { writeJSON } from "./utils/fs.js";
 const SERVER_NAME = "create-project-calavera";
 const SERVER_VERSION = packageJson.version;
 const SERVER_INSTRUCTIONS =
-  "Compose Calavera recipes for the current project. Start with list_profiles, list_integrations, and list_ai_artifacts to discover valid IDs, then call compose_recipe, validate_recipe, explain_recipe, and dry_run_apply. Present the dry-run summary to the user and call apply_recipe only after explicit approval.";
+  "Compose Calavera recipes for the current project. Start with list_profiles, list_integrations, describe_integration when details are needed, and list_ai_artifacts to discover valid IDs, then call compose_recipe, validate_recipe, explain_recipe, and dry_run_apply. Present the dry-run summary to the user and call apply_recipe only after explicit approval.";
 
 const profileIds = profileIdsForRecipe();
 const packageManagerIds = packageManagerIdsForRecipe();
 const recipeSchema = z.record(z.string(), z.unknown()).describe("A Calavera recipe object.");
 const aiArtifactInputSchema = z.object({
-  id: z.string().describe("AI artifact ID, source, or label from list_ai_artifacts."),
-  target: z.string().optional().describe("Optional target directory for hook and agent artifacts."),
+  id: z.string().describe(recipeToolInputDescriptions.aiArtifactId),
+  target: z.string().optional().describe(recipeToolInputDescriptions.aiArtifactTarget),
 });
 
 const toolAnnotations = {
@@ -60,104 +60,84 @@ const toolAnnotations = {
 
 const toolConfigs = {
   list_profiles: {
-    description:
-      "List Calavera profiles, package managers, and default integrations. Use this first when composing a recipe.",
+    description: recipeToolDescriptions.list_profiles,
     inputSchema: {},
     annotations: toolAnnotations.read,
   },
   list_integrations: {
-    description:
-      "List available Calavera integration options. Pass a profile to see only integrations valid for that profile.",
+    description: recipeToolDescriptions.list_integrations,
     inputSchema: {
-      profile: z.enum(profileIds).optional().describe("Optional profile filter."),
+      profile: z.enum(profileIds).optional().describe(recipeToolInputDescriptions.profileFilter),
     },
     annotations: toolAnnotations.read,
   },
   describe_integration: {
-    description:
-      "Describe one Calavera integration, including its profile availability, dependency packages, and included parent integrations.",
+    description: recipeToolDescriptions.describe_integration,
     inputSchema: {
-      id: z.string().describe("Integration ID or label from list_integrations."),
+      id: z.string().describe(recipeToolInputDescriptions.integrationId),
     },
     annotations: toolAnnotations.read,
   },
   list_ai_artifacts: {
-    description:
-      "List bundled AI skills, hooks, and agents that can be included in a Calavera recipe.",
+    description: recipeToolDescriptions.list_ai_artifacts,
     inputSchema: {},
     annotations: toolAnnotations.read,
   },
   compose_recipe: {
-    description:
-      "Compose a schema-valid Calavera recipe from a profile, package manager, integration IDs or labels, and optional AI artifacts.",
+    description: recipeToolDescriptions.compose_recipe,
     inputSchema: {
-      profile: z.enum(profileIds).describe("Base Calavera tooling profile."),
+      profile: z.enum(profileIds).describe(recipeToolInputDescriptions.profile),
       packageManager: z
         .enum(packageManagerIds)
         .default("npm")
-        .describe("Package manager used for dependency installation and generated scripts."),
-      tools: z
-        .array(z.string())
-        .optional()
-        .describe(
-          "Integration IDs or labels. Omit to use the selected profile defaults from list_profiles.",
-        ),
+        .describe(recipeToolInputDescriptions.packageManager),
+      tools: z.array(z.string()).optional().describe(recipeToolInputDescriptions.tools),
       aiArtifacts: z
         .array(aiArtifactInputSchema)
         .optional()
-        .describe("Bundled AI skills, hooks, and agents to include in the recipe."),
+        .describe(recipeToolInputDescriptions.aiArtifacts),
     },
     annotations: toolAnnotations.read,
   },
   validate_recipe: {
-    description:
-      "Validate a Calavera recipe object before previewing or applying it. Returns validation status and errors instead of writing files.",
+    description: recipeToolDescriptions.validate_recipe,
     inputSchema: {
       recipe: recipeSchema,
     },
     annotations: toolAnnotations.read,
   },
   explain_recipe: {
-    description:
-      "Explain the integrations selected by a Calavera recipe, including profile defaults and automatically included parent integrations.",
+    description: recipeToolDescriptions.explain_recipe,
     inputSchema: {
       recipe: recipeSchema,
     },
     annotations: toolAnnotations.read,
   },
   dry_run_apply: {
-    description:
-      "Preview applying a Calavera recipe in the current project. This does not write files or install packages, and should be shown to the user before apply_recipe.",
+    description: recipeToolDescriptions.dry_run_apply,
     inputSchema: {
       recipe: recipeSchema,
       packageManager: z
         .enum(packageManagerIds)
         .optional()
-        .describe("Optional package manager override."),
+        .describe(recipeToolInputDescriptions.packageManagerOverride),
     },
     annotations: toolAnnotations.read,
   },
   apply_recipe: {
-    description:
-      "Apply an approved Calavera recipe in the current project. Call only after presenting dry_run_apply output and receiving explicit user approval.",
+    description: recipeToolDescriptions.apply_recipe,
     inputSchema: {
       recipe: recipeSchema,
       packageManager: z
         .enum(packageManagerIds)
         .optional()
-        .describe("Optional package manager override."),
+        .describe(recipeToolInputDescriptions.packageManagerOverride),
       config: z
         .string()
         .default("calavera.config.json")
-        .describe("Recipe file path to write before applying."),
-      writeConfig: z
-        .boolean()
-        .default(true)
-        .describe("Write the approved recipe to the config path before applying."),
-      noInstall: z
-        .boolean()
-        .default(false)
-        .describe("Skip package manager dependency installation."),
+        .describe(recipeToolInputDescriptions.config),
+      writeConfig: z.boolean().default(true).describe(recipeToolInputDescriptions.writeConfig),
+      noInstall: z.boolean().default(false).describe(recipeToolInputDescriptions.noInstall),
     },
     annotations: toolAnnotations.apply,
   },
@@ -180,27 +160,6 @@ function assertToolInput(input, toolName) {
 function assertRecipeInput(value) {
   validateRecipe(value);
   return /** @type {Recipe} */ (value);
-}
-
-/**
- * @param {unknown} value
- */
-function matchIntegration(value) {
-  const token = String(value).trim().toLowerCase();
-  return listIntegrationOptions().find(
-    ({ id, label }) => id.toLowerCase() === token || label.toLowerCase() === token,
-  );
-}
-
-/**
- * @param {Recipe} recipe
- */
-function dependencyListForRecipe(recipe) {
-  return [
-    ...new Set(
-      resolveRecipeIntegrations(recipe).flatMap((integration) => integration.dependencies ?? []),
-    ),
-  ];
 }
 
 /**
@@ -227,87 +186,46 @@ function projectConfigPath(requestedPath) {
 }
 
 function listProfilesTool() {
-  return {
-    profiles: profileCatalog.map(({ id, label, description }) => ({
-      id,
-      label,
-      description,
-      defaultIntegrations: profileDefaults[id],
-    })),
-    packageManagers: packageManagerCatalog,
-    workflow: recipeWorkflow(),
-  };
+  return listProfilesResponse();
 }
 
 /**
  * @param {Record<string, unknown>} args
  */
 function listIntegrationsTool(args) {
-  return {
-    profile: args.profile ?? null,
-    integrations: listIntegrationOptions(/** @type {string | undefined} */ (args.profile)),
-  };
+  return listIntegrationsResponse({ profile: /** @type {string | undefined} */ (args.profile) });
 }
 
 /**
  * @param {Record<string, unknown>} args
  */
 function describeIntegrationTool(args) {
-  const integration = matchIntegration(args.id);
-
-  if (!integration) {
-    throw new Error(`Unknown integration: ${String(args.id)}.`);
-  }
-
-  return integration;
+  return describeIntegrationResponse(args.id);
 }
 
 function listAiArtifactsTool() {
-  return aiArtifactsResponse();
+  return listAiArtifactsResponse();
 }
 
 /**
  * @param {Record<string, unknown>} args
  */
 function composeRecipeTool(args) {
-  const recipe = composeRecipe(args);
-
-  return {
-    recipe,
-    workflow: recipeWorkflow(),
-  };
+  return composeRecipeResponse(args);
 }
 
 /**
  * @param {unknown} recipe
  */
 function validateRecipeTool(recipe) {
-  try {
-    validateRecipe(recipe);
-    return { ok: true, recipe };
-  } catch (error) {
-    return {
-      ok: false,
-      errors: [error instanceof Error ? error.message : String(error)],
-    };
-  }
+  return validateRecipeResponse(recipe);
 }
 
 /**
  * @param {Record<string, unknown>} args
  */
 function explainRecipeTool(args) {
-  const recipe = assertRecipeInput(args.recipe);
-
-  return {
-    integrations: explainRecipeIntegrations(recipe),
-    dependencies: dependencyListForRecipe(recipe),
-    aiArtifacts: listAiArtifactOptions().filter((artifact) =>
-      Array.isArray(recipe.ai)
-        ? recipe.ai.some((item) => item.type === artifact.type && item.src === artifact.src)
-        : false,
-    ),
-  };
+  return explainRecipeResponse(args.recipe);
 }
 
 /**
@@ -354,22 +272,6 @@ async function applyRecipeTool(args) {
       packageManager: /** @type {PackageManager | undefined} */ (args.packageManager),
     }),
   };
-}
-
-/**
- * @returns {string[]}
- */
-function recipeWorkflow() {
-  return [
-    "list_profiles",
-    "list_integrations",
-    "list_ai_artifacts",
-    "compose_recipe",
-    "validate_recipe",
-    "explain_recipe",
-    "dry_run_apply",
-    "apply_recipe after explicit user approval",
-  ];
 }
 
 /**

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -56,6 +56,65 @@ export const packageManagerCatalog = [
 
 export const aiArtifactTypes = ["skill", "hook", "agent"];
 
+export const recipeCompositionToolNames = Object.freeze([
+  "list_profiles",
+  "list_integrations",
+  "describe_integration",
+  "list_ai_artifacts",
+  "compose_recipe",
+  "validate_recipe",
+  "explain_recipe",
+]);
+
+export const standardMcpToolNames = Object.freeze([
+  ...recipeCompositionToolNames,
+  "dry_run_apply",
+  "apply_recipe",
+]);
+
+export const webMcpToolNames = Object.freeze([...recipeCompositionToolNames, "download_recipe"]);
+
+export const recipeToolDescriptions = Object.freeze({
+  list_profiles:
+    "List Calavera profiles, package managers, and default integrations. Use this first when composing a recipe.",
+  list_integrations:
+    "List available Calavera integration options. Pass a profile to see only integrations valid for that profile.",
+  describe_integration:
+    "Describe one Calavera integration, including its profile availability, dependency packages, and included parent integrations.",
+  list_ai_artifacts:
+    "List bundled AI skills, hooks, and agents that can be included in a Calavera recipe.",
+  compose_recipe:
+    "Compose a schema-valid Calavera recipe from a profile, package manager, integration IDs or labels, and optional AI artifacts.",
+  validate_recipe:
+    "Validate a Calavera recipe object before previewing, applying, or downloading it. Returns validation status and errors instead of writing files.",
+  explain_recipe:
+    "Explain the integrations selected by a Calavera recipe, including profile defaults and automatically included parent integrations.",
+  dry_run_apply:
+    "Preview applying a Calavera recipe in the current project. This does not write files or install packages, and should be shown to the user before apply_recipe.",
+  apply_recipe:
+    "Apply an approved Calavera recipe in the current project. Call only after presenting dry_run_apply output and receiving explicit user approval.",
+  download_recipe:
+    "Download a Calavera recipe as calavera.config.json. Pass a recipe from compose_recipe, or omit recipe to download the current visible composer recipe.",
+});
+
+export const recipeToolInputDescriptions = Object.freeze({
+  profile: "Base Calavera tooling profile.",
+  profileFilter: "Optional profile filter.",
+  packageManager: "Package manager used for dependency installation and generated scripts.",
+  tools: "Integration IDs or labels. Omit to use the selected profile defaults from list_profiles.",
+  integrationId: "Integration ID or label from list_integrations.",
+  aiArtifactId: "AI artifact ID, source, or label from list_ai_artifacts.",
+  aiArtifactTarget: "Optional target directory for hook and agent artifacts.",
+  aiArtifacts: "Bundled AI skills, hooks, and agents to include in the recipe.",
+  recipe: "A Calavera recipe object.",
+  packageManagerOverride: "Optional package manager override.",
+  config: "Recipe file path to write before applying.",
+  writeConfig: "Write the approved recipe to the config path before applying.",
+  noInstall: "Skip package manager dependency installation.",
+  optionalDownloadRecipe:
+    "Optional Calavera recipe object. When omitted, the current visible composer recipe is downloaded.",
+});
+
 /** @type {Record<string, string[]>} */
 export const profileDefaults = {
   modern: [
@@ -233,7 +292,7 @@ export function normalizeAiArtifactInputs(artifactInputs = []) {
 
     if (!artifact) {
       throw new Error(
-        `Invalid aiArtifacts[${index}].id: ${item.id}. Use artifact IDs, labels, or sources from get_ai_artifact_options.`,
+        `Invalid aiArtifacts[${index}].id: ${item.id}. Use artifact IDs, labels, or sources from list_ai_artifacts.`,
       );
     }
 
@@ -287,7 +346,7 @@ export function validateRecipeCompositionInput({
 
   if (invalidIntegrationIds.length > 0) {
     throw new Error(
-      `Invalid tools for the ${profile} profile: ${invalidIntegrationIds.join(", ")}. Use tool IDs or labels from get_project_tooling_options. Allowed IDs: ${allowedIntegrationIds.join(", ")}.`,
+      `Invalid tools for the ${profile} profile: ${invalidIntegrationIds.join(", ")}. Use tool IDs or labels from list_integrations. Allowed IDs: ${allowedIntegrationIds.join(", ")}.`,
     );
   }
 
@@ -389,6 +448,85 @@ export function validateRecipe(recipe) {
   return recipe;
 }
 
+export function recipeWorkflow({ browser = false } = {}) {
+  return browser ? [...webMcpToolNames] : [...standardMcpToolNames];
+}
+
+export function listProfilesResponse(options = {}) {
+  return {
+    profiles: profileCatalog.map(({ id, label, description }) => ({
+      id,
+      label,
+      description,
+      defaultIntegrations: profileDefaults[id],
+    })),
+    packageManagers: packageManagerCatalog,
+    workflow: recipeWorkflow(options),
+  };
+}
+
+export function listIntegrationsResponse({ profile } = {}) {
+  return {
+    profile: profile ?? null,
+    integrations: listIntegrationOptions(profile),
+  };
+}
+
+export function describeIntegrationResponse(id) {
+  const token = normalizedToken(String(id));
+  const integration = listIntegrationOptions().find(
+    ({ id: candidateId, label }) =>
+      normalizedToken(candidateId) === token || normalizedToken(label) === token,
+  );
+
+  if (!integration) {
+    throw new Error(`Unknown integration: ${String(id)}.`);
+  }
+
+  return integration;
+}
+
+export function composeRecipeResponse(configurationInput = {}, options = {}) {
+  return {
+    recipe: composeRecipe(configurationInput),
+    workflow: recipeWorkflow(options),
+  };
+}
+
+export function validateRecipeResponse(recipe) {
+  try {
+    validateRecipe(recipe);
+    return { ok: true, recipe };
+  } catch (error) {
+    return {
+      ok: false,
+      errors: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+}
+
+export function dependencyListForRecipe(recipe) {
+  return [
+    ...new Set(
+      resolveRecipeIntegrations(recipe).flatMap((integration) => integration.dependencies ?? []),
+    ),
+  ];
+}
+
+export function explainRecipeResponse(recipeInput) {
+  const recipe = validateRecipe(recipeInput);
+
+  return {
+    integrations: explainRecipeIntegrations(recipe),
+    dependencies: dependencyListForRecipe(recipe),
+    aiArtifacts: listAiArtifactOptions().filter((artifact) =>
+      Array.isArray(recipe.ai)
+        ? recipe.ai.some((item) => item.type === artifact.type && item.src === artifact.src)
+        : false,
+    ),
+  };
+}
+
 export function catalogResponse(currentConfiguration) {
   return {
     profiles: profileCatalog.map(({ id, label, description }) => ({
@@ -402,7 +540,7 @@ export function catalogResponse(currentConfiguration) {
     aiArtifacts: listAiArtifactOptions(),
     toolInput: {
       accepts:
-        "Use either an integration id or its label in the configure_project_tooling tools array. Matching is case-insensitive.",
+        "Use either an integration id or its label in the compose_recipe tools array. Matching is case-insensitive.",
       examples: ["typescript", "Stylelint", "Oxc JSX accessibility rules"],
     },
     defaults: profileDefaults,
@@ -417,7 +555,7 @@ export function aiArtifactsResponse(currentConfiguration = []) {
     artifacts: listAiArtifactOptions(),
     input: {
       accepts:
-        "Use artifact IDs, labels, or sources in configure_ai_artifacts. Add target for hook and agent artifacts when the default target is not correct.",
+        "Use artifact IDs, labels, or sources in compose_recipe aiArtifacts. Add target for hook and agent artifacts when the default target is not correct.",
       examples: [
         { id: "skill-semantic-html" },
         { id: "hooks/block-dangerous-commands", target: "claude-code" },
@@ -426,6 +564,10 @@ export function aiArtifactsResponse(currentConfiguration = []) {
     },
     currentConfiguration,
   };
+}
+
+export function listAiArtifactsResponse(currentConfiguration = []) {
+  return aiArtifactsResponse(currentConfiguration);
 }
 
 /**

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -458,7 +458,7 @@ export function listProfilesResponse(options = {}) {
       id,
       label,
       description,
-      defaultIntegrations: profileDefaults[id],
+      defaultIntegrations: [...profileDefaults[id]],
     })),
     packageManagers: packageManagerCatalog,
     workflow: recipeWorkflow(options),

--- a/web/script.js
+++ b/web/script.js
@@ -1,15 +1,21 @@
 import {
-  aiArtifactsResponse as buildAiArtifactsResponse,
   buildRecipe,
-  catalogResponse as buildCatalogResponse,
+  composeRecipeResponse,
+  describeIntegrationResponse,
+  explainRecipeResponse,
+  listAiArtifactsResponse,
   listAiArtifactOptions,
   listIntegrationOptions,
-  normalizeAiArtifactInputs,
+  listIntegrationsResponse,
+  listProfilesResponse,
   normalizeAiTarget,
   packageManagerIdsForRecipe,
   profileDefaults,
   profileIdsForRecipe,
-  validateRecipeCompositionInput,
+  recipeToolDescriptions,
+  recipeToolInputDescriptions,
+  validateRecipe,
+  validateRecipeResponse,
 } from "../src/recipe.js";
 import { DEFAULT_AI_TARGET } from "../src/ai/catalog.js";
 
@@ -100,34 +106,10 @@ function renderAiArtifacts() {
   }
 }
 
-function selectProfile(profile) {
-  const radio = form.querySelector(`[name="profile"][value="${profile}"]`);
-  radio.checked = true;
-}
-
-function selectPackageManager(packageManager) {
-  form.querySelector('[name="packageManager"]').value = packageManager;
-}
-
 function selectIntegrations(integrationIds) {
   for (const checkbox of form.querySelectorAll('[name="integration"]')) {
     checkbox.checked = integrationIds.includes(checkbox.value);
   }
-}
-
-function selectAiArtifacts(artifactInputs) {
-  const selectedArtifacts = new Map(artifactInputs.map((item) => [item.id, item]));
-
-  for (const checkbox of form.querySelectorAll('[name="aiArtifact"]')) {
-    checkbox.checked = selectedArtifacts.has(checkbox.value);
-  }
-
-  for (const targetInput of form.querySelectorAll("[data-ai-target]")) {
-    const selectedArtifact = selectedArtifacts.get(targetInput.dataset.aiTarget);
-    targetInput.value = selectedArtifact?.target ?? DEFAULT_AI_TARGET;
-  }
-
-  syncAiTargetStates();
 }
 
 function syncAiTargetStates() {
@@ -182,32 +164,6 @@ function setDefaults() {
   render();
 }
 
-function validateConfigurationInput({ profile, packageManager = "npm", tools, aiArtifacts } = {}) {
-  const validated = validateRecipeCompositionInput({ profile, packageManager, tools, aiArtifacts });
-  return {
-    profile: validated.profile,
-    packageManager: validated.packageManager,
-    tools: validated.tools,
-    aiArtifacts: validated.aiArtifacts,
-  };
-}
-
-function applyRecipeState(configurationInput = {}) {
-  const { profile, packageManager, tools, aiArtifacts } =
-    validateConfigurationInput(configurationInput);
-
-  selectProfile(profile);
-  renderIntegrations();
-  selectPackageManager(packageManager);
-  selectIntegrations(tools);
-  if (aiArtifacts) {
-    selectAiArtifacts(aiArtifacts);
-  }
-  render();
-
-  return recipe();
-}
-
 async function saveFile() {
   const contents = JSON.stringify(recipe(), null, 2);
 
@@ -247,36 +203,17 @@ function downloadFile(recipeContents = recipe()) {
   }, 100);
 }
 
-function catalogResponse() {
-  return buildCatalogResponse(recipe());
-}
-
-function aiArtifactsResponse() {
-  return buildAiArtifactsResponse(recipe().ai ?? []);
-}
-
-function configureProjectTooling({ profile, packageManager, tools, aiArtifacts } = {}) {
-  return applyRecipeState({ profile, packageManager, tools, aiArtifacts });
-}
-
-function configureAiArtifacts({ aiArtifacts = [] } = {}) {
-  const normalizedAiArtifacts = normalizeAiArtifactInputs(aiArtifacts);
-
-  selectAiArtifacts(normalizedAiArtifacts);
-  render();
-
-  return recipe();
-}
-
-function downloadConfigurationJson() {
-  const recipeContents = recipe();
+function downloadRecipe({ recipe: recipeInput } = {}) {
+  const recipeContents = recipeInput === undefined ? recipe() : validateRecipe(recipeInput);
   downloadFile(recipeContents);
 
   return {
     downloaded: true,
     filename: "calavera.config.json",
     mimeType: "application/json",
-    configuration: recipeContents,
+    recipe: recipeContents,
+    browserConstraint:
+      "WebMCP can download recipes from the browser, but cannot dry-run or apply them to a project filesystem.",
   };
 }
 
@@ -291,9 +228,8 @@ function registerWebMcpTools() {
 
   try {
     navigator.modelContext.registerTool({
-      name: "get_project_tooling_options",
-      description:
-        "Read available package managers, preset profiles, linting options, formatting options, and the current project tooling configuration. Use this before updating the form when you need valid option IDs.",
+      name: "list_profiles",
+      description: recipeToolDescriptions.list_profiles,
       inputSchema: {
         type: "object",
         properties: {},
@@ -303,140 +239,180 @@ function registerWebMcpTools() {
         readOnlyHint: true,
         untrustedContentHint: false,
       },
-      execute: async () => catalogResponse(),
+      execute: async () => listProfilesResponse({ browser: true }),
     });
 
     navigator.modelContext.registerTool({
-      name: "get_ai_artifact_options",
-      description:
-        "Read available bundled AI skills, hooks, and agents for the Calavera recipe ai array. Use this before configuring AI artifacts when you need valid artifact IDs, sources, labels, types, or default hook and agent targets.",
-      inputSchema: {
-        type: "object",
-        properties: {},
-        additionalProperties: false,
-      },
-      annotations: {
-        readOnlyHint: true,
-        untrustedContentHint: false,
-      },
-      execute: async () => aiArtifactsResponse(),
-    });
-
-    navigator.modelContext.registerTool({
-      name: "configure_project_tooling",
-      description:
-        "Update the visible form for a project tooling configuration. Choose a preset profile, package manager, and optional tools for linters, formatters, TypeScript, CSS tooling, accessibility checks, and test rules. Returns the configuration JSON shown on the page.",
+      name: "list_integrations",
+      description: recipeToolDescriptions.list_integrations,
       inputSchema: {
         type: "object",
         properties: {
           profile: {
             type: "string",
             enum: profiles,
-            description:
-              "Preset configuration to start from: modern uses newer fast tools, classic uses widely adopted tools, and minimal uses only basic editor consistency settings.",
-          },
-          packageManager: {
-            type: "string",
-            enum: packageManagers,
-            default: "npm",
-            description: "Package manager used to install and run the selected project tooling.",
-          },
-          tools: {
-            type: "array",
-            items: {
-              type: "string",
-            },
-            description:
-              "Tool IDs or labels to include in the configuration, such as linters, formatters, TypeScript support, CSS checks, accessibility checks, and test rules. Omit this field to use the selected profile defaults. Use get_project_tooling_options to see valid IDs and labels.",
-          },
-          aiArtifacts: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                id: {
-                  type: "string",
-                  description:
-                    "AI artifact ID, label, or source from get_ai_artifact_options, such as skill-semantic-html or hooks/block-dangerous-commands.",
-                },
-                target: {
-                  type: "string",
-                  description:
-                    "Optional target directory for hook and agent artifacts. Skills do not use target.",
-                },
-              },
-              required: ["id"],
-              additionalProperties: false,
-            },
-            description:
-              "Bundled AI skills, hooks, and agents to include in the recipe ai array. Omit to keep current AI selections unchanged.",
+            description: recipeToolInputDescriptions.profileFilter,
           },
         },
-        required: ["profile"],
         additionalProperties: false,
       },
       annotations: {
-        readOnlyHint: false,
+        readOnlyHint: true,
         untrustedContentHint: false,
       },
-      execute: async (input) => configureProjectTooling(input),
+      execute: async (input) => listIntegrationsResponse(input),
     });
 
     navigator.modelContext.registerTool({
-      name: "configure_ai_artifacts",
-      description:
-        "Update only the AI artifact selections for the Calavera recipe ai array. Choose bundled skills, hooks, and agents from get_ai_artifact_options. Returns the full configuration JSON shown on the page.",
+      name: "describe_integration",
+      description: recipeToolDescriptions.describe_integration,
       inputSchema: {
         type: "object",
         properties: {
-          aiArtifacts: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                id: {
-                  type: "string",
-                  description:
-                    "AI artifact ID, label, or source from get_ai_artifact_options, such as skill-semantic-html or hooks/block-dangerous-commands.",
-                },
-                target: {
-                  type: "string",
-                  description:
-                    "Optional target directory for hook and agent artifacts. Skills do not use target.",
-                },
-              },
-              required: ["id"],
-              additionalProperties: false,
-            },
-            default: [],
-            description:
-              "Bundled AI artifact selections. Pass an empty array to clear the recipe ai array.",
+          id: {
+            type: "string",
+            description: recipeToolInputDescriptions.integrationId,
           },
         },
-        required: ["aiArtifacts"],
+        required: ["id"],
         additionalProperties: false,
       },
       annotations: {
-        readOnlyHint: false,
+        readOnlyHint: true,
         untrustedContentHint: false,
       },
-      execute: async (input) => configureAiArtifacts(input),
+      execute: async (input) => describeIntegrationResponse(input.id),
     });
 
     navigator.modelContext.registerTool({
-      name: "download_configuration_json",
-      description:
-        "Download the current project tooling configuration as calavera.config.json. Use configure_project_tooling first when you need to change the selected profile, package manager, linters, formatters, or code quality tools before downloading.",
+      name: "list_ai_artifacts",
+      description: recipeToolDescriptions.list_ai_artifacts,
       inputSchema: {
         type: "object",
         properties: {},
         additionalProperties: false,
       },
       annotations: {
+        readOnlyHint: true,
+        untrustedContentHint: false,
+      },
+      execute: async () => listAiArtifactsResponse(recipe().ai ?? []),
+    });
+
+    navigator.modelContext.registerTool({
+      name: "compose_recipe",
+      description: recipeToolDescriptions.compose_recipe,
+      inputSchema: {
+        type: "object",
+        properties: {
+          profile: {
+            type: "string",
+            enum: profiles,
+            description: recipeToolInputDescriptions.profile,
+          },
+          packageManager: {
+            type: "string",
+            enum: packageManagers,
+            default: "npm",
+            description: recipeToolInputDescriptions.packageManager,
+          },
+          tools: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+            description: recipeToolInputDescriptions.tools,
+          },
+          aiArtifacts: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  description: recipeToolInputDescriptions.aiArtifactId,
+                },
+                target: {
+                  type: "string",
+                  description: recipeToolInputDescriptions.aiArtifactTarget,
+                },
+              },
+              required: ["id"],
+              additionalProperties: false,
+            },
+            description: recipeToolInputDescriptions.aiArtifacts,
+          },
+        },
+        required: ["profile"],
+        additionalProperties: false,
+      },
+      annotations: {
+        readOnlyHint: true,
+        untrustedContentHint: false,
+      },
+      execute: async (input) => composeRecipeResponse(input, { browser: true }),
+    });
+
+    navigator.modelContext.registerTool({
+      name: "validate_recipe",
+      description: recipeToolDescriptions.validate_recipe,
+      inputSchema: {
+        type: "object",
+        properties: {
+          recipe: {
+            type: "object",
+            description: recipeToolInputDescriptions.recipe,
+          },
+        },
+        required: ["recipe"],
+        additionalProperties: false,
+      },
+      annotations: {
+        readOnlyHint: true,
+        untrustedContentHint: false,
+      },
+      execute: async (input) => validateRecipeResponse(input.recipe),
+    });
+
+    navigator.modelContext.registerTool({
+      name: "explain_recipe",
+      description: recipeToolDescriptions.explain_recipe,
+      inputSchema: {
+        type: "object",
+        properties: {
+          recipe: {
+            type: "object",
+            description: recipeToolInputDescriptions.recipe,
+          },
+        },
+        required: ["recipe"],
+        additionalProperties: false,
+      },
+      annotations: {
+        readOnlyHint: true,
+        untrustedContentHint: false,
+      },
+      execute: async (input) => explainRecipeResponse(input.recipe),
+    });
+
+    navigator.modelContext.registerTool({
+      name: "download_recipe",
+      description: recipeToolDescriptions.download_recipe,
+      inputSchema: {
+        type: "object",
+        properties: {
+          recipe: {
+            type: "object",
+            description: recipeToolInputDescriptions.optionalDownloadRecipe,
+          },
+        },
+        additionalProperties: false,
+      },
+      annotations: {
         readOnlyHint: false,
         untrustedContentHint: false,
       },
-      execute: async () => downloadConfigurationJson(),
+      execute: async (input) => downloadRecipe(input),
     });
 
     revealWebMcpBanner();


### PR DESCRIPTION
## Summary
- Add shared recipe composition helpers and response builders for profiles, integrations, AI artifacts, validation, and explanations
- Update the standard MCP server and browser WebMCP surface to use the shared contract and expose the new tool names
- Document the browser-specific workflow and update tests to cover the new parity surface

## Testing
- Added and updated contract tests for shared response helpers, tool name sets, and WebMCP registration parity
- Not run (not requested)

fix #199 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the MCP workflow documentation to insert a `describe_integration` step and renumber subsequent steps.
  * Expanded WebMCP guidance, including how browser-based composition works and that local filesystem inspection/dry-run/apply is performed via CLI/standard MCP.

* **New Features**
  * WebMCP now exposes a browser-specific recipe workflow (compose, validate, explain) and supports downloading the composed recipe via `download_recipe`—rather than previewing/applying local changes.

* **Improvements**
  * Standardized tool descriptions and inputs for recipe composition-related actions across MCP modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->