### PR TITLE
Fix agent init bootstrap via package-manager shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.0.1
+
+### Fixed
+
+- Run the CLI entry point correctly when launched through package-manager
+  shims, including `bunx create-project-calavera --init`.
+- Accept forwarded `-- --init` argument separators for agent bootstrap.
+- Make agent bootstrap output clearer about written or skipped files.
+
 ## 2.0.0
 
 This release completes the agent-first Calavera composition milestone tracked in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-project-calavera",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Compose and apply modern tooling recipes for JavaScript and TypeScript projects.",
   "keywords": [
     "cli",

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -49,6 +52,8 @@ import {
   validateRecipeResponse,
   webMcpToolNames,
 } from "../src/recipe.js";
+
+const execFileAsync = promisify(execFile);
 
 const schemaUrl = CONFIG_SCHEMA_URL;
 const rootProperties = [
@@ -396,6 +401,34 @@ test("CLI parser accepts scripted rich composer options", () => {
   assert.deepEqual(
     parseArgs(["init", "--ai-artifact", "hook-block-dangerous-commands@team@codex"]).aiArtifacts,
     [{ id: "hook-block-dangerous-commands", target: "team@codex" }],
+  );
+});
+
+test("CLI parser ignores package-manager forwarding separators", () => {
+  assert.equal(parseArgs(["--", "--init"]).command, "agent-init");
+  assert.equal(parseArgs([" -- ", "--init"]).command, "agent-init");
+  assert.equal(parseArgs(["apply", "--", "--dry-run"]).command, "apply");
+  assert.equal(parseArgs(["apply", "--", "--dry-run"]).dryRun, true);
+});
+
+test("CLI entry point runs through package-manager-style symlinks", async () => {
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-cli-symlink-"));
+  const binPath = join(projectDirectory, "create-project-calavera");
+
+  await symlink(fileURLToPath(new URL("../src/index.js", import.meta.url)), binPath);
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [binPath, "--", "--init", "--dry-run", "--json"],
+    { cwd: projectDirectory },
+  );
+  const result = JSON.parse(stdout);
+
+  assert.equal(result.command, "agent-init");
+  assert.equal(result.dryRun, true);
+  assert.equal(
+    result.changes.some(({ path }) => path === ".agents/skills/calavera"),
+    true,
   );
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 // @ts-check
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { mkdir, readFile, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { parseArgs as parseNodeArgs } from "node:util";
 
 import {
@@ -281,8 +281,9 @@ function assertSupportedPackageManager(packageManager) {
  * @returns {CliOptions}
  */
 export function parseArgs(rawArgs) {
+  const args = rawArgs.filter((arg) => arg.trim() !== "--");
   const { values, positionals } = parseNodeArgs({
-    args: rawArgs,
+    args,
     options: cliParseOptions,
     allowPositionals: true,
   });
@@ -2034,6 +2035,7 @@ function printResult(result, asJSON = false) {
       logger.info(pointer);
     }
 
+    logger.info("Review the files above to confirm what Calavera changed or skipped.");
     logger.info(`Next prompt: ${result.nextPrompt}`);
     return;
   }
@@ -2156,7 +2158,19 @@ async function main() {
   process.exitCode = 1;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+function isDirectEntryPoint() {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  try {
+    return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectEntryPoint()) {
   main().catch((error) => {
     if (error instanceof FileWriteError) {
       logger.error(error.message);


### PR DESCRIPTION
## Summary
- Run the CLI correctly when launched through package-manager shims and forwarded `--` separators
- Improve agent bootstrap output so it is clearer which files were written or skipped
- Add coverage for parser behavior and symlinked entry-point execution

## Testing
- Added unit tests for forwarding separator handling and symlink-based CLI invocation

fix #214 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI behavior when launched through package-manager shims or symlinked entry points.
  * Fixed handling of forwarded `--` separators so bootstrap commands receive the expected arguments.
  * Clarified setup output to better show which files were written or skipped.
* **Chores**
  * Updated the project version to **2.0.1** and added the release entry to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->