### PR TITLE
Document package-manager-specific MCP setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.0.5
+
+### Fixed
+
+- Use the target project's package manager in generated MCP setup guidance,
+  including version-pinned Bun MCP commands.
+- Keep JSON/MCP apply output from writing dependency-install spinner UI to
+  stdout.
+
+### Changed
+
+- Document how agents should handle ambiguous MCP disconnects after
+  `apply_recipe` and treat Calavera-managed dry-run files as apply-owned
+  outputs.
+
 ## 2.0.4
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -146,9 +146,18 @@ Calavera also ships a standard MCP server for agent-native recipe composition:
 npx --package create-project-calavera create-project-calavera-mcp
 ```
 
-Most users will register that command with their AI agent harness of choice,
-usually with the harness configured to run the command from the project root.
-For example:
+Most users will register the equivalent command with their AI agent harness of
+choice, usually with the harness configured to run the command from the project
+root. Use the package manager declared by the target project's `package.json`.
+When configuring the MCP server manually, choose the matching command and put
+the first word in the MCP `command` field and the remaining words in `args`:
+
+- npm: `npx --package create-project-calavera create-project-calavera-mcp`
+- pnpm: `pnpm dlx --package create-project-calavera create-project-calavera-mcp`
+- Yarn: `yarn dlx --package create-project-calavera create-project-calavera-mcp`
+- Bun: `bunx --package create-project-calavera@<version> create-project-calavera-mcp`
+
+For npm-managed projects:
 
 ```json
 {
@@ -161,13 +170,32 @@ For example:
 }
 ```
 
+For Bun-managed projects, pin the package version that is current when you
+register the MCP server:
+
+```json
+{
+  "mcpServers": {
+    "calavera": {
+      "command": "bunx",
+      "args": ["--package", "create-project-calavera@<version>", "create-project-calavera-mcp"]
+    }
+  }
+}
+```
+
+Project-scoped MCP servers run from the project root. Matching the project
+package manager prevents package-manager preflight failures before Calavera can
+start, such as npm 11 rejecting a Bun-managed project through
+`devEngines.packageManager`.
+
 For Claude Code, use a project-scoped `.mcp.json` in the project root when the
 registration should be shared with teammates, or use `claude mcp add` to let
 Claude Code manage the same command. Do not put MCP server registrations in
 `.claude/settings.json`; Claude Code does not load MCP servers from that file.
-Because this registration runs an external `npx` package persistently, expect
-Claude Code to ask for explicit approval before creating the config or launching
-the server for the first time.
+Because this registration runs an external package persistently, expect Claude
+Code to ask for explicit approval before creating the config or launching the
+server for the first time.
 
 Agent guidance should tell the harness to use Calavera when a user wants to
 inspect available project tooling, compose `calavera.config.json`, preview a
@@ -260,6 +288,14 @@ Use the package manager declared by the project instead:
 ```bash
 bunx create-project-calavera apply
 ```
+
+The same rule applies to manual MCP server registration. Use
+`bunx --package create-project-calavera@<version> create-project-calavera-mcp`
+instead of `npx --package create-project-calavera create-project-calavera-mcp`
+when the agent harness launches Calavera from a Bun-managed project root. The
+explicit version avoids Bun dropping the non-default `create-project-calavera-mcp`
+bin during ad-hoc `--package` resolution without making the persistent MCP
+registration float to a later package release.
 
 If you intentionally want to launch through npm anyway, npm requires `--force`
 to bypass its own `devEngines` preflight:

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ keep the fallback-only behavior unless `--agents-md=append` is passed.
 Calavera also ships a standard MCP server for agent-native recipe composition:
 
 ```bash
-npx --package create-project-calavera create-project-calavera-mcp
+npx --package create-project-calavera@<version> create-project-calavera-mcp
 ```
 
 Most users will register the equivalent command with their AI agent harness of
@@ -152,19 +152,20 @@ root. Use the package manager declared by the target project's `package.json`.
 When configuring the MCP server manually, choose the matching command and put
 the first word in the MCP `command` field and the remaining words in `args`:
 
-- npm: `npx --package create-project-calavera create-project-calavera-mcp`
-- pnpm: `pnpm dlx --package create-project-calavera create-project-calavera-mcp`
-- Yarn: `yarn dlx --package create-project-calavera create-project-calavera-mcp`
+- npm: `npx --package create-project-calavera@<version> create-project-calavera-mcp`
+- pnpm: `pnpm dlx --package create-project-calavera@<version> create-project-calavera-mcp`
+- Yarn: `yarn dlx --package create-project-calavera@<version> create-project-calavera-mcp`
 - Bun: `bunx --package create-project-calavera@<version> create-project-calavera-mcp`
 
-For npm-managed projects:
+For npm-managed projects, pin the package version that is current when you
+register the MCP server:
 
 ```json
 {
   "mcpServers": {
     "calavera": {
       "command": "npx",
-      "args": ["--package", "create-project-calavera", "create-project-calavera-mcp"]
+      "args": ["--package", "create-project-calavera@<version>", "create-project-calavera-mcp"]
     }
   }
 }
@@ -291,11 +292,11 @@ bunx create-project-calavera apply
 
 The same rule applies to manual MCP server registration. Use
 `bunx --package create-project-calavera@<version> create-project-calavera-mcp`
-instead of `npx --package create-project-calavera create-project-calavera-mcp`
+instead of `npx --package create-project-calavera@<version> create-project-calavera-mcp`
 when the agent harness launches Calavera from a Bun-managed project root. The
 explicit version avoids Bun dropping the non-default `create-project-calavera-mcp`
-bin during ad-hoc `--package` resolution without making the persistent MCP
-registration float to a later package release.
+bin during ad-hoc `--package` resolution and keeps every persistent MCP
+registration from floating to a later package release.
 
 If you intentionally want to launch through npm anyway, npm requires `--force`
 to bypass its own `devEngines` preflight:

--- a/docs/agent-first-calavera-workflow.md
+++ b/docs/agent-first-calavera-workflow.md
@@ -39,7 +39,7 @@ Register the MCP server from the generated `.agents/calavera/mcp.md` notes:
   "mcpServers": {
     "calavera": {
       "command": "npx",
-      "args": ["--package", "create-project-calavera", "create-project-calavera-mcp"]
+      "args": ["--package", "create-project-calavera@<version>", "create-project-calavera-mcp"]
     }
   }
 }
@@ -55,14 +55,14 @@ start.
 For manual MCP setup, choose the matching command and split it into the harness
 configuration fields:
 
