### PR TITLE
Add agent bootstrap flow for existing projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ npm create project-calavera doctor --json
 npm create project-calavera apply --dry-run --json
 ```
 
+Bootstrap an existing project for agent-first Calavera usage without
+scaffolding app code:
+
+```bash
+npm create project-calavera -- --init
+```
+
+The `--init` bootstrap installs the base Calavera skill, adds concise project
+guidance, writes MCP setup notes, and prints a recommended first prompt for the
+user to give their agent. It leaves existing guidance files unchanged and writes
+fallback Calavera guidance when `AGENTS.md` already exists.
+
 ## MCP Server
 
 Calavera also ships a standard MCP server for agent-native recipe composition:
@@ -144,6 +156,17 @@ dependency packages, file changes, and AI artifact changes that would be made.
 Agents should present that dry-run summary to the user first. `apply_recipe`
 is intentionally the approval boundary: call it only after the user explicitly
 approves the proposed recipe and dry-run result.
+
+## Agent-First Flow
+
+Use Calavera after a project already exists, whether it came from `vp create`,
+Vite, another scaffold tool, or a manually maintained repository:
+
+1. Open the project directory.
+2. Run `npm create project-calavera -- --init`.
+3. Register the MCP server using the generated `.agents/calavera/mcp.md` notes.
+4. Start the agent from the project root.
+5. Ask it: `Use Calavera for this project. Inspect the current project for existing tooling and possible config conflicts, then list the available profiles, integrations, and AI artifacts. Once the profile and requirements are clear, compose a recipe, show me the dry-run result, and apply it only after I approve.`
 
 ### Bun-managed projects and npm `devEngines`
 

--- a/docs/vite-plus-template-research.md
+++ b/docs/vite-plus-template-research.md
@@ -170,7 +170,7 @@ Agent-first flow:
 ```text
 vp create
 cd generated-project
-npm create @schalkneethling/project-calavera -- --init
+npm create project-calavera -- --init
 start an agent
 ask the agent to use the Project Calavera skill
 describe linting, formatting, TypeScript, and AI artifact needs
@@ -191,7 +191,7 @@ Rich CLI flow:
 ```text
 vp create
 cd generated-project
-npm create @schalkneethling/project-calavera
+npm create project-calavera
 select tooling and AI artifacts in the interactive CLI
 write calavera.config.json
 run the printed apply command
@@ -209,23 +209,27 @@ run the printed apply command
 The CLI may later support a write-and-apply mode, but the durable contract should
 remain the recipe file plus an explicit apply step.
 
-## Package Naming Verification
+## Package Naming Notes
 
-The scoped npm create syntax was verified against npm 11.16.0 behavior:
+The currently published npm package is `create-project-calavera`, so current
+docs should use the unscoped create command:
 
 ```text
-npm create @schalkneethling/project-calavera
-  -> @schalkneethling/create-project-calavera@*
+npm create project-calavera
+  -> create-project-calavera@*
 ```
 
-That means `@schalkneethling/create-project-calavera` can remain the published
-package while the user-facing command uses the product-centered
-`project-calavera` name. When passing arguments to the create package, docs
-should use npm's argument separator:
+npm's argument separator is still required when passing arguments to the create
+package:
 
 ```sh
