### PR TITLE
Add rich interactive recipe composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ options. Use selection flags only for scripted or CI flows:
 npm create project-calavera init -- --profile modern --package-manager pnpm --tool Oxlint --tool Stylelint
 ```
 
+Wrap labels that contain spaces in quotes, for example
+`--tool "Oxc React best practices"`. Prefer ids such as `oxlint-react` in
+scripts and CI so commands stay copy-pastable.
+
 Apply a recipe:
 
 ```bash
@@ -208,7 +212,7 @@ npm --force create project-calavera apply
 - `--profile modern|classic|minimal`
 - `--package-manager npm|pnpm|yarn|bun`
 - `--integration <id-or-label>` or `--tool <id-or-label>` for scripted
-  composition; omit these flags to select from the interactive option list
+  composition; quote labels with spaces, or use ids/slugs in scripts and CI
 - `--ai-artifact <id-or-label-or-source>`; use `<artifact>@<target>` for hook
   and agent targets, or omit this flag to select from the interactive option list
 - `--apply` with `init` to preview and then confirm applying the composed recipe

--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ Create a recipe:
 npm create project-calavera init
 ```
 
+The interactive recipe composer lets you choose a profile, package manager,
+integration packs, and bundled AI artifacts. By default it only writes
+`calavera.config.json`.
+
+Run `init` without selection flags for guided prompts that present the available
+options. Use selection flags only for scripted or CI flows:
+
+```bash
+npm create project-calavera init -- --profile modern --package-manager pnpm --tool Oxlint --tool Stylelint
+```
+
 Apply a recipe:
 
 ```bash
@@ -196,6 +207,11 @@ npm --force create project-calavera apply
 - `--config calavera.config.json`
 - `--profile modern|classic|minimal`
 - `--package-manager npm|pnpm|yarn|bun`
