### PR TITLE
Add skills.sh discovery metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # create-project-calavera
 
+[![skills.sh](https://skills.sh/b/schalkneethling/create-project-calavera)](https://skills.sh/schalkneethling/create-project-calavera)
+
 [Project Calavera](https://github.com/schalkneethling/create-project-calavera/)
 is an open-source CLI tool that scaffolds linters, formatters, TypeScript
 configs, AI tooling such as agent skills, hooks, and subagents, and other common
@@ -391,6 +393,25 @@ artifacts and Codex-adapted `.codex/agents/` files. Other vendor tools may need
 their own settings, symlinks, or import step before they consume those files. See
 [`docs/ai-adapter-guidance.md`](docs/ai-adapter-guidance.md) for Claude Code,
 Codex, and other agent-tool guidance.
+
+### skills.sh Discovery
+
+Calavera's bundled skills are grouped for discovery on
+[`skills.sh`](https://skills.sh/schalkneethling/create-project-calavera). Use
+the directory page, badge, or `skills` CLI listing flow to inspect available
+skills before choosing what belongs in a project.
+
+For Calavera-managed projects, prefer selecting bundled skills through
+`calavera.config.json`, the interactive AI artifact prompt, or scripted
+`--ai-artifact` flags. That keeps installed skills tracked in
+`.calavera/state.json`, covered by dry runs, and protected by Calavera's
+overwrite checks.
+
+Direct installs with `npx skills add schalkneethling/create-project-calavera`
+can be useful for one-off discovery or non-Calavera workflows, but those files
+are managed by the `skills` CLI rather than Calavera. Do not mix direct installs
+and Calavera-managed installs for the same destination unless you intentionally
+want Calavera to treat the existing files as local, unmanaged content.
 
 ## Web Composer
 

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -81,6 +81,7 @@ async function readProjectJson(path) {
 
 const schema = await readProjectJson("web/public/calavera.config.schema.json");
 const config = await readProjectJson("calavera.config.json");
+const skillsShConfig = await readProjectJson("skills.sh.json");
 const integrationIds = integrationCatalog.map(({ id }) => id);
 const schemaProperties = schema.properties ?? {};
 const scriptProperties = schemaProperties.scripts?.properties ?? {};
@@ -160,6 +161,28 @@ test("AI artifact catalog exposes unique complete recipe items", async () => {
     }
 
     ids.add(artifact.id);
+  }
+});
+
+test("skills.sh grouping includes every bundled skill exactly once", () => {
+  const bundledSkillSlugs = aiArtifactCatalog
+    .filter((artifact) => artifact.type === "skill")
+    .map((artifact) => artifact.src.replace(/^skills\//, ""))
+    .sort();
+  const groupedSkillSlugs = skillsShConfig.groupings
+    .flatMap((grouping) => grouping.skills)
+    .toSorted();
+
+  assert.equal(skillsShConfig.$schema, "https://skills.sh/schemas/skills.sh.schema.json");
+  assert.equal(skillsShConfig.notGrouped, "bottom");
+  assert.deepEqual(groupedSkillSlugs, bundledSkillSlugs);
+  assert.equal(new Set(groupedSkillSlugs).size, groupedSkillSlugs.length);
+
+  for (const grouping of skillsShConfig.groupings) {
+    assert.equal(typeof grouping.title, "string");
+    assert.ok(grouping.title.length > 0);
+    assert.ok(Array.isArray(grouping.skills));
+    assert.ok(grouping.skills.length > 0);
   }
 });
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Calavera workflows",
+      "description": "Project recipe, planning, and goal-setting skills for Calavera-driven work.",
+      "skills": ["calavera", "refined-plan-mode", "project-goal"]
+    },
+    {
+      "title": "Frontend quality",
+      "description": "Skills for semantic HTML, CSS systems, frontend testing, and browser security.",
+      "skills": [
+        "semantic-html",
+        "css-coder",
+        "css-tokens",
+        "frontend-testing",
+        "frontend-security"
+      ]
+    },
+    {
+      "title": "Maintainer automation",
+      "description": "Skills for code review, issue triage, dependency upkeep, and secure npm publishing.",
+      "skills": [
+        "code-review",
+        "github-goal-issue-triage",
+        "more-secure-dependabot-config",
+        "npm-publishing-best-practices",
+        "npm-trusted-publishing-github-workflow"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a `skills.sh` catalog that groups bundled Calavera skills for discovery
- Document how to use the badge, directory page, and `skills` CLI for skill browsing
- Add a regression test to verify every bundled skill is grouped exactly once

## Testing
- Unit tests updated to validate `skills.sh.json` coverage and grouping integrity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a skills.sh badge and discovery guidance to the project documentation.
  * Introduced a new skills grouping configuration with organized sections for easier browsing.

* **Documentation**
  * Clarified how to find bundled skills and recommended ways to keep skill installs tracked and managed.

* **Tests**
  * Added coverage to verify skills grouping metadata, uniqueness, and completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->