### PR TITLE
Fix appended AGENTS guidance marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.3
+
+### Fixed
+
+- Remove the standalone Calavera marker from appended `AGENTS.md` guidance
+  sections.
+
 ## 2.0.2
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-project-calavera",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Compose and apply modern tooling recipes for JavaScript and TypeScript projects.",
   "keywords": [
     "cli",

--- a/scripts/agent-bootstrap.test.mjs
+++ b/scripts/agent-bootstrap.test.mjs
@@ -61,6 +61,7 @@ test("agent bootstrap can append guidance to existing AGENTS.md", async () => {
     );
     assert.match(agentsMd, /calavera-agent-bootstrap:start/);
     assert.match(agentsMd, /# Calavera Agent Guidance/);
+    assert.doesNotMatch(agentsMd, /<!-- calavera-agent-bootstrap -->/);
     assert.doesNotMatch(agentsMd, /AGENTS\.calavera\.md/);
     assert.ok(result.pointers.includes("Agent guidance: AGENTS.md"));
     await assert.rejects(readFile("AGENTS.calavera.md", "utf8"), { code: "ENOENT" });

--- a/src/index.js
+++ b/src/index.js
@@ -701,9 +701,8 @@ trim_trailing_whitespace = true
 `;
 }
 
-function createAgentBootstrapGuidance() {
-  return `${AGENT_BOOTSTRAP_MARKER}
-# Calavera Agent Guidance
+function createAgentBootstrapGuidanceBody() {
+  return `# Calavera Agent Guidance
 
 - Use Calavera when the user wants to inspect, compose, preview, apply, or update project tooling.
 - Prefer the Calavera MCP server over hand-authoring \`calavera.config.json\`.
@@ -720,9 +719,14 @@ MCP setup notes live in \`${AGENT_BOOTSTRAP_MCP_FILE}\`.
 `;
 }
 
+function createAgentBootstrapGuidance() {
+  return `${AGENT_BOOTSTRAP_MARKER}
+${createAgentBootstrapGuidanceBody()}`;
+}
+
 function createAgentBootstrapGuidanceSection() {
   return `${AGENT_BOOTSTRAP_SECTION_START}
-${createAgentBootstrapGuidance().trimEnd()}
+${createAgentBootstrapGuidanceBody().trimEnd()}
 ${AGENT_BOOTSTRAP_SECTION_END}
 `;
 }


### PR DESCRIPTION
## Summary

- Split Calavera agent guidance into a reusable body plus the standalone AGENTS marker wrapper.
- Keep the standalone <!-- calavera-agent-bootstrap --> marker out of appended AGENTS.md sections.
- Add a regression assertion for appended guidance output.
- Bump the patch version to 2.0.3 with a changelog entry.

## Validation

- node --test scripts/agent-bootstrap.test.mjs
- pnpm run check

fix #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the guidance appended to existing `AGENTS.md` files so it no longer includes an extra standalone marker line.
  * Added coverage to ensure the generated guidance stays clean and consistent.

* **Chores**
  * Bumped the package version to 2.0.3 and updated the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->