-npm create @schalkneethling/project-calavera -- --init
+npm create project-calavera -- --init
 ```
+
+If a future scoped package is published, npm create can map
+`@schalkneethling/project-calavera` to
+`@schalkneethling/create-project-calavera`, but that package is not currently
+published.
 
 The `@schalkneethling/create` package name remains relevant only if Calavera
 later publishes a Vite+ org manifest for `vp create @schalkneethling`.

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -11,7 +11,7 @@ import Ajv2020 from "ajv/dist/2020.js";
 import { buildAiApplyResult, createCodexAgentToml } from "../src/ai/artifacts.js";
 import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "../src/ai/catalog.js";
 import { integrationCatalog } from "../src/catalog.js";
-import { applyRecipeObject } from "../src/index.js";
+import { agentBootstrap, applyRecipeObject } from "../src/index.js";
 import { callMcpTool, createMcpServer } from "../src/mcp.js";
 import { createEmptyState } from "../src/state.js";
 import {
@@ -453,6 +453,96 @@ test("standard MCP validation and dry-run tools return agent-readable JSON", asy
     dryRun.result.changes.some(({ path }) => path === ".agents/skills/semantic-html"),
     true,
   );
+});
+
+test("agent bootstrap dry-run previews guidance without writing files", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-dry-run-"));
+
+  try {
+    process.chdir(projectDirectory);
+
+    const result = await agentBootstrap({ dryRun: true, json: true });
+
+    assert.equal(result.command, "agent-init");
+    assert.equal(result.dryRun, true);
+    assert.equal(
+      result.changes.some(({ path }) => path === ".agents/skills/calavera"),
+      true,
+    );
+    assert.equal(
+      result.changes.some(({ path }) => path === "AGENTS.md"),
+      true,
+    );
+    assert.equal(
+      result.changes.some(({ path }) => path === ".agents/calavera/mcp.md"),
+      true,
+    );
+    assert.match(result.nextPrompt, /Use Calavera for this project/);
+    await assert.rejects(() => stat("AGENTS.md"), /ENOENT/);
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile("AGENTS.md", "Existing project guidance.\n");
+
+    const result = await agentBootstrap({ json: true });
+    const existingGuidance = await readFile("AGENTS.md", "utf8");
+    const fallbackGuidance = await readFile("AGENTS.calavera.md", "utf8");
+    const mcpGuidance = await readFile(".agents/calavera/mcp.md", "utf8");
+    const skill = await readFile(".agents/skills/calavera/SKILL.md", "utf8");
+    const state = JSON.parse(await readFile(".calavera/state.json", "utf8"));
+
+    assert.equal(existingGuidance, "Existing project guidance.\n");
+    assert.match(fallbackGuidance, /Calavera Agent Guidance/);
+    assert.match(mcpGuidance, /create-project-calavera-mcp/);
+    assert.match(mcpGuidance, /AskUserTool|approval/);
+    assert.match(mcpGuidance, /existing tooling files/);
+    assert.match(mcpGuidance, /calavera\.schalkneethling\.com/);
+    assert.match(skill, /name: calavera/);
+    assert.match(skill, /MCP Setup/);
+    assert.match(skill, /Fallbacks/);
+    assert.equal(
+      result.changes.some(
+        ({ type, path, reason }) =>
+          type === "skip" && path === "AGENTS.md" && reason.includes("left unchanged"),
+      ),
+      true,
+    );
+    assert.equal(
+      state.aiArtifacts.some(
+        ({ type, name, path }) =>
+          type === "skill" && name === "calavera" && path === ".agents/skills/calavera",
+      ),
+      true,
+    );
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("agent bootstrap rejects conflicting Calavera state path", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-conflict-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile(".calavera", "not a directory\n");
+
+    await assert.rejects(
+      () => agentBootstrap({ json: true }),
+      /Cannot write Calavera bootstrap state/,
+    );
+  } finally {
+    process.chdir(originalDirectory);
+  }
 });
 
 test("apply dry runs surface managed file overwrite conflicts", async () => {

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -540,6 +540,7 @@ test("agent bootstrap rejects conflicting Calavera state path", async () => {
       () => agentBootstrap({ json: true }),
       /Cannot write Calavera bootstrap state/,
     );
+    await assert.rejects(() => stat(".agents"), /ENOENT/);
   } finally {
     process.chdir(originalDirectory);
   }

--- a/src/ai/catalog.js
+++ b/src/ai/catalog.js
@@ -1,6 +1,7 @@
 export const DEFAULT_AI_TARGET = "claude-code";
 
 export const aiArtifactCatalog = [
+  aiArtifact("skill-calavera", "skill", "skills/calavera", "Calavera", "Skills"),
   aiArtifact("skill-code-review", "skill", "skills/code-review", "Code review", "Skills"),
   aiArtifact("skill-css-coder", "skill", "skills/css-coder", "CSS coder", "Skills"),
   aiArtifact("skill-css-tokens", "skill", "skills/css-tokens", "CSS tokens", "Skills"),

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -43,7 +43,7 @@ If the MCP server cannot be registered, use the hosted Calavera Web UI to compos
 
 https://calavera.schalkneethling.com
 
-After a recipe exists, preview local changes with `create-project-calavera apply --dry-run`. Ask the user to approve the preview before running `create-project-calavera apply`.
+After a recipe exists, preview local changes with `npm create project-calavera apply --dry-run`. Ask the user to approve the preview before running `npm create project-calavera apply`.
 
 ## User Prompt
 

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: calavera
+description: Compose, preview, and apply Calavera-managed JavaScript, TypeScript, CSS, and AI-tooling setup for existing or newly scaffolded projects. Use when the user asks to set up Calavera, choose tooling profiles or integrations, generate or apply calavera.config.json, install bundled skills/hooks/agents, inspect project-tooling options, run a Calavera dry run, or use the Calavera MCP server/Web UI workflow.
+---
+
+# Calavera
+
+Use Calavera to compose and apply project tooling through its MCP tools whenever they are available. This skill guides the active agent; it is not a subagent by itself.
+
+## Start Here
+
+1. Confirm whether Calavera MCP tools are available. Look for tools named `list_profiles`, `list_integrations`, `list_ai_artifacts`, `compose_recipe`, `dry_run_apply`, and `apply_recipe`.
+2. Inspect the project for existing tooling and likely conflicts before composing a recipe. Check files such as `package.json`, `calavera.config.json`, `.editorconfig`, `eslint.config.js`, `oxlint.json`, `.prettierrc.json`, `.stylelintrc.json`, and `tsconfig.json`.
+3. Use AskUserTool or the agent client's equivalent when available to clarify profile preferences, framework needs, conflict decisions, and apply approval. If no such tool exists, ask the user directly.
+4. List choices with `list_profiles`, `list_integrations`, and `list_ai_artifacts`. Use `describe_integration` when the user asks for more information or when you need to compare options.
+5. Once the profile and requirements are clear, compose the recipe with `compose_recipe`.
+6. Validate and explain it with `validate_recipe` and `explain_recipe`.
+7. Present `dry_run_apply` output to the user before changing files.
+8. Call `apply_recipe` only after the user explicitly approves the dry run.
+
+Do not hand-author `calavera.config.json` when the Calavera MCP server is available. Let Calavera compose, validate, dry-run, and apply the recipe so generated files, package scripts, dependencies, AI artifacts, and managed state stay consistent.
+
+## MCP Setup
+
+If the Calavera MCP tools are not available, help the user register this server from the project root:
+
+```json
+{
+  "mcpServers": {
+    "calavera": {
+      "command": "npx",
+      "args": ["--package", "create-project-calavera", "create-project-calavera-mcp"]
+    }
+  }
+}
+```
+
+If this project was bootstrapped with `create-project-calavera --init`, also check `.agents/calavera/mcp.md` for local setup notes.
+
+## Fallbacks
+
+If the MCP server cannot be registered, use the hosted Calavera Web UI to compose and download a recipe:
+
+https://calavera.schalkneethling.com
+
+After a recipe exists, preview local changes with `create-project-calavera apply --dry-run`. Ask the user to approve the preview before running `create-project-calavera apply`.
+
+## User Prompt
+
+When the user wants to start from a scaffolded or existing project, suggest:
+
+```text
+Use Calavera for this project. Inspect the current project for existing tooling and possible config conflicts, then list the available profiles, integrations, and AI artifacts. Once the profile and requirements are clear, compose a recipe, show me the dry-run result, and apply it only after I approve.
+```

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // @ts-check
 import { existsSync } from "node:fs";
-import { mkdir, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -103,11 +103,27 @@ import { logger } from "./utils/logger.js";
  * @property {boolean} dryRun
  * @property {Recipe} recipe
  *
- * @typedef {ApplyResult | CleanResult | DoctorResult | InitResult} CommandResult
+ * @typedef {object} AgentInitResult
+ * @property {"agent-init"} command
+ * @property {boolean} dryRun
+ * @property {Change[]} changes
+ * @property {string[]} pointers
+ * @property {string} nextPrompt
+ *
+ * @typedef {ApplyResult | CleanResult | DoctorResult | InitResult | AgentInitResult} CommandResult
  */
 
 const CONFIG_FILE = "calavera.config.json";
 const STATE_FILE = ".calavera/state.json";
+const AGENT_BOOTSTRAP_GUIDANCE_FILE = "AGENTS.md";
+const AGENT_BOOTSTRAP_FALLBACK_GUIDANCE_FILE = "AGENTS.calavera.md";
+const AGENT_BOOTSTRAP_MCP_FILE = ".agents/calavera/mcp.md";
+const AGENT_BOOTSTRAP_MARKER = "<!-- calavera-agent-bootstrap -->";
+const AGENT_BOOTSTRAP_SKILL_RECIPE = {
+  ai: [{ type: "skill", src: "skills/calavera" }],
+};
+const AGENT_BOOTSTRAP_NEXT_PROMPT =
+  "Use Calavera for this project. Inspect the current project for existing tooling and possible config conflicts, then list the available profiles, integrations, and AI artifacts. Once the profile and requirements are clear, compose a recipe, show me the dry-run result, and apply it only after I approve.";
 const SCRIPT_SOURCE_EXTENSIONS = ["js", "jsx", "ts", "tsx", "mjs", "cjs"];
 const TSC_INCLUDE_PATTERNS = SCRIPT_SOURCE_EXTENSIONS.map((extension) => `src/**/*.${extension}`);
 
@@ -190,6 +206,8 @@ function parseArgs(rawArgs) {
       index += 1;
     } else if (arg === "--dry-run") {
       parsed.dryRun = true;
+    } else if (arg === "--init") {
+      parsed.command = "agent-init";
     } else if (arg === "--json") {
       parsed.json = true;
     } else if (arg === "--no-install") {
@@ -575,6 +593,71 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
+`;
+}
+
+function createAgentBootstrapGuidance() {
+  return `${AGENT_BOOTSTRAP_MARKER}
+# Calavera Agent Guidance
+
+- Use Calavera when the user wants to inspect, compose, preview, apply, or update project tooling.
+- Prefer the Calavera MCP server over hand-authoring \`calavera.config.json\`.
+- If the Calavera MCP tools are not available, help the user register the MCP server from \`${AGENT_BOOTSTRAP_MCP_FILE}\` or fall back to the Calavera Web UI.
+- Inspect existing project tooling before composing a recipe and raise likely config conflicts early.
+- Start with \`list_profiles\`, \`list_integrations\`, and \`list_ai_artifacts\`; use \`describe_integration\` when the user asks for more information or an option needs explanation.
+- Compose recipes with \`compose_recipe\`, validate them with \`validate_recipe\`, and explain the selected integrations with \`explain_recipe\`.
+- Always present \`dry_run_apply\` output to the user before changing files.
+- Call \`apply_recipe\` only after the user explicitly approves the dry-run result.
+- Use AskUserTool or the agent client's equivalent when available for profile choices, conflict decisions, and apply approval.
+
+MCP setup notes live in \`${AGENT_BOOTSTRAP_MCP_FILE}\`.
+`;
+}
+
+function createAgentBootstrapMcpInstructions() {
+  return `# Calavera MCP Setup
+
+Register the Calavera MCP server from the project root:
+
+\`\`\`json
+{
+  "mcpServers": {
+    "calavera": {
+      "command": "npx",
+      "args": ["--package", "create-project-calavera", "create-project-calavera-mcp"]
+    }
+  }
+}
+\`\`\`
+
+If your agent exposes an MCP setup UI or config writer, use the snippet above.
+If the agent needs approval before editing its own config, ask first.
+
+Use the tools in this order:
+
+1. \`list_profiles\`
+2. \`list_integrations\`
+3. \`describe_integration\`
+4. \`list_ai_artifacts\`
+5. \`compose_recipe\`
+6. \`validate_recipe\`
+7. \`explain_recipe\`
+8. \`dry_run_apply\`
+9. \`apply_recipe\`
+
+\`dry_run_apply\` is the review boundary. Show its result to the user and wait for explicit approval before calling \`apply_recipe\`.
+
+Before composing a recipe, inspect the project for existing tooling files such as \`package.json\`, \`calavera.config.json\`, \`.editorconfig\`, \`eslint.config.js\`, \`oxlint.json\`, \`.prettierrc.json\`, \`.stylelintrc.json\`, and \`tsconfig.json\`. Mention likely conflicts or local conventions before proposing changes.
+
+If the MCP server cannot be registered, use the hosted Web UI to compose and download a recipe:
+
+https://calavera.schalkneethling.com
+
+Then run \`create-project-calavera apply --dry-run\` and ask for approval before running \`create-project-calavera apply\`.
+
+Suggested first prompt:
+
+> ${AGENT_BOOTSTRAP_NEXT_PROMPT}
 `;
 }
 
