### PR TITLE
Add stderr startup logging for MCP entrypoint failures

### DIFF
--- a/scripts/mcp-entrypoint.test.mjs
+++ b/scripts/mcp-entrypoint.test.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url";
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import packageJson from "../package.json" with { type: "json" };
+import { runMcpEntrypoint } from "../src/mcp.js";
 
 test("MCP server starts when launched through a bin symlink", async () => {
   const directory = await mkdtemp(join(tmpdir(), "calavera-mcp-entrypoint-"));
@@ -32,4 +34,47 @@ test("MCP server starts when launched through a bin symlink", async () => {
     await client.close();
     await rm(directory, { recursive: true, force: true });
   }
+});
+
+test("MCP entrypoint logs startup failures to stderr without writing stdout", async () => {
+  const stdoutWrites = [];
+  const stderrWrites = [];
+  const exitCodes = [];
+  const originalStdoutWrite = process.stdout.write;
+
+  try {
+    process.stdout.write = function captureStdoutWrite(chunk, ...args) {
+      stdoutWrites.push(String(chunk));
+      return originalStdoutWrite.call(this, chunk, ...args);
+    };
+
+    await runMcpEntrypoint({
+      cwd: "/example/project",
+      stderr: {
+        write(chunk) {
+          stderrWrites.push(String(chunk));
+          return true;
+        },
+      },
+      setExitCode(code) {
+        exitCodes.push(code);
+      },
+      async startServer() {
+        throw new Error("transport failed before initialization");
+      },
+    });
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+  }
+
+  const stderr = stderrWrites.join("");
+
+  assert.deepEqual(exitCodes, [1]);
+  assert.equal(stdoutWrites.join(""), "");
+  assert.match(stderr, /create-project-calavera/);
+  assert.match(stderr, new RegExp(`v${packageJson.version}`));
+  assert.match(stderr, /mode=stdio/);
+  assert.match(stderr, /cwd=\/example\/project/);
+  assert.match(stderr, /failed to start MCP server/);
+  assert.match(stderr, /transport failed before initialization/);
 });

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -345,6 +345,48 @@ export async function startMcpServer(transport = new StdioServerTransport()) {
   await server.connect(transport);
 }
 
+/**
+ * @param {unknown} error
+ * @returns {string}
+ */
+function formatStartupError(error) {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+
+  return String(error);
+}
+
+/**
+ * @param {{
+ *   cwd?: string,
+ *   startServer?: () => Promise<void>,
+ *   stderr?: Pick<NodeJS.WriteStream, "write">,
+ *   setExitCode?: (code: number) => void,
+ * }} [options]
+ */
+export async function runMcpEntrypoint(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const startServer = options.startServer ?? (() => startMcpServer());
+  const stderr = options.stderr ?? process.stderr;
+  const setExitCode =
+    options.setExitCode ??
+    ((code) => {
+      process.exitCode = code;
+    });
+
+  stderr.write(
+    `[${SERVER_NAME}] starting MCP server v${SERVER_VERSION} (mode=stdio, cwd=${cwd})\n`,
+  );
+
+  try {
+    await startServer();
+  } catch (error) {
+    stderr.write(`[${SERVER_NAME}] failed to start MCP server\n${formatStartupError(error)}\n`);
+    setExitCode(1);
+  }
+}
+
 function isDirectEntryPoint() {
   if (!process.argv[1]) {
     return false;
@@ -356,8 +398,5 @@ function isDirectEntryPoint() {
 }
 
 if (isDirectEntryPoint()) {
-  startMcpServer().catch((error) => {
-    console.info(error);
-    process.exitCode = 1;
-  });
+  await runMcpEntrypoint();
 }


### PR DESCRIPTION
## Summary
- Add a reusable MCP entrypoint wrapper that logs startup details to stderr
- Report startup failures with the error stack and set a non-zero exit code
- Cover the failure path with a unit test that verifies stderr output and no stdout writes

## Testing
- Added a unit test for MCP entrypoint startup failure handling
- Not run (not requested)

fix #226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable CLI entrypoint helper for starting the MCP server.
  * Startup messages now include clearer context such as mode, working directory, and package version.

* **Bug Fixes**
  * Improved failure handling during server startup.
  * On startup errors, the command now writes a formatted message to stderr and exits with code 1 instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->