### PR TITLE
Document project-local Calavera workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ npm create project-calavera -- --init
 managers, use `pnpm dlx create-project-calavera --init`,
 `yarn dlx create-project-calavera --init`, or
 `bunx create-project-calavera --init`.
+The Yarn command requires Yarn 2+ because Yarn 1.x does not support `dlx`; Yarn
+1.x users can use `npx --package create-project-calavera create-project-calavera --init`
+or install `create-project-calavera` globally.
 
 The `--init` bootstrap installs the base Calavera skill, adds concise project
 guidance, writes MCP setup notes, and prints a recommended first prompt for the
@@ -197,7 +200,7 @@ is a hard stop or a migration decision the user can still approve. A dry run is
 the best next step when adoption is still possible and the user wants to see the
 impact.
 
-Use the interactive CLI instead when you want to compose the recipe yourself:
+Compose the recipe yourself with the interactive CLI:
 
 ```bash
 npm create project-calavera init

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Run `init` without selection flags for guided prompts that present the available
 options. Use selection flags only for scripted or CI flows:
 
 ```bash
-npm create project-calavera init -- --profile modern --package-manager pnpm --tool Oxlint --tool Stylelint
+npm create project-calavera init -- --profile modern --package-manager pnpm --tool oxlint --tool stylelint
 ```
 
 Wrap labels that contain spaces in quotes, for example
@@ -113,7 +113,7 @@ Inspect machine-readable output for agent workflows:
 
 ```bash
 npm create project-calavera doctor --json
