### PR TITLE
Prompt before appending Calavera guidance to existing AGENTS.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.0.2
+
+### Added
+
+- Ask interactive agent bootstrap users before appending marked Calavera
+  guidance to an existing `AGENTS.md`, with `--agents-md=append|fallback` for
+  scripted runs.
+
+### Changed
+
+- Keep existing non-interactive `AGENTS.md` handling non-destructive by writing
+  Calavera guidance to `AGENTS.calavera.md` unless append mode is explicit.
+
 ## 2.0.1
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -133,8 +133,10 @@ or install `create-project-calavera` globally.
 
 The `--init` bootstrap installs the base Calavera skill, adds concise project
 guidance, writes MCP setup notes, and prints a recommended first prompt for the
-user to give their agent. It leaves existing guidance files unchanged and writes
-fallback Calavera guidance when `AGENTS.md` already exists.
+user to give their agent. When `AGENTS.md` already exists, interactive runs ask
+whether to append marked Calavera guidance directly to that file or leave it
+unchanged and write fallback guidance to `AGENTS.calavera.md`. Scripted runs
+keep the fallback-only behavior unless `--agents-md=append` is passed.
 
 ## MCP Server
 
@@ -267,6 +269,8 @@ npm --force create project-calavera apply
   composition; quote labels with spaces, or use ids/slugs in scripts and CI
 - `--ai-artifact <id-or-label-or-source>`; use `<artifact>@<target>` for hook
   and agent targets, or omit this flag to select from the interactive option list
+- `--agents-md append|fallback` with `--init` to script how existing `AGENTS.md`
+  files are handled
 - `--apply` with `init` to preview and then confirm applying the composed recipe
 - `--dry-run`
 - `--no-install`

