### PR TITLE
Add Claude Code MCP registration guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.0.4
+
+### Added
+
+- Document Claude Code MCP registration with project-scoped `.mcp.json`,
+  `claude mcp add`, and explicit approval guidance for persistent `npx`
+  execution.
+
 ## 2.0.3
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ For example:
 }
 ```
 
+For Claude Code, use a project-scoped `.mcp.json` in the project root when the
+registration should be shared with teammates, or use `claude mcp add` to let
+Claude Code manage the same command. Do not put MCP server registrations in
+`.claude/settings.json`; Claude Code does not load MCP servers from that file.
+Because this registration runs an external `npx` package persistently, expect
+Claude Code to ask for explicit approval before creating the config or launching
+the server for the first time.
+
 Agent guidance should tell the harness to use Calavera when a user wants to
 inspect available project tooling, compose `calavera.config.json`, preview a
 Calavera apply run, or apply an approved recipe. An MCP client can use the tools

--- a/docs/agent-first-calavera-workflow.md
+++ b/docs/agent-first-calavera-workflow.md
@@ -45,6 +45,15 @@ Register the MCP server from the generated `.agents/calavera/mcp.md` notes:
 }
 ```
 
+For Claude Code, prefer a project-scoped `.mcp.json` in the project root when
+the team should share the registration. Do not put MCP server registrations in
+`.claude/settings.json`; Claude Code does not load MCP servers from that file.
+`claude mcp add` can also register the same command if you want Claude Code to
+manage the entry. Because the server command runs
+`npx --package create-project-calavera create-project-calavera-mcp`, Claude Code
+may require explicit approval before creating the persistent registration or
+launching the server for the first time.
+
 Then ask the agent to inspect the project before composing a recipe:
 
 ```text

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-project-calavera",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Compose and apply modern tooling recipes for JavaScript and TypeScript projects.",
   "keywords": [
     "cli",

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -673,6 +673,12 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.equal(existingGuidance, "Existing project guidance.\n");
     assert.match(fallbackGuidance, /Calavera Agent Guidance/);
     assert.match(mcpGuidance, /create-project-calavera-mcp/);
+    assert.match(mcpGuidance, /Claude Code/);
+    assert.match(mcpGuidance, /\.mcp\.json/);
+    assert.match(mcpGuidance, /claude mcp add/);
+    assert.match(mcpGuidance, /\.claude\/settings\.json/);
+    assert.match(mcpGuidance, /persistent code-execution change/);
+    assert.match(mcpGuidance, /explicit user approval/);
     assert.match(mcpGuidance, /AskUserTool|approval/);
     assert.match(mcpGuidance, /existing tooling files/);
     assert.match(mcpGuidance, /calavera\.schalkneethling\.com/);

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -38,6 +38,10 @@ If the Calavera MCP tools are not available, help the user register this server 
 
 If this project was bootstrapped with `create-project-calavera --init`, also check `.agents/calavera/mcp.md` for local setup notes.
 
+For Claude Code, prefer a project-scoped `.mcp.json` in the project root when the team should share the Calavera server registration. Do not put the server under `.claude/settings.json`; Claude Code does not load MCP servers from that file. You can also use `claude mcp add` to register the same `npx --package create-project-calavera create-project-calavera-mcp` command.
+
+Registering the Calavera MCP server is a persistent code-execution change that runs an external `npx` package, so ask for explicit user approval before creating `.mcp.json`, running `claude mcp add`, or approving the first server launch.
+
 ## Fallbacks
 
 If the MCP server cannot be registered, use the hosted Calavera Web UI to compose and download a recipe:

--- a/src/index.js
+++ b/src/index.js
@@ -756,6 +756,31 @@ Register the Calavera MCP server from the project root:
 If your agent exposes an MCP setup UI or config writer, use the snippet above.
 If the agent needs approval before editing its own config, ask first.
 
+## Claude Code
+
+For Claude Code, prefer a project-scoped \`.mcp.json\` in the project root when
+the team should share the Calavera server registration:
+
+\`\`\`json
+{
+  "mcpServers": {
+    "calavera": {
+      "command": "npx",
+      "args": ["--package", "create-project-calavera", "create-project-calavera-mcp"]
+    }
+  }
+}
+\`\`\`
+
+Do not put this server registration in \`.claude/settings.json\`; Claude Code
+does not load MCP servers from that file. You can also register the same command
+with \`claude mcp add\` if you want Claude Code to manage the entry.
+
+Registering this MCP server is a persistent code-execution change because it
+runs \`npx --package create-project-calavera create-project-calavera-mcp\`.
+Ask for explicit user approval before creating \`.mcp.json\`, running
+\`claude mcp add\`, or approving the first server launch.
+
 Use the tools in this order:
 
 1. \`list_profiles\`


### PR DESCRIPTION
## Summary

- Add Claude Code-specific MCP registration guidance to generated bootstrap notes.
- Document .mcp.json as the team-shareable project registration path and claude mcp add as the CLI-managed option.
- Warn that .claude/settings.json is not the Claude Code MCP registration path.
- Call out explicit approval for persistent external npx execution.
- Update README, agent workflow docs, the bundled Calavera skill, and generated guidance tests.
- Bump the package version to 2.0.4 for release.

## Validation

- node --test scripts/check-config-schema.test.mjs
- pnpm run check

fix #221