-npm create project-calavera apply --dry-run --json
+npm create project-calavera apply -- --dry-run --json
 ```
 
 Bootstrap an existing project for agent-first Calavera usage without
@@ -122,6 +122,11 @@ scaffolding app code:
 ```bash
 npm create project-calavera -- --init
 ```
+
+`npm create` needs the `--` separator before Calavera flags. With other package
+managers, use `pnpm dlx create-project-calavera --init`,
+`yarn dlx create-project-calavera --init`, or
+`bunx create-project-calavera --init`.
 
 The `--init` bootstrap installs the base Calavera skill, adds concise project
 guidance, writes MCP setup notes, and prints a recommended first prompt for the
@@ -183,6 +188,34 @@ Vite, another scaffold tool, or a manually maintained repository:
 4. Start the agent from the project root.
 5. Ask it: `Use Calavera for this project. Inspect the current project for existing tooling and possible config conflicts, then list the available profiles, integrations, and AI artifacts. Once the profile and requirements are clear, compose a recipe, show me the dry-run result, and apply it only after I approve.`
 
+Agents should treat `dry_run_apply` as the approval boundary. They should show
+the package manager, integrations, dependency packages, file changes, and AI
+artifact changes before calling `apply_recipe`.
+
+If the agent finds likely conflicts, it should pause and list whether each one
+is a hard stop or a migration decision the user can still approve. A dry run is
+the best next step when adoption is still possible and the user wants to see the
+impact.
+
+Use the interactive CLI instead when you want to compose the recipe yourself:
+
+```bash
+npm create project-calavera init
+npm create project-calavera apply -- --dry-run
+npm create project-calavera apply
+```
+
+`init` composes `calavera.config.json`; `-- --init` bootstraps agent guidance.
+
+Use the web UI when you prefer browser composition. Save or download
+`calavera.config.json`, then run the displayed package-manager command from the
+project folder that contains the saved file.
+
+See
+[`docs/agent-first-calavera-workflow.md`](docs/agent-first-calavera-workflow.md)
+for agent, CLI, web UI, MCP/WebMCP, Vite+, other scaffold, and existing-project
+examples.
+
 ### Bun-managed projects and npm `devEngines`
 
 Some starters declare Bun in `devEngines.packageManager`. npm 11 fails before
@@ -238,9 +271,9 @@ Calavera recipe composition, Calavera apply, and project startup into a single
 creation path. It should remain separate from Calavera's tooling-composition
 responsibilities.
 
-Calavera should also expose agent-native recipe composition through WebMCP and,
-if needed, a standard MCP server so coding agents can compose recipes directly
-instead of driving the human web UI.
+Calavera exposes agent-native recipe composition through the standard MCP server
+and browser-safe recipe composition through WebMCP, so coding agents can compose
+recipes directly instead of driving the human web UI.
 
 See
 [`docs/create-template-and-agent-composition.md`](docs/create-template-and-agent-composition.md)
@@ -307,7 +340,10 @@ Open the printed local URL, choose your packs, then either:
 - download `calavera.config.json`.
 
 Both options are shown by default so users can choose the flow they are most
-comfortable with.
+comfortable with. After saving the file, run the displayed next commands from
+the project folder that contains `calavera.config.json`. The optional bootstrap
+command prepares agent guidance; the dry-run command previews local changes; the
+apply command writes approved changes.
 
 When the browser exposes WebMCP, the composer registers a browser parity surface
 for the MCP recipe composition workflow:

--- a/docs/agent-first-calavera-workflow.md
+++ b/docs/agent-first-calavera-workflow.md
@@ -1,0 +1,182 @@
+# Agent-First Calavera Workflow
+
+Calavera starts after a project folder exists. Create the app with Vite, Vite+,
+another scaffold, or no scaffold at all, then use Calavera to compose, review,
+and apply project tooling through a recipe.
+
+Calavera deliberately does not own application scaffolding. It owns
+`calavera.config.json`, generated tooling config, package scripts, AI artifacts,
+managed state, `doctor`, `update`, `clean`, and apply dry-run output. Vite+ and
+other starters own routes, components, framework files, starter dependencies,
+and project-specific app commands.
+
+## Recommended Agent Flow
+
+From the project root:
+
+```bash
+npm create project-calavera -- --init
+```
+
+`npm create` needs the `--` separator before Calavera flags such as `--init`.
+The other package-manager launchers run the Calavera binary directly, so their
+bootstrap commands are `pnpm dlx create-project-calavera --init`,
+`yarn dlx create-project-calavera --init`, and
+`bunx create-project-calavera --init`.
+See [Package-Manager Commands](#package-manager-commands) below for the full
+command table.
+
+The bootstrap writes Calavera guidance for agents, MCP setup notes, and the base
+Calavera skill. It does not scaffold app code.
+
+Register the MCP server from the generated `.agents/calavera/mcp.md` notes:
+
+```json
+{
+  "mcpServers": {
+    "calavera": {
+      "command": "npx",
+      "args": ["--package", "create-project-calavera", "create-project-calavera-mcp"]
+    }
+  }
+}
+```
+
+Then ask the agent to inspect the project before composing a recipe:
+
+```text
+Use Calavera for this project. Inspect the current project for existing tooling and possible config conflicts, then list the available profiles, integrations, and AI artifacts. Once the profile and requirements are clear, compose a recipe, show me the dry-run result, and apply it only after I approve.
+```
+
+The approval boundary is the dry run. Agents should call `dry_run_apply`, show
+the proposed file changes, package scripts, dependencies, and AI artifacts, then
+call `apply_recipe` only after explicit approval.
+
+If inspection finds likely conflicts, the agent should pause before applying
+changes and list each conflict as either a hard stop or a migration decision the
+user can still approve. When adoption still looks possible, use `dry_run_apply`
+to show the concrete impact before asking whether to continue.
+
+## Rich CLI Flow
+
+Use the interactive CLI when you want to choose the profile, integrations,
+package manager, and bundled AI artifacts yourself:
+
+```bash
+npm create project-calavera init
+```
+
+That writes `calavera.config.json`. Review the file, then preview and apply from
+the same project root:
+
+```bash
+npm create project-calavera apply -- --dry-run
+npm create project-calavera apply
+```
+
+For scripted composition, pass ids or labels:
+
+```bash
+npm create project-calavera init -- --profile modern --package-manager pnpm --tool oxlint --tool stylelint
+```
+
+`init` is the recipe composer. `--init` is the agent bootstrap flag. The names
+are close because npm create treats `init` as the package command and requires
+`-- --init` when forwarding a flag to the package.
+
+## Web UI Flow
+
+Use the hosted composer or local Vite app when you prefer a browser surface:
+
+- Hosted: [https://calavera.schalkneethling.com](https://calavera.schalkneethling.com)
+- Local: `npm run web:dev`
+
+Choose a profile, package manager, integrations, and AI artifacts. Save or
+download `calavera.config.json`, move it into the project root if needed, then
+run the displayed package-manager command from that project folder.
+
+The browser can compose and download recipes. It cannot inspect your local
+project, dry-run filesystem changes, install dependencies, or apply the recipe.
+Use the CLI or standard MCP server for those project-local steps.
+
+## Package-Manager Commands
+
+Use the package manager you selected for the recipe:
+
+| Package manager | Optional agent bootstrap                  | Preview saved recipe                               | Apply approved recipe                    |
+| --------------- | ----------------------------------------- | -------------------------------------------------- | ---------------------------------------- |
+| npm             | `npm create project-calavera -- --init`   | `npm create project-calavera apply -- --dry-run`   | `npm create project-calavera apply`      |
+| pnpm            | `pnpm dlx create-project-calavera --init` | `pnpm dlx create-project-calavera apply --dry-run` | `pnpm dlx create-project-calavera apply` |
+| Yarn            | `yarn dlx create-project-calavera --init` | `yarn dlx create-project-calavera apply --dry-run` | `yarn dlx create-project-calavera apply` |
+| Bun             | `bunx create-project-calavera --init`     | `bunx create-project-calavera apply --dry-run`     | `bunx create-project-calavera apply`     |
+
+Run these commands from the folder that contains `calavera.config.json`.
+Bootstrap is optional and useful for agent-led work. The dry run is the review
+step. Apply is the step that writes files and may install dependencies. The
+extra `--` appears only in npm commands because npm create needs it before
+forwarded flags; the `dlx` and `bunx` commands do not.
+
+## MCP And WebMCP
+
+The standard MCP server is the agent-native project workflow. It exposes
+composition tools and project-local apply tools:
+
+1. `list_profiles`
+2. `list_integrations`
+3. `describe_integration`
+4. `list_ai_artifacts`
+5. `compose_recipe`
+6. `validate_recipe`
+7. `explain_recipe`
+8. `dry_run_apply`
+9. `apply_recipe`
+
+WebMCP exposes the browser-safe composition subset:
+
+1. `list_profiles`
+2. `list_integrations`
+3. `describe_integration`
+4. `list_ai_artifacts`
+5. `compose_recipe`
+6. `validate_recipe`
+7. `explain_recipe`
+8. `download_recipe`
+
+Use standard MCP when the agent can run from the project root. Use WebMCP when
+the agent is helping compose a recipe in the browser and the user will download
+the file before applying it locally.
+
+## Examples
+
+New Vite project:
+
+```bash
+npm create vite@latest my-app
+cd my-app
+npm create project-calavera -- --init
+```
+
+New Vite+ project:
+
+```bash
+vp create
+cd <created-project>
+npm create project-calavera -- --init
+```
+
+Other scaffold or existing project:
+
+```bash
+cd <project-root>
+npm create project-calavera -- --init
+```
+
+In every case, compose the recipe through an agent, the rich CLI, or the web UI;
+review the dry-run output; then apply the approved recipe from the project root.
+
+## Related Docs
+
+- [README](../README.md)
+- [AI adapter guidance](./ai-adapter-guidance.md)
+- [Vite+ awareness and delta workflows](./vite-plus-and-delta-mode.md)
+- [Template and agent composition path](./create-template-and-agent-composition.md)

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -628,6 +628,7 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
   try {
     process.chdir(projectDirectory);
     await writeFile("AGENTS.md", "Existing project guidance.\n");
+    await writeFile("package.json", JSON.stringify({ packageManager: "pnpm@11.3.0" }));
 
     const result = await agentBootstrap({ json: true });
     const existingGuidance = await readFile("AGENTS.md", "utf8");
@@ -642,6 +643,7 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.match(mcpGuidance, /AskUserTool|approval/);
     assert.match(mcpGuidance, /existing tooling files/);
     assert.match(mcpGuidance, /calavera\.schalkneethling\.com/);
+    assert.match(mcpGuidance, /pnpm dlx create-project-calavera apply --dry-run/);
     assert.match(skill, /name: calavera/);
     assert.match(skill, /MCP Setup/);
     assert.match(skill, /Fallbacks/);

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -37,6 +37,8 @@ import {
   listProfilesResponse,
   normalizeAiArtifactInputs,
   normalizeIntegrationInputs,
+  projectLocalCommandCatalog,
+  projectLocalCommandSteps,
   profileDefaults,
   recipeWorkflow,
   recipeToolDescriptions,
@@ -218,6 +220,31 @@ test("shared composition normalizes explicit tool labels and package managers", 
 test("shared composition resolves duplicate tool labels within the active profile", () => {
   assert.deepEqual(normalizeIntegrationInputs(["Accessibility"], "modern"), ["oxlint-jsx-a11y"]);
   assert.deepEqual(normalizeIntegrationInputs(["Accessibility"], "classic"), ["eslint-jsx-a11y"]);
+});
+
+test("project-local command guidance covers every package manager", () => {
+  assert.deepEqual(Object.keys(projectLocalCommandCatalog), packageManagers);
+  assert.equal(
+    projectLocalCommandCatalog.npm.agentBootstrap,
+    "npm create project-calavera -- --init",
+  );
+  assert.equal(
+    projectLocalCommandCatalog.npm.applyDryRun,
+    "npm create project-calavera apply -- --dry-run",
+  );
+
+  for (const packageManager of packageManagers) {
+    const steps = projectLocalCommandSteps(packageManager);
+
+    assert.deepEqual(
+      steps.map(({ id }) => id),
+      ["agentBootstrap", "applyDryRun", "applyRecipe"],
+    );
+    assert.equal(
+      steps.every(({ command }) => command.includes("project-calavera")),
+      true,
+    );
+  }
 });
 
 test("shared composition copies profile defaults before returning recipes", () => {

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -11,6 +11,7 @@ Use Calavera to compose and apply project tooling through its MCP tools whenever
 
 1. Confirm whether Calavera MCP tools are available. Look for tools named `list_profiles`, `list_integrations`, `list_ai_artifacts`, `compose_recipe`, `dry_run_apply`, and `apply_recipe`.
 2. Inspect the project for existing tooling and likely conflicts before composing a recipe. Check files such as `package.json`, `calavera.config.json`, `.editorconfig`, `eslint.config.js`, `oxlint.json`, `.prettierrc.json`, `.stylelintrc.json`, and `tsconfig.json`.
+   If likely conflicts exist, pause before applying changes. List each conflict as a hard stop or a migration decision the user can approve, and use `dry_run_apply` to show concrete impact when adoption still looks possible.
 3. Use AskUserTool or the agent client's equivalent when available to clarify profile preferences, framework needs, conflict decisions, and apply approval. If no such tool exists, ask the user directly.
 4. List choices with `list_profiles`, `list_integrations`, and `list_ai_artifacts`. Use `describe_integration` when the user asks for more information or when you need to compare options.
 5. Once the profile and requirements are clear, compose the recipe with `compose_recipe`.

--- a/src/index.js
+++ b/src/index.js
@@ -709,7 +709,13 @@ MCP setup notes live in \`${AGENT_BOOTSTRAP_MCP_FILE}\`.
 `;
 }
 
