### PR TITLE
Release Calavera 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+## 2.0.0
+
+This release completes the agent-first Calavera composition milestone tracked in
+[#204](https://github.com/schalkneethling/create-project-calavera/issues/204).
+Calavera is now centered on project-agnostic recipe composition for existing or
+newly scaffolded projects, with agents, the CLI, and the web composer sharing
+the same recipe model.
+
+### Added
+
+- Shared recipe composition core for profiles, package managers, integrations,
+  AI artifacts, validation, and explanation.
+- Standard MCP server for agent-native recipe composition, dry-run previews,
+  and approved applies.
+- WebMCP recipe composition parity in the browser, with browser-safe recipe
+  download instead of filesystem apply.
+- Agent bootstrap flow that installs Calavera guidance, MCP setup notes, and
+  the bundled Calavera skill without scaffolding app code.
+- Rich interactive CLI composer for profile, integration, package-manager, and
+  AI artifact selection.
+- Web composer next-command guidance for optional agent bootstrap, dry-run
+  review, and approved apply.
+- Agent-first workflow documentation covering MCP, WebMCP, rich CLI, web UI,
+  Vite+, other scaffolds, and existing projects.
+
+### Changed
+
+- Calavera's documented direction now treats application scaffolding as out of
+  scope and keeps Vite+ or other generators separate from recipe composition and
+  apply.
+- Release docs now describe the 2.0.0 trusted-publishing path and the checks to
+  run before creating the GitHub release.
+
+### Migration Notes
+
+- Existing `calavera.config.json` files using recipe schema version `1` remain
+  valid.
+- Existing projects should preview changes before approving an apply:
+  - CLI: `create-project-calavera apply --dry-run`
+  - MCP: `dry_run_apply`
+- `init` composes `calavera.config.json`; `--init` bootstraps agent guidance.
+  With `npm create`, pass the bootstrap flag as
+  `npm create project-calavera -- --init`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -90,8 +90,8 @@ other agent tools.
 
 ## Deprecation Timing
 
-Do not deprecate `claude-toolkit` until a Calavera release exists that can
-install the bundled AI artifacts. After that release:
+Do not deprecate `claude-toolkit` until Calavera 2.0.0 is published with
+bundled AI artifact installation support. After that release:
 
 1. Update the Toolkit README to point here.
 2. Publish any final Toolkit metadata-only release if needed.

--- a/README.md
+++ b/README.md
@@ -389,12 +389,17 @@ Before the first trusted publish:
 To validate the package locally:
 
 ```bash
+pnpm check
+pnpm web:build
 pnpm publish:check
 pnpm pack --dry-run
 pnpm workflow:check
 ```
 
-Create a release by tagging the version and publishing a GitHub release for that
-tag. The publish workflow checks the project, builds the web composer, packs the
-package, audits the workflow with [zizmor](https://zizmor.sh), then publishes the packed tarball with
-npm provenance.
+For the 2.0.0 release, create tag `v2.0.0` from `main`, draft a GitHub release
+for that tag, and use [`CHANGELOG.md`](CHANGELOG.md) as the starting release
+notes. Publishing the GitHub release triggers the trusted-publishing workflow.
+
+The publish workflow checks the project, builds the web composer, packs the
+package, audits the workflow with [zizmor](https://zizmor.sh), then publishes
+the packed tarball with npm provenance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-project-calavera",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Compose and apply modern tooling recipes for JavaScript and TypeScript projects.",
   "keywords": [
     "cli",
@@ -33,6 +33,7 @@
   "files": [
     "src",
     "docs",
+    "CHANGELOG.md",
     "MIGRATION.md",
     "LICENSE",
     "README.md"


### PR DESCRIPTION
## Summary
- Bump the package to `2.0.0` for the Calavera release.
- Add a `CHANGELOG.md` entry covering the agent-first composition milestone.
- Update release and migration guidance in `README.md` and `MIGRATION.md`.
- Include the changelog in the published package bundle.

## Testing
- Not run (not requested)

fix #204