-- npm: `npx --package create-project-calavera create-project-calavera-mcp`
-- pnpm: `pnpm dlx --package create-project-calavera create-project-calavera-mcp`
-- Yarn: `yarn dlx --package create-project-calavera create-project-calavera-mcp`
+- npm: `npx --package create-project-calavera@<version> create-project-calavera-mcp`
+- pnpm: `pnpm dlx --package create-project-calavera@<version> create-project-calavera-mcp`
+- Yarn: `yarn dlx --package create-project-calavera@<version> create-project-calavera-mcp`
 - Bun: `bunx --package create-project-calavera@<version> create-project-calavera-mcp`
 
 In JSON-based MCP configs, the first word becomes `command` and the remaining
 words become `args`.
-For Bun, keep an explicit package version specifier so `bunx --package` resolves
+Keep an explicit package version specifier so package-manager launchers resolve
 the `create-project-calavera-mcp` bin reliably without making the persistent MCP
 registration float to a later package release.
 

--- a/docs/agent-first-calavera-workflow.md
+++ b/docs/agent-first-calavera-workflow.md
@@ -45,14 +45,34 @@ Register the MCP server from the generated `.agents/calavera/mcp.md` notes:
 }
 ```
 
+Use the package manager declared by the target project's `package.json` when
+creating the MCP registration. The generated notes choose the matching command,
+such as `npx` for npm-managed projects, `pnpm dlx` for pnpm, `yarn dlx` for
+Yarn, or `bunx` for Bun. Project-scoped MCP servers run from the project root,
+so matching the package manager avoids preflight failures before Calavera can
+start.
+
+For manual MCP setup, choose the matching command and split it into the harness
+configuration fields:
+
+- npm: `npx --package create-project-calavera create-project-calavera-mcp`
+- pnpm: `pnpm dlx --package create-project-calavera create-project-calavera-mcp`
+- Yarn: `yarn dlx --package create-project-calavera create-project-calavera-mcp`
+- Bun: `bunx --package create-project-calavera@<version> create-project-calavera-mcp`
+
+In JSON-based MCP configs, the first word becomes `command` and the remaining
+words become `args`.
+For Bun, keep an explicit package version specifier so `bunx --package` resolves
+the `create-project-calavera-mcp` bin reliably without making the persistent MCP
+registration float to a later package release.
+
 For Claude Code, prefer a project-scoped `.mcp.json` in the project root when
 the team should share the registration. Do not put MCP server registrations in
 `.claude/settings.json`; Claude Code does not load MCP servers from that file.
 `claude mcp add` can also register the same command if you want Claude Code to
-manage the entry. Because the server command runs
-`npx --package create-project-calavera create-project-calavera-mcp`, Claude Code
-may require explicit approval before creating the persistent registration or
-launching the server for the first time.
+manage the entry. Because the server command runs an external package, Claude
+Code may require explicit approval before creating the persistent registration
+or launching the server for the first time.
 
 Then ask the agent to inspect the project before composing a recipe:
 
@@ -63,6 +83,13 @@ Use Calavera for this project. Inspect the current project for existing tooling 
 The approval boundary is the dry run. Agents should call `dry_run_apply`, show
 the proposed file changes, package scripts, dependencies, and AI artifacts, then
 call `apply_recipe` only after explicit approval.
+If the MCP transport closes or reports `-32000` during or immediately after
+`apply_recipe`, agents should treat the apply outcome as unknown instead of
+failed. Inspect `calavera.config.json`, `.calavera/state.json`, generated files,
+and package metadata before retrying the apply.
+Files listed by `dry_run_apply`, including `.calavera/run-if-files.mjs`, are
+Calavera-managed outputs. Agents should not hand-write or edit them;
+`apply_recipe` or `create-project-calavera apply` creates them after approval.
 
 If inspection finds likely conflicts, the agent should pause before applying
 changes and list each conflict as either a hard stop or a migration decision the

--- a/github-issue-triage-report.html
+++ b/github-issue-triage-report.html
@@ -96,7 +96,7 @@
   </head>
   <body>
     <h1>GitHub Issue Triage Report</h1>
-    <p class="meta">Generated: 2026-06-27 17:32:06 SAST</p>
+    <p class="meta">Generated: 2026-07-01 15:15:06 SAST</p>
     <p><strong>Input repository:</strong> schalkneethling/create-project-calavera</p>
 
     <h2>Summary</h2>
@@ -117,48 +117,42 @@
         <tr>
           <td>schalkneethling/create-project-calavera</td>
           <td>Triaged</td>
-          <td>16</td>
+          <td>12</td>
           <td>0</td>
-          <td>8</td>
-          <td>5</td>
           <td>3</td>
-          <td>
-            <a href="https://github.com/schalkneethling/create-project-calavera/issues/130"
-              >#130 Clean up legacy installer modules</a
-            >
-          </td>
+          <td>4</td>
+          <td>5</td>
+          <td><a href="https://github.com/schalkneethling/create-project-calavera/issues/226">#226 Improve MCP startup observability and failure logging</a></td>
         </tr>
       </tbody>
     </table>
 
     <details open>
-      <summary>
-        schalkneethling/create-project-calavera - 16 open issues - next: #130 Clean up legacy
-        installer modules
-      </summary>
+      <summary>schalkneethling/create-project-calavera - 12 open issues - next: #226 Improve MCP startup observability and failure logging</summary>
 
       <h2>Project Goal Summary</h2>
       <p>
-        Calavera composes and applies repeatable project tooling recipes without becoming an
-        application scaffold. Current priorities are the recipe-driven CLI, shared catalog, web
-        composer parity, safe dry-run/JSON automation, and generated tooling quality.
+        Calavera helps web developers compose, apply, inspect, and refresh repeatable project
+        tooling recipes without coupling those recipes to a framework or starter. Current focus is
+        the recipe-driven CLI, shared integration catalog, Vite-based composer, safe dry-run/JSON
+        automation, package-manager compatibility, and stable generated tooling quality.
       </p>
 
       <h2>Label Update Status</h2>
       <p>
-        Priority labels <code>p0</code>, <code>p1</code>, <code>p2</code>, and
-        <code>p3</code> already existed. Issue #130 was reprioritized from <code>p2</code> to
-        <code>p1</code> because GOAL.md explicitly tracked it as an unresolved catalog-first
-        architecture question. No other priority label changes were needed.
+        Priority labels <code>p0</code>, <code>p1</code>, <code>p2</code>, and <code>p3</code>
+        already existed. This pass applied exactly one priority label to every open issue. Issue
+        <a href="https://github.com/schalkneethling/create-project-calavera/issues/166">#166</a> was moved from <code>p3</code> to <code>p2</code>.
+        Issue <a href="https://github.com/schalkneethling/create-project-calavera/issues/177">#177</a> was also marked <code>good first issue</code>
+        and rewritten with contributor-facing guidance.
       </p>
 
       <h2>Next-Issue Nomination</h2>
       <p>
-        <a href="https://github.com/schalkneethling/create-project-calavera/issues/130"
-          >#130 Clean up legacy installer modules</a
-        >
-        is the nominated next issue: it removes ambiguous legacy generation code, directly supports
-        the catalog-first goal, and has enough context for a focused implementation.
+        <a href="https://github.com/schalkneethling/create-project-calavera/issues/226">#226 Improve MCP startup observability and failure logging</a>
+        is the nominated next issue. It is a concrete <code>p1</code> bug that directly affects
+        MCP usability, troubleshooting, and agent workflows, and it has enough acceptance criteria
+        for a focused implementation.
       </p>
 
       <h2>Issues</h2>
@@ -176,260 +170,99 @@
         <tbody>
           <tr>
             <td><span class="label p1">p1</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/130"
-                >#130 Clean up legacy installer modules</a
-              >
-            </td>
-            <td>
-              Directly resolves a GOAL.md open question about catalog-first architecture and removes
-              confusion around the active generation path.
-            </td>
-            <td>High: reduces maintenance ambiguity and protects CLI/catalog consistency.</td>
+            <td><a href="https://github.com/schalkneethling/create-project-calavera/issues/226">#226 Improve MCP startup observability and failure logging</a></td>
+            <td>Supports the GOAL.md emphasis on safe automation and useful MCP behavior by making startup failures actionable instead of silent.</td>
+            <td>High: failed MCP startup can block agents and users from using Calavera through automation workflows.</td>
+            <td><span class="label">bug</span><span class="label p1">p1</span></td>
+            <td>Concrete bug with a contributor comment already present; good candidate for immediate maintainer guidance.</td>
+          </tr>
+          <tr>
+            <td><span class="label p1">p1</span></td>
+            <td><a href="https://github.com/schalkneethling/create-project-calavera/issues/225">#225 Use project package manager in MCP setup guidance</a></td>
+            <td>Directly advances first-class package-manager support and prevents generated MCP guidance from breaking in projects managed by npm, pnpm, yarn, or bun.</td>
+            <td>High: incorrect launch guidance can make the MCP server look broken before Calavera starts.</td>
             <td><span class="label">enhancement</span><span class="label p1">p1</span></td>
-            <td>Reprioritized from p2 to p1 during this triage pass.</td>
+            <td>Strongly aligned with current package-manager reliability work.</td>
           </tr>
           <tr>
             <td><span class="label p1">p1</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/131"
-                >#131 Add and publish Calavera config JSON Schema</a
-              >
-            </td>
-            <td>
-              Schema-backed recipes strongly support repeatable configuration, CLI/composer parity,
-              and automation-friendly validation.
-            </td>
-            <td>High: improves recipe correctness and editor/agent interoperability.</td>
-            <td>
-              <span class="label">enhancement</span><span class="label p1">p1</span
-              ><span class="label">next-release</span>
-            </td>
-            <td>
-              The current tree appears to contain the schema work already; the issue may need a
-              completion review.
-            </td>
-          </tr>
-          <tr>
-            <td><span class="label p1">p1</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/147"
-                >#147 Improve frontend-security audit workflow, severity model, and scope routing</a
-              >
-            </td>
-            <td>
-              Improves the quality and trustworthiness of bundled AI skills, which are part of
-              Calavera-managed artifacts.
-            </td>
-            <td>High: avoids misleading security-review output from installed skills.</td>
-            <td>
-              <span class="label">documentation</span><span class="label p1">p1</span
-              ><span class="label">next-release</span>
-            </td>
-            <td>The current tree appears to already include the requested workflow changes.</td>
-          </tr>
-          <tr>
-            <td><span class="label p1">p1</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/148"
-                >#148 Tighten XSS, DOM, URL, and CSP guidance in frontend-security skill</a
-              >
-            </td>
-            <td>
-              Supports generated skill quality and user trust by correcting security guidance that
-              may be copied into projects.
-            </td>
-            <td>High: prevents unsafe XSS/CSP recommendations.</td>
-            <td>
-              <span class="label">documentation</span><span class="label p1">p1</span
-              ><span class="label">next-release</span>
-            </td>
-            <td>The current tree appears to already address the listed concerns.</td>
-          </tr>
-          <tr>
-            <td><span class="label p1">p1</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/149"
-                >#149 Align CSRF, JWT, and browser token storage guidance</a
-              >
-            </td>
-            <td>
-              Improves bundled skill accuracy for authentication and browser storage decisions.
-            </td>
-            <td>High: reduces risk of unsafe auth guidance.</td>
-            <td>
-              <span class="label">documentation</span><span class="label p1">p1</span
-              ><span class="label">next-release</span>
-            </td>
-            <td>
-              The current tree appears to already include context-dependent token storage guidance.
-            </td>
-          </tr>
-          <tr>
-            <td><span class="label p1">p1</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/150"
-                >#150 Correct input validation, parsing, and output encoding examples</a
-              >
-            </td>
-            <td>
-              Strengthens installed security references and helps users avoid parser-confusion bugs.
-            </td>
-            <td>High: prevents misleading validation examples from spreading.</td>
-            <td>
-              <span class="label">documentation</span><span class="label p1">p1</span
-              ><span class="label">next-release</span>
-            </td>
-            <td>
-              The current tree appears to already include stricter URL, number, date, and encoding
-              examples.
-            </td>
-          </tr>
-          <tr>
-            <td><span class="label p1">p1</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/151"
-                >#151 Harden file upload and archive handling guidance</a
-              >
-            </td>
-            <td>Improves security reference quality for uploaded files and generated downloads.</td>
-            <td>High: reduces risk from unsafe copied upload/archive examples.</td>
-            <td>
-              <span class="label">documentation</span><span class="label p1">p1</span
-              ><span class="label">next-release</span>
-            </td>
-            <td>
-              The current tree appears to already include random filenames, content detection, safe
-              download headers, and archive limits.
-            </td>
-          </tr>
-          <tr>
-            <td><span class="label p1">p1</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/152"
-                >#152 Revise Node/npm supply-chain and command execution guidance</a
-              >
-            </td>
-            <td>Protects user trust in bundled Node/npm security guidance.</td>
-            <td>High: avoids unsafe lifecycle script and command execution recommendations.</td>
-            <td>
-              <span class="label">documentation</span><span class="label p1">p1</span
-              ><span class="label">next-release</span>
-            </td>
-            <td>
-              The current tree appears to already include the requested conservative guidance.
-            </td>
+            <td><a href="https://github.com/schalkneethling/create-project-calavera/issues/227">#227 Add project inspection and conflict hints to recipe composition</a></td>
+            <td>Maps closely to the project goal of safe inspection before applying repeatable tooling recipes.</td>
+            <td>High: reduces accidental conflicts with existing project tooling and helps agents make better recipe choices.</td>
+            <td><span class="label">enhancement</span><span class="label p1">p1</span></td>
+            <td>Larger scope than #226 and #225, but high strategic value.</td>
           </tr>
           <tr>
             <td><span class="label p2">p2</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/154"
-                >#154 Add composer UI controls for AI artifact selection</a
-              >
-            </td>
-            <td>
-              Advances composer/CLI parity for AI artifacts, but is larger than the cleanup issue
-              and less blocking.
-            </td>
-            <td>Medium: improves usability for web composer users.</td>
+            <td><a href="https://github.com/schalkneethling/create-project-calavera/issues/229">#229 Explain omitted script flags in dry-run output</a></td>
+            <td>Improves dry-run clarity, which GOAL.md calls out as important for humans, CI, and agents.</td>
+            <td>Medium: prevents confusing silent omissions without changing generated successful scripts.</td>
             <td><span class="label">enhancement</span><span class="label p2">p2</span></td>
-            <td>Likely needs coordinated UI, catalog, and recipe export changes.</td>
+            <td>Useful, focused enhancement; not an urgent blocker.</td>
           </tr>
           <tr>
             <td><span class="label p2">p2</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/155"
-                >#155 Register WebMCP tools for AI configuration operations</a
-              >
-            </td>
-            <td>Supports automation and agent workflows, aligning with JSON/tooling goals.</td>
-            <td>Medium: valuable but not blocking the core CLI path.</td>
+            <td><a href="https://github.com/schalkneethling/create-project-calavera/issues/228">#228 Add useful one-line summaries to list_integrations</a></td>
+            <td>Supports catalog-first integration discovery and reduces unnecessary describe calls for agents and users.</td>
+            <td>Medium: improves selection ergonomics and automation efficiency.</td>
             <td><span class="label">enhancement</span><span class="label p2">p2</span></td>
-            <td>Should likely follow or coordinate with composer AI selection work.</td>
+            <td>Requires careful catalog copy but limited behavioral risk.</td>
           </tr>
           <tr>
             <td><span class="label p2">p2</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/156"
-                >#156 Add Codex custom-agent adapter for bundled agent Markdown</a
-              >
-            </td>
-            <td>
-              Improves portability of AI artifacts without changing the core tooling recipe model.
-            </td>
-            <td>Medium: useful for Codex users, but narrower than catalog architecture cleanup.</td>
+            <td><a href="https://github.com/schalkneethling/create-project-calavera/issues/190">#190 Clarify file ownership in apply dry-run output</a></td>
+            <td>Strengthens safe inspection by making managed files, scaffolds, and merges clearer before writes happen.</td>
+            <td>Medium: improves user confidence in dry runs and helps avoid misunderstandings about state ownership.</td>
             <td><span class="label">enhancement</span><span class="label p2">p2</span></td>
-            <td>Needs a clear output shape before implementation.</td>
+            <td>Could become higher priority if contributors frequently misread dry-run output.</td>
           </tr>
           <tr>
             <td><span class="label p2">p2</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/157"
-                >#157 Document vendor-specific AI adapter guidance</a
-              >
-            </td>
-            <td>
-              Clarifies how installed AI artifacts relate to vendor-specific consumption paths.
-            </td>
-            <td>Medium: reduces user confusion, mainly documentation impact.</td>
-            <td><span class="label">documentation</span><span class="label p2">p2</span></td>
-            <td>Best handled after or alongside adapter decisions.</td>
-          </tr>
-          <tr>
-            <td><span class="label p2">p2</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/161"
-                >#161 Write integration-contribution blog post using Varlock as the example</a
-              >
-            </td>
-            <td>
-              Helps contributors understand the catalog-first model and post-install pointers.
-            </td>
-            <td>Medium: supports adoption and contribution quality.</td>
-            <td><span class="label">documentation</span><span class="label p2">p2</span></td>
-            <td>Publishing location may need confirmation if not intended for this repository.</td>
+            <td><a href="https://github.com/schalkneethling/create-project-calavera/issues/166">#166 Consider Ajv for Calavera recipe schema validation</a></td>
+            <td>The published draft 2020-12 schema is part of Calavera's recipe contract; validating against it improves automation reliability.</td>
+            <td>Medium: useful contract confidence, especially for arbitrary recipes and CI checks.</td>
+            <td><span class="label">enhancement</span><span class="label p2">p2</span></td>
+            <td>Moved from p3 to p2 because schema validation is more than speculative polish for this project.</td>
           </tr>
           <tr>
             <td><span class="label p3">p3</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/158"
-                >#158 Add Vite+ awareness and lint/format delta mode</a
-              >
-            </td>
-            <td>
-              Potentially useful, but exploratory and not necessary for current catalog-first
-              stability.
-            </td>
-            <td>Low: speculative until design is clearer.</td>
+            <td><a href="https://github.com/schalkneethling/create-project-calavera/issues/230">#230 Avoid redundant quality script aliases when only one check exists</a></td>
+            <td>Keeps generated package scripts tidy, but the current behavior is harmless and does not block repeatable recipes.</td>
+            <td>Low: reduces script surface area without changing core capability.</td>
             <td><span class="label">enhancement</span><span class="label p3">p3</span></td>
-            <td>Keep opt-in if implemented.</td>
+            <td>Good cleanup after higher-priority dry-run and MCP reliability items.</td>
           </tr>
           <tr>
             <td><span class="label p3">p3</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/159"
-                >#159 Define the @schalkneethling/create template path</a
-              >
-            </td>
-            <td>
-              Important boundary-setting, but intentionally outside Calavera's non-goal of app
-              scaffolding.
-            </td>
-            <td>Low: useful planning work, not an immediate blocker.</td>
+            <td><a href="https://github.com/schalkneethling/create-project-calavera/issues/177">#177 Introduce spacing tokens for composer CSS</a></td>
+            <td>Improves composer maintainability, but does not materially affect recipe correctness or CLI automation.</td>
+            <td>Low: CSS architecture polish with a contained implementation surface.</td>
+            <td><span class="label">enhancement</span><span class="label">good first issue</span><span class="label p3">p3</span></td>
+            <td>Updated during this pass with contributor-friendly context and marked good first issue.</td>
+          </tr>
+          <tr>
+            <td><span class="label p3">p3</span></td>
+            <td><a href="https://github.com/schalkneethling/create-project-calavera/issues/176">#176 Introduce color tokens for composer component states</a></td>
+            <td>Improves web composer styling consistency, but is secondary to CLI/catalog and automation behavior.</td>
+            <td>Low: maintainability polish for visual state styling.</td>
             <td><span class="label">enhancement</span><span class="label p3">p3</span></td>
-            <td>Should remain separate from app scaffolding implementation.</td>
+            <td>Pairs naturally with #177 and #175 but can be done independently.</td>
           </tr>
           <tr>
             <td><span class="label p3">p3</span></td>
-            <td>
-              <a href="https://github.com/schalkneethling/create-project-calavera/issues/160"
-                >#160 Make bundled AI artifacts vendor-neutral over time</a
-              >
-            </td>
-            <td>Good long-term portability cleanup, but intentionally gradual and less urgent.</td>
-            <td>Low: polish and portability work after core AI artifact paths settle.</td>
+            <td><a href="https://github.com/schalkneethling/create-project-calavera/issues/175">#175 Introduce a typographic scale for composer CSS</a></td>
+            <td>Improves composer CSS structure while leaving the core recipe workflow unchanged.</td>
+            <td>Low: visual system maintainability improvement.</td>
+            <td><span class="label">enhancement</span><span class="label p3">p3</span></td>
+            <td>Keep separate from spacing and color token work to preserve small contribution scope.</td>
+          </tr>
+          <tr>
+            <td><span class="label p3">p3</span></td>
+            <td><a href="https://github.com/schalkneethling/create-project-calavera/issues/160">#160 Make bundled AI artifacts vendor-neutral over time</a></td>
+            <td>Supports portability over time, but current vendor-specific language was intentionally preserved for migration safety.</td>
+            <td>Low: gradual documentation and artifact wording cleanup.</td>
             <td><span class="label">documentation</span><span class="label p3">p3</span></td>
-            <td>Audit first; avoid renames that break existing recipes.</td>
+            <td>Evidence is intentionally exploratory; keep low until concrete rename/rewrite candidates are identified.</td>
           </tr>
         </tbody>
       </table>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-project-calavera",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Compose and apply modern tooling recipes for JavaScript and TypeScript projects.",
   "keywords": [
     "cli",

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -747,6 +747,10 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.match(skill, /reports `-32000`/);
     assert.match(skill, /outcome as unknown instead of failed/);
     assert.match(skill, /Fallbacks/);
+    assert.match(skill, /npm create project-calavera apply -- --dry-run/);
+    assert.match(skill, /pnpm dlx create-project-calavera apply --dry-run/);
+    assert.match(skill, /bunx create-project-calavera apply --dry-run/);
+    assert.doesNotMatch(skill, /npm create project-calavera apply --dry-run/);
     assert.equal(
       result.changes.some(
         ({ type, path, reason }) =>

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -683,7 +683,9 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.match(mcpGuidance, /"command": "pnpm"/);
     assert.match(
       mcpGuidance,
-      /"args": \[\s+"dlx",\s+"--package",\s+"create-project-calavera",\s+"create-project-calavera-mcp"\s+\]/,
+      new RegExp(
+        `"args": \\[\\s+"dlx",\\s+"--package",\\s+"create-project-calavera@${packageJson.version}",\\s+"create-project-calavera-mcp"\\s+\\]`,
+      ),
     );
     assert.doesNotMatch(mcpGuidance, /"command": "npx"/);
     assert.match(mcpGuidance, /using this project's package manager \(pnpm\)/);
@@ -692,15 +694,21 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.match(mcpGuidance, /first word in the MCP `command` field/);
     assert.match(
       mcpGuidance,
-      /- npm: `npx --package create-project-calavera create-project-calavera-mcp`/,
+      new RegExp(
+        `- npm: \`npx --package create-project-calavera@${packageJson.version} create-project-calavera-mcp\``,
+      ),
     );
     assert.match(
       mcpGuidance,
-      /- pnpm: `pnpm dlx --package create-project-calavera create-project-calavera-mcp`/,
+      new RegExp(
+        `- pnpm: \`pnpm dlx --package create-project-calavera@${packageJson.version} create-project-calavera-mcp\``,
+      ),
     );
     assert.match(
       mcpGuidance,
-      /- Yarn: `yarn dlx --package create-project-calavera create-project-calavera-mcp`/,
+      new RegExp(
+        `- Yarn: \`yarn dlx --package create-project-calavera@${packageJson.version} create-project-calavera-mcp\``,
+      ),
     );
     assert.match(
       mcpGuidance,
@@ -725,6 +733,10 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.match(skill, /name: calavera/);
     assert.match(skill, /MCP Setup/);
     assert.match(skill, /devEngines\.packageManager/);
+    assert.match(
+      skill,
+      /npx --package create-project-calavera@<version> create-project-calavera-mcp/,
+    );
     assert.match(
       skill,
       /bunx --package create-project-calavera@<version> create-project-calavera-mcp/,

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, stat, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -10,6 +10,7 @@ import { promisify } from "node:util";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import Ajv2020 from "ajv/dist/2020.js";
+import packageJson from "../package.json" with { type: "json" };
 
 import { buildAiApplyResult, createCodexAgentToml } from "../src/ai/artifacts.js";
 import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "../src/ai/catalog.js";
@@ -672,7 +673,41 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
 
     assert.equal(existingGuidance, "Existing project guidance.\n");
     assert.match(fallbackGuidance, /Calavera Agent Guidance/);
+    assert.match(fallbackGuidance, /Treat files listed by `dry_run_apply`/);
+    assert.match(fallbackGuidance, /\.calavera\/run-if-files\.mjs/);
+    assert.match(fallbackGuidance, /Do not hand-write or edit them/);
+    assert.match(fallbackGuidance, /reports `-32000`/);
+    assert.match(fallbackGuidance, /treat the outcome as unknown instead of failed/);
+    assert.match(fallbackGuidance, /\.calavera\/state\.json/);
     assert.match(mcpGuidance, /create-project-calavera-mcp/);
+    assert.match(mcpGuidance, /"command": "pnpm"/);
+    assert.match(
+      mcpGuidance,
+      /"args": \[\s+"dlx",\s+"--package",\s+"create-project-calavera",\s+"create-project-calavera-mcp"\s+\]/,
+    );
+    assert.doesNotMatch(mcpGuidance, /"command": "npx"/);
+    assert.match(mcpGuidance, /using this project's package manager \(pnpm\)/);
+    assert.match(mcpGuidance, /devEngines\.packageManager/);
+    assert.match(mcpGuidance, /When configuring an MCP server manually/);
+    assert.match(mcpGuidance, /first word in the MCP `command` field/);
+    assert.match(
+      mcpGuidance,
+      /- npm: `npx --package create-project-calavera create-project-calavera-mcp`/,
+    );
+    assert.match(
+      mcpGuidance,
+      /- pnpm: `pnpm dlx --package create-project-calavera create-project-calavera-mcp`/,
+    );
+    assert.match(
+      mcpGuidance,
+      /- Yarn: `yarn dlx --package create-project-calavera create-project-calavera-mcp`/,
+    );
+    assert.match(
+      mcpGuidance,
+      new RegExp(
+        `- Bun: \`bunx --package create-project-calavera@${packageJson.version} create-project-calavera-mcp\``,
+      ),
+    );
     assert.match(mcpGuidance, /Claude Code/);
     assert.match(mcpGuidance, /\.mcp\.json/);
     assert.match(mcpGuidance, /claude mcp add/);
@@ -680,11 +715,25 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.match(mcpGuidance, /persistent code-execution change/);
     assert.match(mcpGuidance, /explicit user approval/);
     assert.match(mcpGuidance, /AskUserTool|approval/);
+    assert.match(mcpGuidance, /Calavera-managed helper for generated package scripts/);
+    assert.match(mcpGuidance, /Do not hand-write or edit/);
+    assert.match(mcpGuidance, /reports `-32000`/);
+    assert.match(mcpGuidance, /before retrying the apply/);
     assert.match(mcpGuidance, /existing tooling files/);
     assert.match(mcpGuidance, /calavera\.schalkneethling\.com/);
     assert.match(mcpGuidance, /pnpm dlx create-project-calavera apply --dry-run/);
     assert.match(skill, /name: calavera/);
     assert.match(skill, /MCP Setup/);
+    assert.match(skill, /devEngines\.packageManager/);
+    assert.match(
+      skill,
+      /bunx --package create-project-calavera@<version> create-project-calavera-mcp/,
+    );
+    assert.match(skill, /first word in `command` and the remaining words in `args`/);
+    assert.match(skill, /Treat files listed by `dry_run_apply`/);
+    assert.match(skill, /\.calavera\/run-if-files\.mjs/);
+    assert.match(skill, /reports `-32000`/);
+    assert.match(skill, /outcome as unknown instead of failed/);
     assert.match(skill, /Fallbacks/);
     assert.equal(
       result.changes.some(
@@ -700,6 +749,46 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
       ),
       true,
     );
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("agent bootstrap uses devEngines package manager for MCP guidance", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-bun-mcp-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile(
+      "package.json",
+      JSON.stringify({
+        devEngines: {
+          packageManager: {
+            name: "bun",
+            version: "1.3.14",
+            onFail: "download",
+          },
+        },
+      }),
+    );
+
+    await agentBootstrap({ json: true });
+    const mcpGuidance = await readFile(".agents/calavera/mcp.md", "utf8");
+
+    assert.match(mcpGuidance, /"command": "bunx"/);
+    assert.match(
+      mcpGuidance,
+      new RegExp(
+        `"args": \\[\\s+"--package",\\s+"create-project-calavera@${packageJson.version}",\\s+"create-project-calavera-mcp"\\s+\\]`,
+      ),
+    );
+    assert.match(mcpGuidance, /using this project's package manager \(Bun\)/);
+    assert.match(
+      mcpGuidance,
+      /npm rejecting a Bun-managed\s+project through `devEngines\.packageManager`/,
+    );
+    assert.doesNotMatch(mcpGuidance, /"command": "npx"/);
   } finally {
     process.chdir(originalDirectory);
   }
@@ -764,6 +853,47 @@ test("MCP apply_recipe rejects config paths outside the current workspace", asyn
       /config path must stay inside the current project workspace/,
     );
   } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("JSON apply installs dependencies without writing spinner UI to stdout", async () => {
+  const originalDirectory = process.cwd();
+  const originalPath = process.env.PATH;
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-json-apply-install-"));
+  const binDirectory = join(projectDirectory, "bin");
+  const npmPath = join(binDirectory, "npm");
+  const stdoutWrites = [];
+  const originalStdoutWrite = process.stdout.write;
+
+  try {
+    process.chdir(projectDirectory);
+    await mkdir(binDirectory);
+    await writeFile(
+      npmPath,
+      "#!/usr/bin/env node\nimport { writeFileSync } from 'node:fs';\nwriteFileSync('install-called.txt', process.argv.slice(2).join(' '));\n",
+    );
+    await chmod(npmPath, 0o755);
+    await writeFile("package.json", `${JSON.stringify({ scripts: {} }, null, 2)}\n`);
+    process.env.PATH = [binDirectory, originalPath].filter(Boolean).join(delimiter);
+    process.stdout.write = function captureStdoutWrite(chunk, ...args) {
+      stdoutWrites.push(String(chunk));
+      return originalStdoutWrite.call(this, chunk, ...args);
+    };
+
+    const result = await applyRecipeObject(buildRecipe("modern", ["oxlint"], "npm"), {
+      json: true,
+      assumeYes: true,
+    });
+
+    assert.equal(result.dryRun, false);
+    assert.deepEqual(result.dependencies, ["oxlint"]);
+    assert.match(await readFile("install-called.txt", "utf8"), /install --save-dev oxlint/);
+    assert.doesNotMatch(stdoutWrites.join(""), /Installing development dependencies/);
+    assert.doesNotMatch(stdoutWrites.join(""), /Dependencies installed/);
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.env.PATH = originalPath;
     process.chdir(originalDirectory);
   }
 });

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -53,7 +53,7 @@ If the MCP server cannot be registered, use the hosted Calavera Web UI to compos
 
 https://calavera.schalkneethling.com
 
-After a recipe exists, preview local changes with `npm create project-calavera apply --dry-run`. Ask the user to approve the preview before running `npm create project-calavera apply`.
+After a recipe exists, preview local changes with the package-manager-specific apply dry-run command: `npm create project-calavera apply -- --dry-run` for npm, `pnpm dlx create-project-calavera apply --dry-run` for pnpm, `yarn dlx create-project-calavera apply --dry-run` for Yarn, or `bunx create-project-calavera apply --dry-run` for Bun. Ask the user to approve the preview before running the matching apply command.
 
 ## User Prompt
 

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -18,12 +18,15 @@ Use Calavera to compose and apply project tooling through its MCP tools whenever
 6. Validate and explain it with `validate_recipe` and `explain_recipe`.
 7. Present `dry_run_apply` output to the user before changing files.
 8. Call `apply_recipe` only after the user explicitly approves the dry run.
+9. If the MCP transport closes or reports `-32000` during or immediately after `apply_recipe`, treat the outcome as unknown instead of failed. Inspect `calavera.config.json`, `.calavera/state.json`, generated files, and package metadata before retrying the apply.
 
 Do not hand-author `calavera.config.json` when the Calavera MCP server is available. Let Calavera compose, validate, dry-run, and apply the recipe so generated files, package scripts, dependencies, AI artifacts, and managed state stay consistent.
 
+Treat files listed by `dry_run_apply`, including `.calavera/run-if-files.mjs`, as Calavera-managed outputs. Do not hand-write or edit them; let `apply_recipe` or `create-project-calavera apply` create them after approval.
+
 ## MCP Setup
 
-If the Calavera MCP tools are not available, help the user register this server from the project root:
+If the Calavera MCP tools are not available, help the user register this server from the project root. Check the target project's `package.json` first and use the package manager declared by `packageManager` or `devEngines.packageManager`.
 
 ```json
 {
@@ -36,11 +39,13 @@ If the Calavera MCP tools are not available, help the user register this server 
 }
 ```
 
+For manual MCP setup, use `npx --package create-project-calavera create-project-calavera-mcp` for npm-managed projects, `pnpm dlx --package create-project-calavera create-project-calavera-mcp` for pnpm, `yarn dlx --package create-project-calavera create-project-calavera-mcp` for Yarn, and `bunx --package create-project-calavera@<version> create-project-calavera-mcp` for Bun. In JSON-based MCP configs, put the first word in `command` and the remaining words in `args`. Matching the project package manager prevents package-manager preflight failures before Calavera can start, such as npm rejecting a Bun-managed project. Keep an explicit version for Bun so `bunx --package` resolves the `create-project-calavera-mcp` bin reliably without making the persistent MCP registration float to a later package release.
+
 If this project was bootstrapped with `create-project-calavera --init`, also check `.agents/calavera/mcp.md` for local setup notes.
 
-For Claude Code, prefer a project-scoped `.mcp.json` in the project root when the team should share the Calavera server registration. Do not put the server under `.claude/settings.json`; Claude Code does not load MCP servers from that file. You can also use `claude mcp add` to register the same `npx --package create-project-calavera create-project-calavera-mcp` command.
+For Claude Code, prefer a project-scoped `.mcp.json` in the project root when the team should share the Calavera server registration. Do not put the server under `.claude/settings.json`; Claude Code does not load MCP servers from that file. You can also use `claude mcp add` to register the same package-manager-specific command.
 
-Registering the Calavera MCP server is a persistent code-execution change that runs an external `npx` package, so ask for explicit user approval before creating `.mcp.json`, running `claude mcp add`, or approving the first server launch.
+Registering the Calavera MCP server is a persistent code-execution change that runs an external package, so ask for explicit user approval before creating `.mcp.json`, running `claude mcp add`, or approving the first server launch.
 
 ## Fallbacks
 

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -33,13 +33,13 @@ If the Calavera MCP tools are not available, help the user register this server 
   "mcpServers": {
     "calavera": {
       "command": "npx",
-      "args": ["--package", "create-project-calavera", "create-project-calavera-mcp"]
+      "args": ["--package", "create-project-calavera@<version>", "create-project-calavera-mcp"]
     }
   }
 }
 ```
 
-For manual MCP setup, use `npx --package create-project-calavera create-project-calavera-mcp` for npm-managed projects, `pnpm dlx --package create-project-calavera create-project-calavera-mcp` for pnpm, `yarn dlx --package create-project-calavera create-project-calavera-mcp` for Yarn, and `bunx --package create-project-calavera@<version> create-project-calavera-mcp` for Bun. In JSON-based MCP configs, put the first word in `command` and the remaining words in `args`. Matching the project package manager prevents package-manager preflight failures before Calavera can start, such as npm rejecting a Bun-managed project. Keep an explicit version for Bun so `bunx --package` resolves the `create-project-calavera-mcp` bin reliably without making the persistent MCP registration float to a later package release.
+For manual MCP setup, use `npx --package create-project-calavera@<version> create-project-calavera-mcp` for npm-managed projects, `pnpm dlx --package create-project-calavera@<version> create-project-calavera-mcp` for pnpm, `yarn dlx --package create-project-calavera@<version> create-project-calavera-mcp` for Yarn, and `bunx --package create-project-calavera@<version> create-project-calavera-mcp` for Bun. In JSON-based MCP configs, put the first word in `command` and the remaining words in `args`. Matching the project package manager prevents package-manager preflight failures before Calavera can start, such as npm rejecting a Bun-managed project. Keep an explicit version so package-manager launchers resolve the `create-project-calavera-mcp` bin reliably without making the persistent MCP registration float to a later package release.
 
 If this project was bootstrapped with `create-project-calavera --init`, also check `.agents/calavera/mcp.md` for local setup notes.
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import {
   text,
 } from "@clack/prompts";
 import { execa } from "execa";
+import packageJson from "../package.json" with { type: "json" };
 
 import {
   assertAiSourceExists,
@@ -713,6 +714,8 @@ function createAgentBootstrapGuidanceBody() {
 - Compose recipes with \`compose_recipe\`, validate them with \`validate_recipe\`, and explain the selected integrations with \`explain_recipe\`.
 - Always present \`dry_run_apply\` output to the user before changing files.
 - Call \`apply_recipe\` only after the user explicitly approves the dry-run result.
+- If the MCP transport closes or reports \`-32000\` during or immediately after \`apply_recipe\`, treat the outcome as unknown instead of failed. Inspect \`calavera.config.json\`, \`.calavera/state.json\`, generated files, and package metadata before retrying the apply.
+- Treat files listed by \`dry_run_apply\`, including \`.calavera/run-if-files.mjs\`, as Calavera-managed outputs. Do not hand-write or edit them; let \`apply_recipe\` or \`create-project-calavera apply\` create them after approval.
 - Use AskUserTool or the agent client's equivalent when available for profile choices, conflict decisions, and apply approval.
 
 MCP setup notes live in \`${AGENT_BOOTSTRAP_MCP_FILE}\`.
@@ -733,25 +736,99 @@ ${AGENT_BOOTSTRAP_SECTION_END}
 
 /**
  * @param {PackageManager} packageManager
+ * @returns {{ command: string, args: string[] }}
+ */
+function createMcpLaunchCommand(packageManager) {
+  switch (packageManager) {
+    case "pnpm":
+      return {
+        command: "pnpm",
+        args: ["dlx", "--package", "create-project-calavera", "create-project-calavera-mcp"],
+      };
+    case "yarn":
+      return {
+        command: "yarn",
+        args: ["dlx", "--package", "create-project-calavera", "create-project-calavera-mcp"],
+      };
+    case "bun":
+      return {
+        command: "bunx",
+        args: [
+          "--package",
+          `create-project-calavera@${packageJson.version}`,
+          "create-project-calavera-mcp",
+        ],
+      };
+    default:
+      return {
+        command: "npx",
+        args: ["--package", "create-project-calavera", "create-project-calavera-mcp"],
+      };
+  }
+}
+
+/**
+ * @param {{ command: string, args: string[] }} launchCommand
+ * @returns {string}
+ */
+function formatShellCommand(launchCommand) {
+  return [launchCommand.command, ...launchCommand.args].join(" ");
+}
+
+function createMcpManualCommandReference() {
+  return supportedPackageManagers
+    .map((packageManager) => {
+      const commands = projectLocalCommandCatalog[packageManager];
+      return `- ${commands.label}: \`${formatShellCommand(createMcpLaunchCommand(packageManager))}\``;
+    })
+    .join("\n");
+}
+
+/**
+ * @param {{ command: string, args: string[] }} launchCommand
+ * @returns {string}
+ */
+function createMcpServerConfigSnippet(launchCommand) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        calavera: launchCommand,
+      },
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * @param {PackageManager} packageManager
  * @returns {string}
  */
 function createAgentBootstrapMcpInstructions(packageManager) {
   const commands = projectLocalCommandCatalog[packageManager];
+  const launchCommand = createMcpLaunchCommand(packageManager);
+  const mcpConfig = createMcpServerConfigSnippet(launchCommand);
+  const shellCommand = formatShellCommand(launchCommand);
+  const manualCommandReference = createMcpManualCommandReference();
 
   return `# Calavera MCP Setup
 
-Register the Calavera MCP server from the project root:
+Register the Calavera MCP server from the project root using this project's package manager (${commands.label}):
 
 \`\`\`json
-{
-  "mcpServers": {
-    "calavera": {
-      "command": "npx",
-      "args": ["--package", "create-project-calavera", "create-project-calavera-mcp"]
-    }
-  }
-}
+${mcpConfig}
 \`\`\`
+
+Project-scoped MCP servers run with the project root as their working directory.
+Using the package manager declared by the project avoids package-manager
+preflight failures before Calavera can start, such as npm rejecting a Bun-managed
+project through \`devEngines.packageManager\`.
+
+When configuring an MCP server manually, choose the command that matches the
+project's package manager. Put the first word in the MCP \`command\` field and
+the remaining words in \`args\`:
+
+${manualCommandReference}
 
 If your agent exposes an MCP setup UI or config writer, use the snippet above.
 If the agent needs approval before editing its own config, ask first.
@@ -759,27 +836,16 @@ If the agent needs approval before editing its own config, ask first.
 ## Claude Code
 
 For Claude Code, prefer a project-scoped \`.mcp.json\` in the project root when
-the team should share the Calavera server registration:
-
-\`\`\`json
-{
-  "mcpServers": {
-    "calavera": {
-      "command": "npx",
-      "args": ["--package", "create-project-calavera", "create-project-calavera-mcp"]
-    }
-  }
-}
-\`\`\`
+the team should share the Calavera server registration. Use the same package
+manager-specific snippet above.
 
 Do not put this server registration in \`.claude/settings.json\`; Claude Code
 does not load MCP servers from that file. You can also register the same command
 with \`claude mcp add\` if you want Claude Code to manage the entry.
 
 Registering this MCP server is a persistent code-execution change because it
-runs \`npx --package create-project-calavera create-project-calavera-mcp\`.
-Ask for explicit user approval before creating \`.mcp.json\`, running
-\`claude mcp add\`, or approving the first server launch.
+runs \`${shellCommand}\`. Ask for explicit user approval before creating
+\`.mcp.json\`, running \`claude mcp add\`, or approving the first server launch.
 
 Use the tools in this order:
 
@@ -794,6 +860,16 @@ Use the tools in this order:
 9. \`apply_recipe\`
 
 \`dry_run_apply\` is the review boundary. Show its result to the user and wait for explicit approval before calling \`apply_recipe\`.
+
+If the MCP transport closes or reports \`-32000\` during or immediately after
+\`apply_recipe\`, treat the apply outcome as unknown instead of failed. Inspect
+\`calavera.config.json\`, \`.calavera/state.json\`, generated files, and package
+metadata before retrying the apply.
+
+If \`dry_run_apply\` lists \`.calavera/run-if-files.mjs\`, treat it as a
+Calavera-managed helper for generated package scripts. Do not hand-write or edit
+that file; let \`apply_recipe\` or \`create-project-calavera apply\` create it
+after approval.
 
 Before composing a recipe, inspect the project for existing tooling files such as \`package.json\`, \`calavera.config.json\`, \`.editorconfig\`, \`eslint.config.js\`, \`oxlint.json\`, \`.prettierrc.json\`, \`.stylelintrc.json\`, and \`tsconfig.json\`. Mention likely conflicts or local conventions before proposing changes. If conflicts exist, say whether they are hard stops or migration decisions, then use \`dry_run_apply\` to show the impact when adoption is still possible.
 
@@ -1298,10 +1374,10 @@ export async function applyRecipeObject(recipe, options = {}) {
   if (dependencyList.length > 0 && !applyOptions.noInstall && !applyOptions.dryRun) {
     const [command, commandArgs] =
       packageManagerCommands[packageManager].installDev(dependencyList);
-    const spin = spinner();
-    spin.start("Installing development dependencies...");
+    const spin = applyOptions.json ? null : spinner();
+    spin?.start("Installing development dependencies...");
     await execa(command, commandArgs, { stderr: "inherit" });
-    spin.stop("Dependencies installed");
+    spin?.stop("Dependencies installed");
   }
 
   return {

--- a/src/index.js
+++ b/src/index.js
@@ -739,30 +739,28 @@ ${AGENT_BOOTSTRAP_SECTION_END}
  * @returns {{ command: string, args: string[] }}
  */
 function createMcpLaunchCommand(packageManager) {
+  const packageSpecifier = `create-project-calavera@${packageJson.version}`;
+
   switch (packageManager) {
     case "pnpm":
       return {
         command: "pnpm",
-        args: ["dlx", "--package", "create-project-calavera", "create-project-calavera-mcp"],
+        args: ["dlx", "--package", packageSpecifier, "create-project-calavera-mcp"],
       };
     case "yarn":
       return {
         command: "yarn",
-        args: ["dlx", "--package", "create-project-calavera", "create-project-calavera-mcp"],
+        args: ["dlx", "--package", packageSpecifier, "create-project-calavera-mcp"],
       };
     case "bun":
       return {
         command: "bunx",
-        args: [
-          "--package",
-          `create-project-calavera@${packageJson.version}`,
-          "create-project-calavera-mcp",
-        ],
+        args: ["--package", packageSpecifier, "create-project-calavera-mcp"],
       };
     default:
       return {
         command: "npx",
-        args: ["--package", "create-project-calavera", "create-project-calavera-mcp"],
+        args: ["--package", packageSpecifier, "create-project-calavera-mcp"],
       };
   }
 }


### PR DESCRIPTION
## Summary
- Clarify MCP registration commands for npm, pnpm, Yarn, and Bun based on the project’s declared package manager
- Add guidance for Bun-managed projects to pin the Calavera package version when using `bunx --package`
- Document apply-path edge cases, including `-32000` transport closures and Calavera-managed generated files
- Expand tests to cover package-manager-aware MCP guidance and silent dependency install behavior in JSON mode

## Testing
- Added unit coverage for generated MCP guidance across npm, pnpm, Yarn, and Bun
- Added a JSON-mode apply test to verify dependency installation happens without spinner UI output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded MCP setup guidance with package-manager-specific manual registration commands and clearer JSON `command` vs `args` examples.
  * Added Bun-specific notes (including version pinning) to improve reliable MCP startup.
  * Clarified apply outcomes: if MCP disconnects or returns `-32000`, treat the result as unknown and review generated/config files; also note that dry-run outputs must not be hand-edited.
* **Bug Fixes**
  * Prevented progress/spinner text from being written to stdout when running in JSON mode.
* **Tests**
  * Added coverage for package-manager-specific MCP guidance generation and for JSON-mode stdout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->