-function createAgentBootstrapMcpInstructions() {
+/**
+ * @param {PackageManager} packageManager
+ * @returns {string}
+ */
+function createAgentBootstrapMcpInstructions(packageManager) {
+  const commands = projectLocalCommandCatalog[packageManager];
+
   return `# Calavera MCP Setup
 
 Register the Calavera MCP server from the project root:
@@ -748,7 +754,7 @@ If the MCP server cannot be registered, use the hosted Web UI to compose and dow
 
 https://calavera.schalkneethling.com
 
-Then run \`${projectLocalCommandCatalog.npm.applyDryRun}\` and ask for approval before running \`${projectLocalCommandCatalog.npm.applyRecipe}\`.
+Then run \`${commands.applyDryRun}\` and ask for approval before running \`${commands.applyRecipe}\`.
 
 Suggested first prompt:
 
@@ -1394,6 +1400,10 @@ export async function agentBootstrap(options = {}) {
     dryRun: false,
     ...options,
   };
+  const detectedPackageJSON = await readPackageJSONIfPresent();
+  const packageManager = assertSupportedPackageManager(
+    bootstrapOptions.packageManager ?? detectPackageManager(detectedPackageJSON),
+  );
 
   await assertBootstrapDirectoryAvailable(".calavera");
 
@@ -1409,7 +1419,7 @@ export async function agentBootstrap(options = {}) {
   await writeAgentBootstrapGuidance(bootstrapOptions.dryRun, changes);
   await writeBootstrapTextFile(
     AGENT_BOOTSTRAP_MCP_FILE,
-    createAgentBootstrapMcpInstructions(),
+    createAgentBootstrapMcpInstructions(packageManager),
     bootstrapOptions.dryRun,
     changes,
     "Existing Calavera MCP setup notes differ and were left unchanged.",

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ import {
   listAiArtifactOptions,
   listIntegrationOptions,
   packageManagerIdsForRecipe,
+  projectLocalCommandCatalog,
   profileIdsForRecipe,
   profileDefaults,
   resolveRecipeIntegrations,
@@ -697,6 +698,7 @@ function createAgentBootstrapGuidance() {
 - Prefer the Calavera MCP server over hand-authoring \`calavera.config.json\`.
 - If the Calavera MCP tools are not available, help the user register the MCP server from \`${AGENT_BOOTSTRAP_MCP_FILE}\` or fall back to the Calavera Web UI.
 - Inspect existing project tooling before composing a recipe and raise likely config conflicts early.
+- If likely conflicts exist, pause before applying changes. List each conflict as a hard stop or a migration decision the user can approve, and use \`dry_run_apply\` to show concrete impact when adoption still looks possible.
 - Start with \`list_profiles\`, \`list_integrations\`, and \`list_ai_artifacts\`; use \`describe_integration\` when the user asks for more information or an option needs explanation.
 - Compose recipes with \`compose_recipe\`, validate them with \`validate_recipe\`, and explain the selected integrations with \`explain_recipe\`.
 - Always present \`dry_run_apply\` output to the user before changing files.
@@ -740,13 +742,13 @@ Use the tools in this order:
 
 \`dry_run_apply\` is the review boundary. Show its result to the user and wait for explicit approval before calling \`apply_recipe\`.
 
-Before composing a recipe, inspect the project for existing tooling files such as \`package.json\`, \`calavera.config.json\`, \`.editorconfig\`, \`eslint.config.js\`, \`oxlint.json\`, \`.prettierrc.json\`, \`.stylelintrc.json\`, and \`tsconfig.json\`. Mention likely conflicts or local conventions before proposing changes.
+Before composing a recipe, inspect the project for existing tooling files such as \`package.json\`, \`calavera.config.json\`, \`.editorconfig\`, \`eslint.config.js\`, \`oxlint.json\`, \`.prettierrc.json\`, \`.stylelintrc.json\`, and \`tsconfig.json\`. Mention likely conflicts or local conventions before proposing changes. If conflicts exist, say whether they are hard stops or migration decisions, then use \`dry_run_apply\` to show the impact when adoption is still possible.
 
 If the MCP server cannot be registered, use the hosted Web UI to compose and download a recipe:
 
 https://calavera.schalkneethling.com
 
-Then run \`npm create project-calavera apply --dry-run\` and ask for approval before running \`npm create project-calavera apply\`.
+Then run \`${projectLocalCommandCatalog.npm.applyDryRun}\` and ask for approval before running \`${projectLocalCommandCatalog.npm.applyRecipe}\`.
 
 Suggested first prompt:
 

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -54,6 +54,42 @@ export const packageManagerCatalog = [
   },
 ];
 
+export const projectLocalCommandCatalog = Object.freeze({
+  npm: Object.freeze({
+    label: "npm",
+    agentBootstrap: "npm create project-calavera -- --init",
+    applyDryRun: "npm create project-calavera apply -- --dry-run",
+    applyRecipe: "npm create project-calavera apply",
+  }),
+  pnpm: Object.freeze({
+    label: "pnpm",
+    agentBootstrap: "pnpm dlx create-project-calavera --init",
+    applyDryRun: "pnpm dlx create-project-calavera apply --dry-run",
+    applyRecipe: "pnpm dlx create-project-calavera apply",
+  }),
+  yarn: Object.freeze({
+    label: "Yarn",
+    agentBootstrap: "yarn dlx create-project-calavera --init",
+    applyDryRun: "yarn dlx create-project-calavera apply --dry-run",
+    applyRecipe: "yarn dlx create-project-calavera apply",
+  }),
+  bun: Object.freeze({
+    label: "Bun",
+    agentBootstrap: "bunx create-project-calavera --init",
+    applyDryRun: "bunx create-project-calavera apply --dry-run",
+    applyRecipe: "bunx create-project-calavera apply",
+  }),
+});
+
+export const projectLocalCommandNotes = Object.freeze({
+  projectDirectory:
+    "Run these commands from the project folder where you saved calavera.config.json.",
+  agentBootstrap:
+    "Optional. Bootstrap Calavera guidance when you want an agent to inspect, compose, preview, and apply recipes with approval.",
+  applyDryRun: "Preview the saved recipe before changing files or installing dependencies.",
+  applyRecipe: "Apply the saved recipe after reviewing and approving the dry-run output.",
+});
+
 export const aiArtifactTypes = ["skill", "hook", "agent"];
 
 export const recipeCompositionToolNames = Object.freeze([
@@ -246,6 +282,36 @@ export function profileIdsForRecipe() {
 
 export function packageManagerIdsForRecipe() {
   return [...packageManagerIds];
+}
+
+export function projectLocalCommandsForPackageManager(packageManager = "npm") {
+  assertKnownValue("packageManager", packageManager, packageManagerIds);
+  return projectLocalCommandCatalog[packageManager];
+}
+
+export function projectLocalCommandSteps(packageManager = "npm") {
+  const commands = projectLocalCommandsForPackageManager(packageManager);
+
+  return [
+    {
+      id: "agentBootstrap",
+      label: "Optional agent bootstrap",
+      command: commands.agentBootstrap,
+      description: projectLocalCommandNotes.agentBootstrap,
+    },
+    {
+      id: "applyDryRun",
+      label: "Review recipe changes",
+      command: commands.applyDryRun,
+      description: projectLocalCommandNotes.applyDryRun,
+    },
+    {
+      id: "applyRecipe",
+      label: "Apply approved recipe",
+      command: commands.applyRecipe,
+      description: projectLocalCommandNotes.applyRecipe,
+    },
+  ];
 }
 
 export function listIntegrationOptions(profile) {

--- a/web/index.html
+++ b/web/index.html
@@ -101,12 +101,14 @@
             <button id="download" type="button">Download JSON</button>
           </div>
           <p>
-            Once you have your configuration saved, head to
-            <a href="https://github.com/schalkneethling/create-project-calavera"
-              >the Project Calvera repository</a
-            >
-            to learn how to apply and manage your configuration.
+            Save or download <code>calavera.config.json</code>, then run the matching commands from
+            your project folder.
           </p>
+          <section class="next-commands" aria-labelledby="next-commands-heading">
+            <h2 id="next-commands-heading">Next commands</h2>
+            <p id="next-commands-note" class="next-commands-note"></p>
+            <ol id="next-commands"></ol>
+          </section>
           <pre><code id="output"></code></pre>
         </aside>
       </section>

--- a/web/script.js
+++ b/web/script.js
@@ -10,6 +10,8 @@ import {
   listProfilesResponse,
   normalizeAiTarget,
   packageManagerIdsForRecipe,
+  projectLocalCommandNotes,
+  projectLocalCommandSteps,
   profileDefaults,
   profileIdsForRecipe,
   recipeToolDescriptions,
@@ -23,6 +25,8 @@ const form = document.querySelector("#composer");
 const integrations = document.querySelector("#integrations");
 const aiArtifacts = document.querySelector("#ai-artifacts");
 const output = document.querySelector("#output");
+const nextCommands = document.querySelector("#next-commands");
+const nextCommandsNote = document.querySelector("#next-commands-note");
 const webMcpBanner = document.querySelector("#webmcp-banner");
 const profiles = profileIdsForRecipe();
 const packageManagers = packageManagerIdsForRecipe();
@@ -151,8 +155,33 @@ function recipe() {
   );
 }
 
+function selectedPackageManager() {
+  const packageManager = new FormData(form).get("packageManager");
+  return packageManager ? String(packageManager) : "npm";
+}
+
+function renderNextCommands() {
+  nextCommands.replaceChildren();
+  nextCommandsNote.textContent = projectLocalCommandNotes.projectDirectory;
+
+  for (const step of projectLocalCommandSteps(selectedPackageManager())) {
+    const item = document.createElement("li");
+    const label = document.createElement("strong");
+    const description = document.createElement("span");
+    const command = document.createElement("code");
+
+    label.textContent = step.label;
+    description.textContent = step.description;
+    command.textContent = step.command;
+
+    item.append(label, description, command);
+    nextCommands.append(item);
+  }
+}
+
 function render() {
   output.textContent = JSON.stringify(recipe(), null, 2);
+  renderNextCommands();
 }
 
 function setDefaults() {

--- a/web/styles.css
+++ b/web/styles.css
@@ -311,6 +311,72 @@ button:focus-visible {
   outline-offset: 0.1875rem;
 }
 
+code {
+  font-family: SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 0.86rem;
+}
+
+.next-commands {
+  border-block: 0.0625rem solid rgb(38 50 77 / 24%);
+  margin-block: 1rem;
+  padding-block: 1rem;
+}
+
+.next-commands h2 {
+  color: var(--ink);
+  font-size: 1rem;
+  margin-block: 0 0.5rem;
+  margin-inline: 0;
+}
+
+.next-commands-note {
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.45;
+  margin-block: 0 0.75rem;
+  margin-inline: 0;
+}
+
+.next-commands ol {
+  display: grid;
+  gap: 0.875rem;
+  list-style-position: outside;
+  list-style-type: decimal-leading-zero;
+  margin-block: 0;
+  margin-inline: 0;
+  padding-inline-start: 1.5rem;
+}
+
+.next-commands li {
+  display: grid;
+  gap: 0.375rem;
+  grid-template-columns: minmax(0, 1fr);
+  padding-inline-start: 0.125rem;
+}
+
+.next-commands strong {
+  color: var(--teal-deep);
+  font-size: 0.9rem;
+}
+
+.next-commands span {
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.4;
+}
+
+.next-commands code {
+  background: #fffaf0;
+  border: 0.0625rem solid rgb(38 50 77 / 28%);
+  border-radius: 0.375rem;
+  color: var(--ink);
+  display: block;
+  overflow-x: auto;
+  padding-block: 0.5rem;
+  padding-inline: 0.625rem;
+  white-space: nowrap;
+}
+
 pre {
   background: linear-gradient(180deg, rgb(232 93 81 / 8%), transparent 34%), var(--ink);
   border-radius: 0.5rem;
@@ -321,11 +387,6 @@ pre {
   max-block-size: 72vh;
   overflow: auto;
   padding: 1rem;
-}
-
-code {
-  font-family: SFMono-Regular, Consolas, "Liberation Mono", monospace;
-  font-size: 0.86rem;
 }
 
 @media (width <= 53.75em) {


### PR DESCRIPTION
## Summary
- Add agent-first workflow guidance for bootstrap, dry run, and apply steps
- Document package-manager specific commands in README and a new workflow guide
- Surface next commands in the web UI and centralize project-local command strings in code
- Add coverage to ensure the command catalog and step ordering stay aligned

## Testing
- Unit tests updated for the project-local command catalog and steps
- Not run (not requested)

fix #202 fix #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer step-by-step guidance for agent and CLI workflows, including dry-run, review, and apply steps.
  * The web preview now shows the next commands to run after saving a config file.
  * Support for multiple package managers is now reflected in generated command guidance.

* **Documentation**
  * Expanded setup and workflow docs with updated examples and clearer instructions for using the CLI and web flow.

* **Bug Fixes**
  * Improved conflict-handling guidance so users are prompted to pause and review likely changes before applying them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->