@@ -1085,6 +1168,179 @@ export async function applyRecipeObject(recipe, options = {}) {
 }
 
 /**
+ * @param {CalaveraState} previousState
+ * @param {AiArtifactState[]} aiArtifacts
+ * @returns {CalaveraState}
+ */
+function mergeAiArtifactsIntoState(previousState, aiArtifacts) {
+  const artifactsByPath = new Map(
+    previousState.aiArtifacts.map((artifact) => [artifact.path, artifact]),
+  );
+
+  for (const artifact of aiArtifacts) {
+    artifactsByPath.set(artifact.path, artifact);
+  }
+
+  return {
+    ...previousState,
+    version: 1,
+    aiArtifacts: [...artifactsByPath.values()],
+  };
+}
+
+/**
+ * @param {string} path
+ * @param {string} contents
+ * @param {boolean} dryRun
+ * @param {Change[]} changes
+ * @param {string} conflictReason
+ * @returns {Promise<boolean>}
+ */
+async function writeBootstrapTextFile(path, contents, dryRun, changes, conflictReason) {
+  const targetPath = path.trim();
+
+  if (!targetPath) {
+    throw new Error("Bootstrap file path must be a non-empty string.");
+  }
+
+  if (await fileExists(targetPath)) {
+    const currentContents = await readFile(targetPath, "utf8");
+
+    changes.push({
+      type: "skip",
+      path: targetPath,
+      reason: currentContents === contents ? "Already up to date." : conflictReason,
+    });
+
+    return currentContents === contents;
+  }
+
+  changes.push({ type: "write", path: targetPath });
+
+  if (!dryRun) {
+    const directory = dirname(targetPath);
+    if (directory !== ".") {
+      await mkdir(directory, { recursive: true });
+    }
+
+    await writeFile(targetPath, contents);
+  }
+
+  return true;
+}
+
+/**
+ * @param {string} path
+ */
+async function assertBootstrapDirectoryAvailable(path) {
+  if (!(await fileExists(path))) {
+    return;
+  }
+
+  const pathStats = await stat(path);
+
+  if (!pathStats.isDirectory()) {
+    throw new Error(
+      `Cannot write Calavera bootstrap state because ${path} exists and is not a directory.`,
+    );
+  }
+}
+
+/**
+ * @param {boolean} dryRun
+ * @param {Change[]} changes
+ */
+async function writeAgentBootstrapGuidance(dryRun, changes) {
+  const guidance = createAgentBootstrapGuidance();
+
+  if (!(await fileExists(AGENT_BOOTSTRAP_GUIDANCE_FILE))) {
+    await writeBootstrapTextFile(
+      AGENT_BOOTSTRAP_GUIDANCE_FILE,
+      guidance,
+      dryRun,
+      changes,
+      "Existing agent guidance differs and was left unchanged.",
+    );
+    return;
+  }
+
+  const currentGuidance = await readFile(AGENT_BOOTSTRAP_GUIDANCE_FILE, "utf8");
+
+  if (currentGuidance === guidance) {
+    changes.push({
+      type: "skip",
+      path: AGENT_BOOTSTRAP_GUIDANCE_FILE,
+      reason: "Already up to date.",
+    });
+    return;
+  }
+
+  changes.push({
+    type: "skip",
+    path: AGENT_BOOTSTRAP_GUIDANCE_FILE,
+    reason: "Existing AGENTS.md left unchanged; Calavera guidance was written separately.",
+  });
+
+  await writeBootstrapTextFile(
+    AGENT_BOOTSTRAP_FALLBACK_GUIDANCE_FILE,
+    guidance,
+    dryRun,
+    changes,
+    "Existing fallback Calavera guidance differs and was left unchanged.",
+  );
+}
+
+/**
+ * @param {Partial<CliOptions>} [options]
+ * @returns {Promise<AgentInitResult>}
+ */
+export async function agentBootstrap(options = {}) {
+  const bootstrapOptions = {
+    dryRun: false,
+    ...options,
+  };
+  const previousState = await readStateIfPresent();
+  const aiResult = await buildAiApplyResult(
+    AGENT_BOOTSTRAP_SKILL_RECIPE,
+    { dryRun: bootstrapOptions.dryRun },
+    previousState,
+  );
+  /** @type {Change[]} */
+  const changes = [...aiResult.changes];
+
+  await writeAgentBootstrapGuidance(bootstrapOptions.dryRun, changes);
+  await writeBootstrapTextFile(
+    AGENT_BOOTSTRAP_MCP_FILE,
+    createAgentBootstrapMcpInstructions(),
+    bootstrapOptions.dryRun,
+    changes,
+    "Existing Calavera MCP setup notes differ and were left unchanged.",
+  );
+
+  if (!bootstrapOptions.dryRun) {
+    await assertBootstrapDirectoryAvailable(".calavera");
+    await mkdir(".calavera", { recursive: true });
+    await writeJSON(
+      STATE_FILE,
+      mergeAiArtifactsIntoState(previousState, aiResult.artifacts),
+      false,
+    );
+  }
+
+  return {
+    command: "agent-init",
+    dryRun: bootstrapOptions.dryRun,
+    changes,
+    pointers: [
+      ...aiResult.pointers,
+      `Agent guidance: ${AGENT_BOOTSTRAP_GUIDANCE_FILE} or ${AGENT_BOOTSTRAP_FALLBACK_GUIDANCE_FILE}`,
+      `MCP setup notes: ${AGENT_BOOTSTRAP_MCP_FILE}`,
+    ],
+    nextPrompt: AGENT_BOOTSTRAP_NEXT_PROMPT,
+  };
+}
+
+/**
  * @param {CliOptions} options
  * @returns {Promise<InitResult>}
  */
