### PR TITLE
Fix MCP bin symlink entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Start the MCP server when `create-project-calavera-mcp` is launched through a
+  package-manager bin symlink.
 - Remove the standalone Calavera marker from appended `AGENTS.md` guidance
   sections.
 

--- a/scripts/mcp-entrypoint.test.mjs
+++ b/scripts/mcp-entrypoint.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+test("MCP server starts when launched through a bin symlink", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "calavera-mcp-entrypoint-"));
+  const symlinkPath = join(directory, "create-project-calavera-mcp");
+  const mcpPath = fileURLToPath(new URL("../src/mcp.js", import.meta.url));
+  await symlink(mcpPath, symlinkPath);
+
+  const client = new Client({
+    name: "calavera-entrypoint-test",
+    version: "1.0.0",
+  });
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [symlinkPath],
+  });
+
+  try {
+    await client.connect(transport);
+    const { tools } = await client.listTools();
+
+    assert.ok(tools.some(({ name }) => name === "compose_recipe"));
+  } finally {
+    await client.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -2,8 +2,9 @@
 // @ts-check
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { realpathSync } from "node:fs";
 import { isAbsolute, relative, resolve, sep } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import packageJson from "../package.json" with { type: "json" };
 import * as z from "zod";
 
@@ -344,7 +345,17 @@ export async function startMcpServer(transport = new StdioServerTransport()) {
   await server.connect(transport);
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+function isDirectEntryPoint() {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  // Package-manager bins are symlinks. Compare realpaths so npx/npm exec/global
+  // installs still start the MCP server instead of silently exiting.
+  return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+}
+
+if (isDirectEntryPoint()) {
   startMcpServer().catch((error) => {
     console.info(error);
     process.exitCode = 1;


### PR DESCRIPTION
## Summary

- Replace the MCP server entry-point guard with a realpath comparison so package-manager bin symlinks still start the server.
- Add a code comment explaining why the realpath check is necessary for npx/npm exec/global installs.
- Add an MCP stdio regression test that launches src/mcp.js through a symlink and verifies the server exposes tools.
- Document the fix in the 2.0.3 changelog.

## Validation

- node --test scripts/mcp-entrypoint.test.mjs
- pnpm run check

fix #222