+- `--integration <id-or-label>` or `--tool <id-or-label>` for scripted
+  composition; omit these flags to select from the interactive option list
+- `--ai-artifact <id-or-label-or-source>`; use `<artifact>@<target>` for hook
+  and agent targets, or omit this flag to select from the interactive option list
+- `--apply` with `init` to preview and then confirm applying the composed recipe
 - `--dry-run`
 - `--no-install`
 - `--yes`

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   "dependencies": {
     "@clack/prompts": "^1.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "chalk": "^5.3.0",
     "execa": "^9.6.0",
     "prettier": "^3.5.3",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
-      chalk:
-        specifier: ^5.3.0
-        version: 5.6.2
       execa:
         specifier: ^9.6.0
         version: 9.6.1
@@ -712,10 +709,6 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2287,8 +2280,6 @@ snapshots:
       get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
-
-  chalk@5.6.2: {}
 
   color-convert@2.0.1:
     dependencies:

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -11,7 +11,7 @@ import Ajv2020 from "ajv/dist/2020.js";
 import { buildAiApplyResult, createCodexAgentToml } from "../src/ai/artifacts.js";
 import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "../src/ai/catalog.js";
 import { integrationCatalog } from "../src/catalog.js";
-import { agentBootstrap, applyRecipeObject } from "../src/index.js";
+import { agentBootstrap, applyRecipeObject, initRecipe, parseArgs } from "../src/index.js";
 import { callMcpTool, createMcpServer } from "../src/mcp.js";
 import { createEmptyState } from "../src/state.js";
 import {
@@ -81,6 +81,10 @@ const ajv = new Ajv2020({ allErrors: true, validateFormats: false });
 
 function assertValid(validate, value) {
   assert.equal(validate(value), true, ajv.errorsText(validate.errors));
+}
+
+async function assertPathMissing(path, message = `${path} should not exist`) {
+  await assert.rejects(() => stat(path), /ENOENT/, message);
 }
 
 test("config schema is the published draft 2020-12 schema", () => {
@@ -330,6 +334,101 @@ test("shared composition operation responses expose catalog, recipe, and explana
     explainRecipeResponse(recipeResponse.recipe).aiArtifacts[0].id,
     "skill-semantic-html",
   );
+});
+
+test("CLI parser accepts scripted rich composer options", () => {
+  const options = parseArgs([
+    "init",
+    "--profile",
+    "modern",
+    "--package-manager",
+    "pnpm",
+    "--integration",
+    "Oxlint,Stylelint",
+    "--tool",
+    "Oxc React best practices",
+    "--ai-artifact",
+    "skill-semantic-html",
+    "--ai-artifact",
+    "hook-block-dangerous-commands@codex",
+    "--apply",
+    "--yes",
+  ]);
+
+  assert.equal(options.command, "init");
+  assert.equal(options.profile, "modern");
+  assert.equal(options.packageManager, "pnpm");
+  assert.deepEqual(options.integrations, ["Oxlint", "Stylelint", "Oxc React best practices"]);
+  assert.deepEqual(options.aiArtifacts, [
+    { id: "skill-semantic-html" },
+    { id: "hook-block-dangerous-commands", target: "codex" },
+  ]);
+  assert.equal(options.apply, true);
+  assert.equal(options.assumeYes, true);
+});
+
+test("CLI rich composer writes a schema-valid config without applying by default", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-rich-cli-"));
+
+  try {
+    process.chdir(projectDirectory);
+
+    const result = await initRecipe({
+      command: "init",
+      config: "calavera.config.json",
+      dryRun: false,
+      json: true,
+      noInstall: true,
+      assumeYes: true,
+      apply: false,
+      profile: "modern",
+      packageManager: "pnpm",
+      integrations: ["Oxlint", "Stylelint"],
+      aiArtifacts: [{ id: "Semantic HTML" }],
+    });
+    const writtenConfig = JSON.parse(await readFile("calavera.config.json", "utf8"));
+
+    assert.equal(result.validation.ok, true);
+    assert.deepEqual(writtenConfig, result.recipe);
+    assert.deepEqual(writtenConfig.integrations, ["oxlint", "stylelint"]);
+    assert.deepEqual(writtenConfig.ai, [{ type: "skill", src: "skills/semantic-html" }]);
+    assertValid(ajv.compile(schema), writtenConfig);
+    await assertPathMissing("package.json", "config-only compose must not create package.json");
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("CLI rich composer dry-run apply keeps the review boundary non-destructive", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-rich-cli-apply-dry-run-"));
+
+  try {
+    process.chdir(projectDirectory);
+
+    const result = await initRecipe({
+      command: "init",
+      config: "calavera.config.json",
+      dryRun: true,
+      json: true,
+      noInstall: true,
+      assumeYes: true,
+      apply: true,
+      profile: "minimal",
+      packageManager: "npm",
+      integrations: ["editorconfig"],
+      aiArtifacts: [],
+    });
+
+    assert.equal(result.applyDryRun?.dryRun, true);
+    assert.equal(result.applyResult, undefined);
+    await assertPathMissing("calavera.config.json", "dry-run compose must not write config");
+    await assertPathMissing("package.json", "dry-run apply must not create package.json");
+    await assertPathMissing(".editorconfig", "dry-run apply must not write managed files");
+  } finally {
+    process.chdir(originalDirectory);
+  }
 });
 
 test("standard MCP workflow exposes dry-run and apply tools", () => {

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -365,6 +365,11 @@ test("CLI parser accepts scripted rich composer options", () => {
   ]);
   assert.equal(options.apply, true);
   assert.equal(options.assumeYes, true);
+
+  assert.deepEqual(
+    parseArgs(["init", "--ai-artifact", "hook-block-dangerous-commands@team@codex"]).aiArtifacts,
+    [{ id: "hook-block-dangerous-commands", target: "team@codex" }],
+  );
 });
 
 test("CLI rich composer writes a schema-valid config without applying by default", async () => {
@@ -422,6 +427,11 @@ test("CLI rich composer dry-run apply keeps the review boundary non-destructive"
     });
 
     assert.equal(result.applyDryRun?.dryRun, true);
+    assert.deepEqual(
+      result.applyDryRun?.changes.map(({ path }) => path),
+      ["package.json", ".editorconfig"],
+    );
+    assert.deepEqual(result.applyDryRun?.integrations, ["editorconfig"]);
     assert.equal(result.applyResult, undefined);
     await assertPathMissing("calavera.config.json", "dry-run compose must not write config");
     await assertPathMissing("package.json", "dry-run apply must not create package.json");

--- a/src/index.js
+++ b/src/index.js
@@ -246,7 +246,7 @@ function optionalStringValue(value) {
  * @returns {{ id: string, target?: string }}
  */
 function parseAiArtifactFlag(value) {
-  const separatorIndex = value.lastIndexOf("@");
+  const separatorIndex = value.indexOf("@");
 
   if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
     return { id: value };

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,20 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { parseArgs as parseNodeArgs } from "node:util";
 
-import { cancel, confirm, intro, isCancel, multiselect, select, spinner } from "@clack/prompts";
+import {
+  cancel,
+  confirm,
+  groupMultiselect,
+  intro,
+  isCancel,
+  note,
+  outro,
+  select,
+  spinner,
+  text,
+} from "@clack/prompts";
 import { execa } from "execa";
 
 import {
@@ -14,7 +26,6 @@ import {
   hashAiInstall,
   resolveAiArtifacts,
 } from "./ai/artifacts.js";
-import { integrationCatalog } from "./catalog.js";
 import {
   createEmptyState,
   managedFileStateForPath,
@@ -22,12 +33,25 @@ import {
   normalizeState,
   optionalStringArray,
 } from "./state.js";
-import { buildRecipe, profileDefaults, resolveRecipeIntegrations } from "./recipe.js";
+import {
+  composeRecipe,
+  explainRecipeResponse,
+  listAiArtifactOptions,
+  listIntegrationOptions,
+  packageManagerIdsForRecipe,
+  profileIdsForRecipe,
+  profileDefaults,
+  resolveRecipeIntegrations,
+  validateRecipeResponse,
+} from "./recipe.js";
+import { assertKnownValue } from "./utils/assertions.js";
 import { FileWriteError } from "./utils/file-write-error.js";
 import { fileExists, readJSON, writeJSON } from "./utils/fs.js";
 import { isNotEmptyString, isPlainObject } from "./utils/guards.js";
 import { textHash } from "./utils/hash.js";
 import { logger } from "./utils/logger.js";
+import { groupedPromptOptions } from "./utils/prompt-options.js";
+import { pluralizeCount, style, titleCase } from "./utils/text.js";
 
 /**
  * @typedef {"npm" | "pnpm" | "yarn" | "bun"} PackageManager
@@ -42,8 +66,11 @@ import { logger } from "./utils/logger.js";
  * @property {boolean} json
  * @property {boolean} noInstall
  * @property {boolean} assumeYes
+ * @property {boolean} apply
  * @property {PackageManager} [packageManager]
  * @property {string} [profile]
+ * @property {string[]} integrations
+ * @property {{ id: string, target?: string }[]} aiArtifacts
  *
  * @typedef {object} PackageManagerCommands
  * @property {[string, string[]]} init
@@ -102,6 +129,10 @@ import { logger } from "./utils/logger.js";
  * @property {string} config
  * @property {boolean} dryRun
  * @property {Recipe} recipe
+ * @property {{ ok: boolean, recipe?: Recipe, errors?: string[] }} validation
+ * @property {{ integrations: unknown[], dependencies: string[], aiArtifacts: unknown[] }} explanation
+ * @property {ApplyResult} [applyDryRun]
+ * @property {ApplyResult} [applyResult]
  *
  * @typedef {object} AgentInitResult
  * @property {"agent-init"} command
@@ -155,18 +186,76 @@ const packageManagerCommands = {
 const supportedPackageManagers = /** @type {PackageManager[]} */ (
   Object.keys(packageManagerCommands)
 );
+const supportedProfiles = profileIdsForRecipe();
+const recipePackageManagers = packageManagerIdsForRecipe();
 const args = process.argv.slice(2);
+/** @type {import("node:util").ParseArgsOptionsConfig} */
+const cliParseOptions = {
+  config: { type: "string", default: CONFIG_FILE },
+  apply: { type: "boolean" },
+  "dry-run": { type: "boolean" },
+  init: { type: "boolean" },
+  json: { type: "boolean" },
+  "no-install": { type: "boolean" },
+  yes: { type: "boolean" },
+  "package-manager": { type: "string" },
+  profile: { type: "string" },
+  integration: { type: "string", multiple: true, default: [] },
+  integrations: { type: "string", multiple: true, default: [] },
+  tool: { type: "string", multiple: true, default: [] },
+  tools: { type: "string", multiple: true, default: [] },
+  "ai-artifact": { type: "string", multiple: true, default: [] },
+  "ai-artifacts": { type: "string", multiple: true, default: [] },
+};
 
 /**
- * @param {string} packageManager
- * @returns {never}
+ * @param {string | undefined} value
+ * @returns {string[]}
  */
-function exitUnsupportedPackageManager(packageManager) {
-  logger.error(
-    `Unsupported package manager "${packageManager}". Supported package managers: ${supportedPackageManagers.join(", ")}.`,
+function listFlagValues(value) {
+  return (value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+/**
+ * @param {unknown[]} values
+ * @returns {string[]}
+ */
+function collectListValues(...values) {
+  return values.flatMap((value) =>
+    Array.isArray(value)
+      ? value.flatMap((item) => (typeof item === "string" ? listFlagValues(item) : []))
+      : typeof value === "string"
+        ? listFlagValues(value)
+        : [],
   );
-  process.exit(1);
-  throw new Error(`Unsupported package manager "${packageManager}".`);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string | undefined}
+ */
+function optionalStringValue(value) {
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * @param {string} value
+ * @returns {{ id: string, target?: string }}
+ */
+function parseAiArtifactFlag(value) {
+  const separatorIndex = value.lastIndexOf("@");
+
+  if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
+    return { id: value };
+  }
+
+  return {
+    id: value.slice(0, separatorIndex),
+    target: value.slice(separatorIndex + 1),
+  };
 }
 
 /**
@@ -178,7 +267,9 @@ function assertSupportedPackageManager(packageManager) {
     !packageManager ||
     !supportedPackageManagers.includes(/** @type {PackageManager} */ (packageManager))
   ) {
-    exitUnsupportedPackageManager(packageManager ?? "<missing>");
+    throw new Error(
+      `Invalid package manager: ${packageManager ?? "<missing>"}. Allowed values: ${supportedPackageManagers.join(", ")}.`,
+    );
   }
 
   return /** @type {PackageManager} */ (packageManager);
@@ -188,39 +279,41 @@ function assertSupportedPackageManager(packageManager) {
  * @param {string[]} rawArgs
  * @returns {CliOptions}
  */
-function parseArgs(rawArgs) {
+export function parseArgs(rawArgs) {
+  const { values, positionals } = parseNodeArgs({
+    args: rawArgs,
+    options: cliParseOptions,
+    allowPositionals: true,
+  });
+  const profile = optionalStringValue(values.profile);
+  const packageManager = optionalStringValue(values["package-manager"]);
   /** @type {CliOptions} */
   const parsed = {
-    command: rawArgs[0]?.startsWith("-") ? "init" : (rawArgs[0] ?? "init"),
-    config: CONFIG_FILE,
-    dryRun: false,
-    json: false,
-    noInstall: false,
-    assumeYes: false,
+    command: values.init ? "agent-init" : (positionals[0] ?? "init"),
+    config: optionalStringValue(values.config) ?? CONFIG_FILE,
+    dryRun: values["dry-run"] === true,
+    json: values.json === true,
+    noInstall: values["no-install"] === true,
+    assumeYes: values.yes === true,
+    apply: values.apply === true,
+    integrations: collectListValues(
+      values.integration,
+      values.integrations,
+      values.tool,
+      values.tools,
+    ),
+    aiArtifacts: collectListValues(values["ai-artifact"], values["ai-artifacts"]).map(
+      parseAiArtifactFlag,
+    ),
   };
 
-  for (let index = 0; index < rawArgs.length; index += 1) {
-    const arg = rawArgs[index];
-    if (arg === "--config") {
-      parsed.config = rawArgs[index + 1] ?? CONFIG_FILE;
-      index += 1;
-    } else if (arg === "--dry-run") {
-      parsed.dryRun = true;
-    } else if (arg === "--init") {
-      parsed.command = "agent-init";
-    } else if (arg === "--json") {
-      parsed.json = true;
-    } else if (arg === "--no-install") {
-      parsed.noInstall = true;
-    } else if (arg === "--yes") {
-      parsed.assumeYes = true;
-    } else if (arg === "--package-manager") {
-      parsed.packageManager = assertSupportedPackageManager(rawArgs[index + 1]);
-      index += 1;
-    } else if (arg === "--profile") {
-      parsed.profile = rawArgs[index + 1] ?? undefined;
-      index += 1;
-    }
+  if (profile !== undefined) {
+    assertKnownValue("profile", profile, supportedProfiles);
+    parsed.profile = profile;
+  }
+
+  if (packageManager !== undefined) {
+    parsed.packageManager = assertSupportedPackageManager(packageManager);
   }
 
   return parsed;
@@ -1343,59 +1436,119 @@ export async function agentBootstrap(options = {}) {
 }
 
 /**
- * @param {CliOptions} options
- * @returns {Promise<InitResult>}
+ * @param {unknown} value
+ * @returns {never | void}
  */
-async function initRecipe(options) {
-  if (!options.json) {
-    console.clear();
-    intro("Compose your Calavera tooling recipe");
+function exitIfCancel(value) {
+  if (isCancel(value)) {
+    cancel("Setup cancelled");
+    process.exit(0);
   }
+}
 
-  const profile =
+/**
+ * @param {Recipe} recipe
+ * @param {{ integrations: unknown[], dependencies: string[], aiArtifacts: unknown[] }} explanation
+ * @returns {string}
+ */
+function formatRecipeSummary(recipe, explanation) {
+  return [
+    `${style("bold", "Profile")}: ${recipe.profile}`,
+    `${style("bold", "Package manager")}: ${recipe.packageManager}`,
+    `${style("bold", "Integrations")}: ${pluralizeCount((recipe.integrations ?? []).length, "item")}`,
+    `${style("bold", "Dependencies")}: ${
+      explanation.dependencies.length > 0 ? explanation.dependencies.join(", ") : "none"
+    }`,
+    `${style("bold", "AI artifacts")}: ${explanation.aiArtifacts.length}`,
+  ].join("\n");
+}
+
+/**
+ * @param {ApplyResult} result
+ * @returns {string}
+ */
+function formatApplySummary(result) {
+  const changedPaths = result.changes.map((change) => change.path);
+
+  return [
+    `${style("bold", "Package manager")}: ${result.packageManager}`,
+    `${style("bold", "Integrations")}: ${result.integrations.join(", ") || "none"}`,
+    `${style("bold", "Dev dependencies")}: ${result.dependencies.join(", ") || "none"}`,
+    `${style("bold", "Planned changes")}: ${changedPaths.join(", ") || "none"}`,
+  ].join("\n");
+}
+
+/**
+ * @param {CliOptions} options
+ * @returns {Promise<string>}
+ */
+async function promptForProfile(options) {
+  const selected =
     options.profile ??
     (await select({
       message: "Choose a tooling profile",
-      options: [
-        { value: "modern", label: "Modern", hint: "Oxlint, Oxfmt, Stylelint" },
-        {
-          value: "classic",
-          label: "Classic",
-          hint: "ESLint, Prettier, Stylelint",
-        },
-        { value: "minimal", label: "Minimal", hint: "EditorConfig only" },
-      ],
+      options: supportedProfiles.map((id) => ({
+        value: id,
+        label: titleCase(id),
+        hint: `${profileDefaults[id]?.length ?? 0} default integrations`,
+      })),
     }));
 
-  if (isCancel(profile)) {
-    cancel("Setup cancelled");
-    process.exit(0);
-  }
+  exitIfCancel(selected);
+  return typeof selected === "string" ? selected : "modern";
+}
 
-  const profileName = typeof profile === "string" ? profile : "modern";
-  const defaults = profileDefaults[profileName] ?? profileDefaults.modern;
-  const optionalOptions = /** @type {Integration[]} */ (integrationCatalog)
-    .filter((integration) => integration.status !== "required")
-    .map((integration) => ({
-      value: integration.id,
-      label: integration.label,
-      hint: `${integration.group} · ${integration.status}`,
-    }));
-
+/**
+ * @param {CliOptions} options
+ * @param {PackageManager} detectedPackageManager
+ * @returns {Promise<PackageManager>}
+ */
+async function promptForPackageManager(options, detectedPackageManager) {
   const selected =
-    options.assumeYes || options.profile
-      ? defaults
-      : await multiselect({
-          message: "Choose integration packs",
-          options: optionalOptions,
-          initialValues: defaults,
-          required: true,
-        });
+    options.packageManager ??
+    (options.assumeYes
+      ? detectedPackageManager
+      : await select({
+          message: "Choose a package manager",
+          initialValue: detectedPackageManager,
+          options: recipePackageManagers.map((id) => ({
+            value: id,
+            label: id,
+            hint: id === detectedPackageManager ? "detected" : undefined,
+          })),
+        }));
 
-  if (isCancel(selected)) {
-    cancel("Setup cancelled");
-    process.exit(0);
+  exitIfCancel(selected);
+
+  return assertSupportedPackageManager(
+    typeof selected === "string" ? selected : detectedPackageManager,
+  );
+}
+
+/**
+ * @param {CliOptions} options
+ * @param {string} profile
+ * @returns {Promise<string[]>}
+ */
+async function promptForIntegrations(options, profile) {
+  const defaults = profileDefaults[profile] ?? profileDefaults.modern ?? [];
+
+  if (options.integrations.length > 0) {
+    return options.integrations;
   }
+
+  if (options.assumeYes || options.profile) {
+    return defaults;
+  }
+
+  const selected = await groupMultiselect({
+    message: "Choose integration packs",
+    options: groupedPromptOptions(listIntegrationOptions(profile)),
+    initialValues: defaults,
+    required: true,
+  });
+
+  exitIfCancel(selected);
 
   if (
     !Array.isArray(selected) ||
@@ -1404,19 +1557,142 @@ async function initRecipe(options) {
     throw new Error("Selected integration values must be strings.");
   }
 
+  return selected;
+}
+
+/**
+ * @param {CliOptions} options
+ * @returns {Promise<{ id: string, target?: string }[]>}
+ */
+async function promptForAiArtifacts(options) {
+  if (options.aiArtifacts.length > 0 || options.assumeYes) {
+    return options.aiArtifacts;
+  }
+
+  const artifactOptions = listAiArtifactOptions();
+  const selected = await groupMultiselect({
+    message: "Choose AI artifacts",
+    options: groupedPromptOptions(artifactOptions),
+    initialValues: [],
+    required: false,
+  });
+
+  exitIfCancel(selected);
+
+  if (!Array.isArray(selected) || !selected.every((artifact) => typeof artifact === "string")) {
+    throw new Error("Selected AI artifact values must be strings.");
+  }
+
+  /** @type {{ id: string, target?: string }[]} */
+  const aiArtifacts = [];
+
+  for (const id of selected) {
+    const artifact = artifactOptions.find((option) => option.id === id);
+
+    if (!artifact?.defaultTarget) {
+      aiArtifacts.push({ id });
+      continue;
+    }
+
+    const target = await text({
+      message: `Target directory for ${artifact.label}`,
+      defaultValue: artifact.defaultTarget,
+      placeholder: artifact.defaultTarget,
+    });
+
+    exitIfCancel(target);
+    aiArtifacts.push({ id, target: typeof target === "string" ? target : artifact.defaultTarget });
+  }
+
+  return aiArtifacts;
+}
+
+/**
+ * @param {CliOptions} options
+ * @returns {Promise<InitResult>}
+ */
+export async function initRecipe(options) {
+  if (!options.json) {
+    console.clear();
+    intro("Compose your Calavera tooling recipe");
+  }
+
   const detectedPackageJSON = await readPackageJSONIfPresent();
-  const packageManager = assertSupportedPackageManager(
-    options.packageManager ?? detectPackageManager(detectedPackageJSON),
+  const detectedPackageManager = assertSupportedPackageManager(
+    detectPackageManager(detectedPackageJSON),
   );
-  const recipe = buildRecipe(profileName, selected, packageManager);
+  const profile = await promptForProfile(options);
+  const packageManager = await promptForPackageManager(options, detectedPackageManager);
+  const integrations = await promptForIntegrations(options, profile);
+  const aiArtifacts = await promptForAiArtifacts(options);
+  const recipe = composeRecipe({
+    profile,
+    packageManager,
+    tools: integrations,
+    aiArtifacts,
+  });
+  const validation = validateRecipeResponse(recipe);
+  const explanation = explainRecipeResponse(recipe);
 
   await writeJSON(options.config, recipe, options.dryRun);
+
+  if (!options.json) {
+    note(formatRecipeSummary(recipe, explanation), "Recipe summary");
+  }
+
+  /** @type {ApplyResult | undefined} */
+  let applyDryRun;
+  /** @type {ApplyResult | undefined} */
+  let applyResult;
+
+  if (options.apply) {
+    applyDryRun = await applyRecipeObject(recipe, {
+      ...options,
+      dryRun: true,
+      assumeYes: true,
+      packageManager,
+    });
+
+    if (!options.json) {
+      note(formatApplySummary(applyDryRun), "Apply dry run");
+    }
+
+    const shouldApply =
+      options.assumeYes ||
+      (await confirm({
+        message: "Apply these Calavera-managed changes now?",
+        initialValue: false,
+      }));
+
+    exitIfCancel(shouldApply);
+
+    if (shouldApply && !options.dryRun) {
+      applyResult = await applyRecipeObject(recipe, {
+        ...options,
+        dryRun: false,
+        assumeYes: true,
+        packageManager,
+      });
+    }
+  }
+
+  if (!options.json) {
+    outro(
+      applyResult
+        ? "Calavera recipe composed and applied."
+        : `Calavera recipe ${options.dryRun ? "previewed" : "written"}.`,
+    );
+  }
 
   return {
     command: "init",
     config: options.config,
     dryRun: options.dryRun,
     recipe,
+    validation,
+    explanation,
+    applyDryRun,
+    applyResult,
   };
 }
 
@@ -1747,6 +2023,35 @@ function printResult(result, asJSON = false) {
     }
 
     logger.info(`Next prompt: ${result.nextPrompt}`);
+    return;
+  }
+
+  if (result.command === "init") {
+    if (result.dryRun) {
+      logger.info(`Calavera recipe dry run complete. Would write ${result.config}.`);
+    } else {
+      logger.success(`Wrote ${result.config}.`);
+    }
+
+    logger.info(`Profile: ${result.recipe.profile}`);
+    logger.info(`Package manager: ${result.recipe.packageManager}`);
+    logger.info(`Integrations: ${(result.recipe.integrations ?? []).join(", ")}`);
+
+    if (Array.isArray(result.recipe.ai) && result.recipe.ai.length > 0) {
+      logger.info(`AI artifacts: ${result.recipe.ai.length}`);
+    }
+
+    if (result.applyDryRun && !result.applyResult) {
+      logger.info("Apply was previewed but not run.");
+    }
+
+    if (result.applyResult) {
+      logger.success("Calavera apply complete.");
+      for (const pointer of result.applyResult.pointers) {
+        logger.info(pointer);
+      }
+    }
+
     return;
   }
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,21 +1,19 @@
-/* Thanks goes to https://github.com/t3-oss/create-t3-app/blob/main/cli/src/utils/logger.ts */
-
-import chalk from "chalk";
+import { styledValues } from "./text.js";
 
 export const logger = {
   debug(...args) {
-    console.info(chalk.white(...args));
+    console.info(...styledValues("white", args));
   },
   error(...args) {
-    console.info(chalk.red(...args));
+    console.info(...styledValues("red", args));
   },
   warn(...args) {
-    console.info(chalk.yellow(...args));
+    console.info(...styledValues("yellow", args));
   },
   info(...args) {
-    console.info(chalk.cyan(...args));
+    console.info(...styledValues("cyan", args));
   },
   success(...args) {
-    console.info(chalk.green(...args));
+    console.info(...styledValues("green", args));
   },
 };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -5,10 +5,10 @@ export const logger = {
     console.info(...styledValues("white", args));
   },
   error(...args) {
-    console.info(...styledValues("red", args));
+    console.error(...styledValues("red", args));
   },
   warn(...args) {
-    console.info(...styledValues("yellow", args));
+    console.warn(...styledValues("yellow", args));
   },
   info(...args) {
     console.info(...styledValues("cyan", args));

--- a/src/utils/prompt-options.js
+++ b/src/utils/prompt-options.js
@@ -1,0 +1,38 @@
+// @ts-check
+
+/**
+ * @typedef {object} GroupedPromptSourceOption
+ * @property {string} id
+ * @property {string} [group]
+ * @property {string} [label]
+ * @property {string} [status]
+ * @property {string} [type]
+ * @property {string} [defaultTarget]
+ */
+
+/**
+ * @param {GroupedPromptSourceOption[]} options
+ * @returns {Record<string, Array<{ value: string, label: string, hint: string }>>}
+ */
+export function groupedPromptOptions(options) {
+  /** @type {Record<string, Array<{ value: string, label: string, hint: string }>>} */
+  const groups = {};
+
+  for (const option of options) {
+    const group = option.group ?? "Other";
+    groups[group] ??= [];
+    groups[group].push({
+      value: option.id,
+      label: option.label ?? option.id,
+      hint: [
+        option.status,
+        option.type,
+        option.defaultTarget ? `target: ${option.defaultTarget}` : null,
+      ]
+        .filter(Boolean)
+        .join(" · "),
+    });
+  }
+
+  return groups;
+}

--- a/src/utils/text.js
+++ b/src/utils/text.js
@@ -1,0 +1,38 @@
+// @ts-check
+import { styleText } from "node:util";
+
+/**
+ * @param {import("node:util").InspectColor | readonly import("node:util").InspectColor[]} format
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function style(format, value) {
+  return styleText(format, String(value));
+}
+
+/**
+ * @param {import("node:util").InspectColor | readonly import("node:util").InspectColor[]} format
+ * @param {unknown[]} values
+ * @returns {string[]}
+ */
+export function styledValues(format, values) {
+  return values.map((value) => style(format, value));
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+export function titleCase(value) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/**
+ * @param {number} count
+ * @param {string} singular
+ * @param {string} [plural]
+ * @returns {string}
+ */
+export function pluralizeCount(count, singular, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}

--- a/src/utils/text.js
+++ b/src/utils/text.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { styleText } from "node:util";
+import * as util from "node:util";
 
 /**
  * @param {import("node:util").InspectColor | readonly import("node:util").InspectColor[]} format
@@ -7,7 +7,9 @@ import { styleText } from "node:util";
  * @returns {string}
  */
 export function style(format, value) {
-  return styleText(format, String(value));
+  const text = String(value);
+
+  return typeof util.styleText === "function" ? util.styleText(format, text) : text;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Expand `init` to support guided selection of profiles, package managers, integrations, and AI artifacts
- Add scripted flags for richer CLI composition and optional `--apply` review/apply flow
- Replace `chalk` with internal text styling helpers and update docs plus coverage

## Testing
- Added unit tests for CLI parsing and rich composer init flows
- Added unit tests covering dry-run apply behavior and schema-valid config output

fix #201 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided recipe creation flow with clearer prompts for profile, package manager, integrations, and AI artifacts.
  * Added support for previewing changes before applying them, with clearer output and status details.
  * Expanded command-line options for scripted and CI use, including richer flag formats.

* **Bug Fixes**
  * Improved config generation so the default output path is clearer and the flow is safer by default.

* **Documentation**
  * Updated the README with new usage examples and flag guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->