--- a/docs/agent-first-calavera-workflow.md
+++ b/docs/agent-first-calavera-workflow.md
@@ -27,7 +27,10 @@ See [Package-Manager Commands](#package-manager-commands) below for the full
 command table.
 
 The bootstrap writes Calavera guidance for agents, MCP setup notes, and the base
-Calavera skill. It does not scaffold app code.
+Calavera skill. It does not scaffold app code. When `AGENTS.md` already exists,
+interactive runs ask whether to append marked Calavera guidance directly to that
+file or write `AGENTS.calavera.md` for manual merging. Scripted runs keep
+`AGENTS.md` unchanged unless `--agents-md=append` is passed.
 
 Register the MCP server from the generated `.agents/calavera/mcp.md` notes:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-project-calavera",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Compose and apply modern tooling recipes for JavaScript and TypeScript projects.",
   "keywords": [
     "cli",
@@ -53,7 +53,7 @@
     "web:dev": "vite --host 127.0.0.1",
     "web:build": "vite build",
     "web:preview": "vite preview --host 127.0.0.1",
-    "quality": "pnpm lint && pnpm format:all:check && pnpm typecheck && pnpm schema:check",
+    "quality": "pnpm lint && pnpm format:all:check && pnpm typecheck && pnpm test",
     "lint": "node .calavera/run-if-files.mjs \"JavaScript/TypeScript\" \"js,jsx,ts,tsx,mjs,cjs\" -- oxlint . && node .calavera/run-if-files.mjs \"CSS\" \"css,scss\" -- stylelint \"**/*.{css,scss}\"",
     "lint:fix": "node .calavera/run-if-files.mjs \"JavaScript/TypeScript\" \"js,jsx,ts,tsx,mjs,cjs\" -- oxlint --fix . && node .calavera/run-if-files.mjs \"CSS\" \"css,scss\" -- stylelint \"**/*.{css,scss}\" --fix",
     "format": "node .calavera/run-if-files.mjs \"JavaScript/TypeScript\" \"js,jsx,ts,tsx,mjs,cjs\" -- oxfmt --write .",
@@ -61,6 +61,7 @@
     "format:all:check": "oxfmt --check .",
     "format:check": "node .calavera/run-if-files.mjs \"JavaScript/TypeScript\" \"js,jsx,ts,tsx,mjs,cjs\" -- oxfmt --check .",
     "schema:check": "node --test scripts/check-config-schema.test.mjs",
+    "test": "node --test scripts/*.test.mjs",
     "typecheck": "node .calavera/run-if-files.mjs \"JavaScript/TypeScript\" \"js,jsx,ts,tsx,mjs,cjs\" -- tsc --noEmit",
     "publish:check": "publint",
     "workflow:check": "uvx zizmor@1.25.2 --offline .github/workflows"

--- a/scripts/agent-bootstrap.test.mjs
+++ b/scripts/agent-bootstrap.test.mjs
@@ -1,0 +1,89 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { agentBootstrap, parseArgs } from "../src/index.js";
+
+async function withTempProject(run) {
+  const previousCwd = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-bootstrap-"));
+
+  process.chdir(projectDirectory);
+
+  try {
+    await run(projectDirectory);
+  } finally {
+    process.chdir(previousCwd);
+    await rm(projectDirectory, { recursive: true, force: true });
+  }
+}
+
+test("parseArgs accepts an explicit AGENTS.md handling mode", () => {
+  assert.equal(parseArgs(["--init", "--agents-md=append"]).agentsMd, "append");
+  assert.equal(parseArgs(["--init", "--agents-md=fallback"]).agentsMd, "fallback");
+  assert.throws(() => parseArgs(["--init", "--agents-md=overwrite"]), /Invalid agents-md/);
+});
+
+test("agent bootstrap keeps scripted existing AGENTS.md handling non-destructive", async () => {
+  await withTempProject(async () => {
+    await writeFile("AGENTS.md", "# Existing project guidance\n");
+
+    const result = await agentBootstrap({ dryRun: true, json: true });
+
+    assert.equal(result.dryRun, true);
+    assert.ok(
+      result.changes.some(
+        (change) =>
+          change.type === "skip" &&
+          change.path === "AGENTS.md" &&
+          change.reason?.includes("left unchanged"),
+      ),
+    );
+    assert.ok(
+      result.changes.some(
+        (change) => change.type === "write" && change.path === "AGENTS.calavera.md",
+      ),
+    );
+  });
+});
+
+test("agent bootstrap can append guidance to existing AGENTS.md", async () => {
+  await withTempProject(async () => {
+    await writeFile("AGENTS.md", "# Existing project guidance\n");
+
+    const result = await agentBootstrap({ agentsMd: "append" });
+    const agentsMd = await readFile("AGENTS.md", "utf8");
+
+    assert.ok(
+      result.changes.some((change) => change.type === "update" && change.path === "AGENTS.md"),
+    );
+    assert.match(agentsMd, /calavera-agent-bootstrap:start/);
+    assert.match(agentsMd, /# Calavera Agent Guidance/);
+    assert.doesNotMatch(agentsMd, /AGENTS\.calavera\.md/);
+    assert.ok(result.pointers.includes("Agent guidance: AGENTS.md"));
+    await assert.rejects(readFile("AGENTS.calavera.md", "utf8"), { code: "ENOENT" });
+  });
+});
+
+test("agent bootstrap does not duplicate an existing Calavera guidance section", async () => {
+  await withTempProject(async () => {
+    await writeFile("AGENTS.md", "# Existing project guidance\n");
+
+    await agentBootstrap({ agentsMd: "append" });
+    const result = await agentBootstrap({ agentsMd: "append" });
+    const agentsMd = await readFile("AGENTS.md", "utf8");
+    const sectionCount = agentsMd.match(/calavera-agent-bootstrap:start/g)?.length ?? 0;
+
+    assert.equal(sectionCount, 1);
+    assert.ok(
+      result.changes.some(
+        (change) =>
+          change.type === "skip" &&
+          change.path === "AGENTS.md" &&
+          change.reason?.includes("already up to date"),
+      ),
+    );
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,7 @@ import { pluralizeCount, style, titleCase } from "./utils/text.js";
  * @property {boolean} assumeYes
  * @property {boolean} apply
  * @property {PackageManager} [packageManager]
+ * @property {"append" | "fallback"} [agentsMd]
  * @property {string} [profile]
  * @property {string[]} integrations
  * @property {{ id: string, target?: string }[]} aiArtifacts
@@ -151,6 +152,8 @@ const AGENT_BOOTSTRAP_GUIDANCE_FILE = "AGENTS.md";
 const AGENT_BOOTSTRAP_FALLBACK_GUIDANCE_FILE = "AGENTS.calavera.md";
 const AGENT_BOOTSTRAP_MCP_FILE = ".agents/calavera/mcp.md";
 const AGENT_BOOTSTRAP_MARKER = "<!-- calavera-agent-bootstrap -->";
+const AGENT_BOOTSTRAP_SECTION_START = "<!-- calavera-agent-bootstrap:start -->";
+const AGENT_BOOTSTRAP_SECTION_END = "<!-- calavera-agent-bootstrap:end -->";
 const AGENT_BOOTSTRAP_SKILL_RECIPE = {
   ai: [{ type: "skill", src: "skills/calavera" }],
 };
@@ -197,6 +200,7 @@ const cliParseOptions = {
   "dry-run": { type: "boolean" },
   init: { type: "boolean" },
   json: { type: "boolean" },
+  "agents-md": { type: "string" },
   "no-install": { type: "boolean" },
   yes: { type: "boolean" },
   "package-manager": { type: "string" },
@@ -289,6 +293,7 @@ export function parseArgs(rawArgs) {
   });
   const profile = optionalStringValue(values.profile);
   const packageManager = optionalStringValue(values["package-manager"]);
+  const agentsMd = optionalStringValue(values["agents-md"]);
   /** @type {CliOptions} */
   const parsed = {
     command: values.init ? "agent-init" : (positionals[0] ?? "init"),
@@ -316,6 +321,11 @@ export function parseArgs(rawArgs) {
 
   if (packageManager !== undefined) {
     parsed.packageManager = assertSupportedPackageManager(packageManager);
+  }
+
+  if (agentsMd !== undefined) {
+    assertKnownValue("agents-md", agentsMd, ["append", "fallback"]);
+    parsed.agentsMd = /** @type {"append" | "fallback"} */ (agentsMd);
   }
 
   return parsed;
@@ -707,6 +717,13 @@ function createAgentBootstrapGuidance() {
 - Use AskUserTool or the agent client's equivalent when available for profile choices, conflict decisions, and apply approval.
 
 MCP setup notes live in \`${AGENT_BOOTSTRAP_MCP_FILE}\`.
+`;
+}
+
+function createAgentBootstrapGuidanceSection() {
+  return `${AGENT_BOOTSTRAP_SECTION_START}
+${createAgentBootstrapGuidance().trimEnd()}
+${AGENT_BOOTSTRAP_SECTION_END}
 `;
 }
 
@@ -1349,17 +1366,146 @@ async function assertBootstrapDirectoryAvailable(path) {
 }
 
 /**
+ * @param {CliOptions} options
+ * @returns {Promise<"append" | "fallback">}
+ */
+async function resolveAgentBootstrapGuidanceMode(options) {
+  if (options.agentsMd) {
+    return options.agentsMd;
+  }
+
+  if (options.json || options.assumeYes || !process.stdin.isTTY) {
+    return "fallback";
+  }
+
+  const selected = await select({
+    message: `${AGENT_BOOTSTRAP_GUIDANCE_FILE} already exists. How should Calavera add guidance?`,
+    options: [
+      {
+        value: "append",
+        label: "Append guidance",
+        hint: "Add marked Calavera guidance directly to AGENTS.md",
+      },
+      {
+        value: "fallback",
+        label: "Fallback only",
+        hint: `Leave AGENTS.md unchanged and write ${AGENT_BOOTSTRAP_FALLBACK_GUIDANCE_FILE}`,
+      },
+    ],
+  });
+
+  exitIfCancel(selected);
+
+  return selected === "append" ? "append" : "fallback";
+}
+
+/**
+ * @param {string} contents
+ * @param {string} section
+ * @returns {{ contents: string, changed: boolean }}
+ */
+function upsertAgentBootstrapGuidanceSection(contents, section) {
+  const startIndex = contents.indexOf(AGENT_BOOTSTRAP_SECTION_START);
+  const endIndex = contents.indexOf(AGENT_BOOTSTRAP_SECTION_END);
+
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    return {
+      contents: `${contents.trimEnd()}\n\n${section}`,
+      changed: true,
+    };
+  }
+
+  const replaceEndIndex = endIndex + AGENT_BOOTSTRAP_SECTION_END.length;
+  const nextContents = `${contents.slice(0, startIndex)}${section.trimEnd()}${contents.slice(
+    replaceEndIndex,
+  )}`;
+
+  return {
+    contents: nextContents,
+    changed: nextContents !== contents,
+  };
+}
+
+/**
+ * @param {string} currentGuidance
  * @param {boolean} dryRun
  * @param {Change[]} changes
+ * @param {CliOptions} options
  */
-async function writeAgentBootstrapGuidance(dryRun, changes) {
+async function handleExistingAgentBootstrapGuidance(currentGuidance, dryRun, changes, options) {
+  const guidance = createAgentBootstrapGuidance();
+  const guidanceSection = createAgentBootstrapGuidanceSection();
+
+  if (currentGuidance.includes(AGENT_BOOTSTRAP_SECTION_START)) {
+    const nextGuidance = upsertAgentBootstrapGuidanceSection(currentGuidance, guidanceSection);
+
+    changes.push({
+      type: nextGuidance.changed ? "update" : "skip",
+      path: AGENT_BOOTSTRAP_GUIDANCE_FILE,
+      reason: nextGuidance.changed
+        ? "Calavera guidance section will be updated."
+        : "Calavera guidance section already up to date.",
+    });
+
+    if (!dryRun && nextGuidance.changed) {
+      await writeFile(AGENT_BOOTSTRAP_GUIDANCE_FILE, nextGuidance.contents);
+    }
+    return;
+  }
+
+  if (currentGuidance.includes(AGENT_BOOTSTRAP_MARKER)) {
+    changes.push({
+      type: "skip",
+      path: AGENT_BOOTSTRAP_GUIDANCE_FILE,
+      reason: "Calavera guidance already present.",
+    });
+    return;
+  }
+
+  const mode = await resolveAgentBootstrapGuidanceMode(options);
+
+  if (mode === "append") {
+    const nextGuidance = upsertAgentBootstrapGuidanceSection(currentGuidance, guidanceSection);
+
+    changes.push({
+      type: "update",
+      path: AGENT_BOOTSTRAP_GUIDANCE_FILE,
+      reason: "Append marked Calavera guidance section.",
+    });
+
+    if (!dryRun) {
+      await writeFile(AGENT_BOOTSTRAP_GUIDANCE_FILE, nextGuidance.contents);
+    }
+    return;
+  }
+
+  changes.push({
+    type: "skip",
+    path: AGENT_BOOTSTRAP_GUIDANCE_FILE,
+    reason: `Existing AGENTS.md left unchanged; Calavera guidance ${dryRun ? "would be" : "was"} written separately.`,
+  });
+
+  await writeBootstrapTextFile(
+    AGENT_BOOTSTRAP_FALLBACK_GUIDANCE_FILE,
+    guidance,
+    dryRun,
+    changes,
+    "Existing fallback Calavera guidance differs and was left unchanged.",
+  );
+}
+
+/**
+ * @param {CliOptions} options
+ * @param {Change[]} changes
+ */
+async function writeAgentBootstrapGuidance(options, changes) {
   const guidance = createAgentBootstrapGuidance();
 
   if (!(await fileExists(AGENT_BOOTSTRAP_GUIDANCE_FILE))) {
     await writeBootstrapTextFile(
       AGENT_BOOTSTRAP_GUIDANCE_FILE,
       guidance,
-      dryRun,
+      options.dryRun,
       changes,
       "Existing agent guidance differs and was left unchanged.",
     );
@@ -1377,19 +1523,7 @@ async function writeAgentBootstrapGuidance(dryRun, changes) {
     return;
   }
 
-  changes.push({
-    type: "skip",
-    path: AGENT_BOOTSTRAP_GUIDANCE_FILE,
-    reason: "Existing AGENTS.md left unchanged; Calavera guidance was written separately.",
-  });
-
-  await writeBootstrapTextFile(
-    AGENT_BOOTSTRAP_FALLBACK_GUIDANCE_FILE,
-    guidance,
-    dryRun,
-    changes,
-    "Existing fallback Calavera guidance differs and was left unchanged.",
-  );
+  await handleExistingAgentBootstrapGuidance(currentGuidance, options.dryRun, changes, options);
 }
 
 /**
@@ -1397,8 +1531,17 @@ async function writeAgentBootstrapGuidance(dryRun, changes) {
  * @returns {Promise<AgentInitResult>}
  */
 export async function agentBootstrap(options = {}) {
+  /** @type {CliOptions} */
   const bootstrapOptions = {
+    command: "agent-init",
+    config: CONFIG_FILE,
     dryRun: false,
+    json: false,
+    noInstall: false,
+    assumeYes: false,
+    apply: false,
+    integrations: [],
+    aiArtifacts: [],
     ...options,
   };
   const detectedPackageJSON = await readPackageJSONIfPresent();
@@ -1417,7 +1560,7 @@ export async function agentBootstrap(options = {}) {
   /** @type {Change[]} */
   const changes = [...aiResult.changes];
 
-  await writeAgentBootstrapGuidance(bootstrapOptions.dryRun, changes);
+  await writeAgentBootstrapGuidance(bootstrapOptions, changes);
   await writeBootstrapTextFile(
     AGENT_BOOTSTRAP_MCP_FILE,
     createAgentBootstrapMcpInstructions(packageManager),
@@ -1425,6 +1568,13 @@ export async function agentBootstrap(options = {}) {
     changes,
     "Existing Calavera MCP setup notes differ and were left unchanged.",
   );
+
+  const wroteFallbackGuidance = changes.some(
+    (change) => change.path === AGENT_BOOTSTRAP_FALLBACK_GUIDANCE_FILE,
+  );
+  const agentGuidancePointer = wroteFallbackGuidance
+    ? `Agent guidance: ${AGENT_BOOTSTRAP_FALLBACK_GUIDANCE_FILE} for manual merge with ${AGENT_BOOTSTRAP_GUIDANCE_FILE}`
+    : `Agent guidance: ${AGENT_BOOTSTRAP_GUIDANCE_FILE}`;
 
   if (!bootstrapOptions.dryRun) {
     await mkdir(".calavera", { recursive: true });
@@ -1441,7 +1591,7 @@ export async function agentBootstrap(options = {}) {
     changes,
     pointers: [
       ...aiResult.pointers,
-      `Agent guidance: ${AGENT_BOOTSTRAP_GUIDANCE_FILE} or ${AGENT_BOOTSTRAP_FALLBACK_GUIDANCE_FILE}`,
+      agentGuidancePointer,
       `MCP setup notes: ${AGENT_BOOTSTRAP_MCP_FILE}`,
     ],
     nextPrompt: AGENT_BOOTSTRAP_NEXT_PROMPT,
@@ -2027,6 +2177,14 @@ function printResult(result, asJSON = false) {
           result.dryRun
             ? `Would skip ${change.path}: ${change.reason}`
             : `Skipped ${change.path}: ${change.reason}`,
+        );
+      }
+
+      if (change.type === "update") {
+        logger.info(
+          result.dryRun
+            ? `Would update ${change.path}: ${change.reason}`
+            : `Updated ${change.path}: ${change.reason}`,
         );
       }
     }


### PR DESCRIPTION
## Summary
- Ask interactive `--init` runs how to handle an existing `AGENTS.md`.
- Add `--agents-md=append|fallback` for scripted control.
- Keep non-interactive handling non-destructive by default and update docs, changelog, and tests.

## Testing
- Added unit tests for argument parsing, fallback behavior, append behavior, and duplicate section handling.