@@ -1463,6 +1719,27 @@ function printResult(result, asJSON = false) {
     return;
   }
 
+  if (result.command === "agent-init") {
+    logger.success("Calavera agent bootstrap complete.");
+
+    for (const change of result.changes) {
+      if (change.type === "write") {
+        logger.info(`Wrote ${change.path}`);
+      }
+
+      if (change.type === "skip") {
+        logger.info(`Skipped ${change.path}: ${change.reason}`);
+      }
+    }
+
+    for (const pointer of result.pointers) {
+      logger.info(pointer);
+    }
+
+    logger.info(`Next prompt: ${result.nextPrompt}`);
+    return;
+  }
+
   if (result.command === "apply" && result.dryRun) {
     logger.info("Calavera apply dry run complete. No files were changed.");
     logger.info(`Package manager: ${result.packageManager}`);
@@ -1520,6 +1797,11 @@ async function main() {
 
   if (options.command === "init") {
     printResult(await initRecipe(options), options.json);
+    return;
+  }
+
+  if (options.command === "agent-init" || options.command === "bootstrap") {
+    printResult(await agentBootstrap(options), options.json);
     return;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -653,7 +653,7 @@ If the MCP server cannot be registered, use the hosted Web UI to compose and dow
 
 https://calavera.schalkneethling.com
 
-Then run \`create-project-calavera apply --dry-run\` and ask for approval before running \`create-project-calavera apply\`.
+Then run \`npm create project-calavera apply --dry-run\` and ask for approval before running \`npm create project-calavera apply\`.
 
 Suggested first prompt:
 
@@ -1299,6 +1299,9 @@ export async function agentBootstrap(options = {}) {
     dryRun: false,
     ...options,
   };
+
+  await assertBootstrapDirectoryAvailable(".calavera");
+
   const previousState = await readStateIfPresent();
   const aiResult = await buildAiApplyResult(
     AGENT_BOOTSTRAP_SKILL_RECIPE,
@@ -1318,7 +1321,6 @@ export async function agentBootstrap(options = {}) {
   );
 
   if (!bootstrapOptions.dryRun) {
-    await assertBootstrapDirectoryAvailable(".calavera");
     await mkdir(".calavera", { recursive: true });
     await writeJSON(
       STATE_FILE,
@@ -1720,15 +1722,23 @@ function printResult(result, asJSON = false) {
   }
 
   if (result.command === "agent-init") {
-    logger.success("Calavera agent bootstrap complete.");
+    if (result.dryRun) {
+      logger.info("Calavera agent bootstrap dry run complete. No files were changed.");
+    } else {
+      logger.success("Calavera agent bootstrap complete.");
+    }
 
     for (const change of result.changes) {
       if (change.type === "write") {
-        logger.info(`Wrote ${change.path}`);
+        logger.info(result.dryRun ? `Would write ${change.path}` : `Wrote ${change.path}`);
       }
 
       if (change.type === "skip") {
-        logger.info(`Skipped ${change.path}: ${change.reason}`);
+        logger.info(
+          result.dryRun
+            ? `Would skip ${change.path}: ${change.reason}`
+            : `Skipped ${change.path}: ${change.reason}`,
+        );
       }
     }
 

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -346,7 +346,7 @@ export async function startMcpServer(transport = new StdioServerTransport()) {
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   startMcpServer().catch((error) => {
-    console.error(error);
+    console.info(error);
     process.exitCode = 1;
   });
 }


### PR DESCRIPTION
## Summary
- add `--init` agent bootstrap support for existing projects
- install the Calavera skill, generate MCP setup notes, and preserve existing `AGENTS.md` guidance by writing a fallback file when needed
- document the new agent-first workflow and align docs with the current unscoped package name

## Testing
- Added unit tests covering dry-run previews, existing `AGENTS.md` fallback behavior, and `.calavera` state path conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an agent-first bootstrap flow for existing projects, including a new command to generate Calavera guidance and MCP setup notes.
  * Introduced a bundled Calavera skill and updated the CLI to recognize the new bootstrap flow.

* **Bug Fixes**
  * Preserves existing agent guidance when present and writes fallback guidance only when needed.
  * Adds validation to prevent bootstrap from running when the Calavera state location is invalid.

* **Documentation**
  * Updated README and command-flow docs with the latest setup steps, prompt guidance, and package naming notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->