### PR TITLE
[codex] Add project inspection and dry-run clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Format the generated issue triage report so release checks pass.
 - Add project inspection findings, omitted script explanations, and ownership
   wording to MCP/apply dry-run output.
+- Reject recipes that try to install both Oxfmt and Prettier in one project.
 - Document writable `TMPDIR` and `BUN_INSTALL_CACHE_DIR` recovery settings for
   Bun-based MCP launches in restricted hosts.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - Format the generated issue triage report so release checks pass.
+- Add project inspection findings, omitted script explanations, and ownership
+  wording to MCP/apply dry-run output.
 - Document writable `TMPDIR` and `BUN_INSTALL_CACHE_DIR` recovery settings for
   Bun-based MCP launches in restricted hosts.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,99 @@ JavaScript, TypeScript, and library projects, and it works as a complement to
 framework scaffolding tools like Vite+ and `vp create`, giving any project a
 consistent, repeatable setup through a single recipe file.
 
+## Agent-First Flow
+
+Use Calavera after a project already exists, whether it came from `vp create`,
+Vite, another scaffold tool, or a manually maintained repository:
+
+1. Open the project directory.
+2. Run `npm create project-calavera -- --init`.
+3. Register the MCP server using the generated `.agents/calavera/mcp.md` notes.
+4. Start the agent from the project root.
+5. Agent prompt: `Use Calavera for this project. Inspect the current project for existing tooling and possible config conflicts, then list the available profiles, integrations, and AI artifacts. Once the profile and requirements are clear, compose a recipe, show me the dry-run result, and apply it only after I approve.`
+
+Find the equivalent commands for your package manager in the
+[agent-first command table](#agent-first-command-table).
+
+### Agent-First Command Table
+
+| Package manager | Bootstrap agent guidance                  | Preview apply                                      | Apply recipe                             |
+| --------------- | ----------------------------------------- | -------------------------------------------------- | ---------------------------------------- |
+| npm             | `npm create project-calavera -- --init`   | `npm create project-calavera apply -- --dry-run`   | `npm create project-calavera apply`      |
+| pnpm            | `pnpm dlx create-project-calavera --init` | `pnpm dlx create-project-calavera apply --dry-run` | `pnpm dlx create-project-calavera apply` |
+| Yarn            | `yarn dlx create-project-calavera --init` | `yarn dlx create-project-calavera apply --dry-run` | `yarn dlx create-project-calavera apply` |
+| Bun             | `bunx create-project-calavera --init`     | `bunx create-project-calavera apply --dry-run`     | `bunx create-project-calavera apply`     |
+
+`npm create` needs the `--` separator before Calavera flags such as `--init`
+and `--dry-run`. Yarn requires Yarn 2+ for `dlx`; Yarn 1.x users can use
+`npx --package create-project-calavera create-project-calavera --init`.
+
+Agents should treat `dry_run_apply` as the approval boundary. They should show
+the package manager, integrations, dependency packages, inspection findings,
+omitted script explanations, ownership notes, file changes, and AI artifact
+changes before calling `apply_recipe`.
+
+If the agent finds likely conflicts, it should pause and list whether each one
+is a hard stop or a migration decision the user can still approve. A dry run is
+the best next step when adoption is still possible and the user wants to see the
+impact.
+
+Compose the recipe yourself with the interactive CLI:
+
+```bash
+npm create project-calavera init
+npm create project-calavera apply -- --dry-run
+npm create project-calavera apply
+```
+
+`init` composes `calavera.config.json`; `-- --init` bootstraps agent guidance.
+
+Use the web UI when you prefer browser composition. Save or download
+`calavera.config.json`, then run the displayed package-manager command from the
+project folder that contains the saved file.
+
+See
+[`docs/agent-first-calavera-workflow.md`](docs/agent-first-calavera-workflow.md)
+for agent, CLI, web UI, MCP/WebMCP, Vite+, other scaffold, and existing-project
+examples.
+
+### Bun-managed projects and npm `devEngines`
+
+Some starters declare Bun in `devEngines.packageManager`. npm 11 fails before
+Calavera can run when `npm create` is used from one of those projects:
+
+```text
+Invalid devEngines.packageManager
+Invalid name "bun" does not match "npm" for "packageManager"
+```
+
+Use the package manager declared by the project instead:
+
+```bash
+bunx create-project-calavera apply
+```
+
+The same rule applies to manual MCP server registration. Use
+`bunx --package create-project-calavera@<version> create-project-calavera-mcp`
+instead of `npx --package create-project-calavera@<version> create-project-calavera-mcp`
+when the agent harness launches Calavera from a Bun-managed project root. The
+explicit version avoids Bun dropping the non-default `create-project-calavera-mcp`
+bin during ad-hoc `--package` resolution and keeps every persistent MCP
+registration from floating to a later package release.
+
+If `bunx` reports `error: bun is unable to write files to tempdir:
+PermissionDenied` in a restricted agent or MCP sandbox, configure the MCP host to
+set `TMPDIR` to an absolute writable directory. If Bun's package cache is also
+blocked, set `BUN_INSTALL_CACHE_DIR` to an absolute writable cache directory for
+that server registration.
+
+If you intentionally want to launch through npm anyway, npm requires `--force`
+to bypass its own `devEngines` preflight:
+
+```bash
+npm --force create project-calavera apply
+```
+
 ## What Calavera Manages
 
 - Linting and formatting tools
@@ -232,99 +325,6 @@ file ownership/action notes, and AI artifact changes that would be made. Agents
 should present that dry-run summary to the user first. `apply_recipe` is
 intentionally the approval boundary: call it only after the user explicitly
 approves the proposed recipe and dry-run result.
-
-## Agent-First Flow
-
-Use Calavera after a project already exists, whether it came from `vp create`,
-Vite, another scaffold tool, or a manually maintained repository:
-
-1. Open the project directory.
-2. Run `npm create project-calavera -- --init`.
-3. Register the MCP server using the generated `.agents/calavera/mcp.md` notes.
-4. Start the agent from the project root.
-5. Agent prompt: `Use Calavera for this project. Inspect the current project for existing tooling and possible config conflicts, then list the available profiles, integrations, and AI artifacts. Once the profile and requirements are clear, compose a recipe, show me the dry-run result, and apply it only after I approve.`
-
-Find the equivalent commands for your package manager in the
-[agent-first command table](#agent-first-command-table).
-
-### Agent-First Command Table
-
-| Package manager | Bootstrap agent guidance                  | Preview apply                                      | Apply recipe                             |
-| --------------- | ----------------------------------------- | -------------------------------------------------- | ---------------------------------------- |
-| npm             | `npm create project-calavera -- --init`   | `npm create project-calavera apply -- --dry-run`   | `npm create project-calavera apply`      |
-| pnpm            | `pnpm dlx create-project-calavera --init` | `pnpm dlx create-project-calavera apply --dry-run` | `pnpm dlx create-project-calavera apply` |
-| Yarn            | `yarn dlx create-project-calavera --init` | `yarn dlx create-project-calavera apply --dry-run` | `yarn dlx create-project-calavera apply` |
-| Bun             | `bunx create-project-calavera --init`     | `bunx create-project-calavera apply --dry-run`     | `bunx create-project-calavera apply`     |
-
-`npm create` needs the `--` separator before Calavera flags such as `--init`
-and `--dry-run`. Yarn requires Yarn 2+ for `dlx`; Yarn 1.x users can use
-`npx --package create-project-calavera create-project-calavera --init`.
-
-Agents should treat `dry_run_apply` as the approval boundary. They should show
-the package manager, integrations, dependency packages, inspection findings,
-omitted script explanations, ownership notes, file changes, and AI artifact
-changes before calling `apply_recipe`.
-
-If the agent finds likely conflicts, it should pause and list whether each one
-is a hard stop or a migration decision the user can still approve. A dry run is
-the best next step when adoption is still possible and the user wants to see the
-impact.
-
-Compose the recipe yourself with the interactive CLI:
-
-```bash
-npm create project-calavera init
-npm create project-calavera apply -- --dry-run
-npm create project-calavera apply
-```
-
-`init` composes `calavera.config.json`; `-- --init` bootstraps agent guidance.
-
-Use the web UI when you prefer browser composition. Save or download
-`calavera.config.json`, then run the displayed package-manager command from the
-project folder that contains the saved file.
-
-See
-[`docs/agent-first-calavera-workflow.md`](docs/agent-first-calavera-workflow.md)
-for agent, CLI, web UI, MCP/WebMCP, Vite+, other scaffold, and existing-project
-examples.
-
-### Bun-managed projects and npm `devEngines`
-
-Some starters declare Bun in `devEngines.packageManager`. npm 11 fails before
-Calavera can run when `npm create` is used from one of those projects:
-
-```text
-Invalid devEngines.packageManager
-Invalid name "bun" does not match "npm" for "packageManager"
-```
-
-Use the package manager declared by the project instead:
-
-```bash
-bunx create-project-calavera apply
-```
-
-The same rule applies to manual MCP server registration. Use
-`bunx --package create-project-calavera@<version> create-project-calavera-mcp`
-instead of `npx --package create-project-calavera@<version> create-project-calavera-mcp`
-when the agent harness launches Calavera from a Bun-managed project root. The
-explicit version avoids Bun dropping the non-default `create-project-calavera-mcp`
-bin during ad-hoc `--package` resolution and keeps every persistent MCP
-registration from floating to a later package release.
-
-If `bunx` reports `error: bun is unable to write files to tempdir:
-PermissionDenied` in a restricted agent or MCP sandbox, configure the MCP host to
-set `TMPDIR` to an absolute writable directory. If Bun's package cache is also
-blocked, set `BUN_INSTALL_CACHE_DIR` to an absolute writable cache directory for
-that server registration.
-
-If you intentionally want to launch through npm anyway, npm requires `--force`
-to bypass its own `devEngines` preflight:
-
-```bash
-npm --force create project-calavera apply
-```
 
 ## Common Flags
 

--- a/README.md
+++ b/README.md
@@ -215,20 +215,22 @@ inspect available project tooling, compose `calavera.config.json`, preview a
 Calavera apply run, or apply an approved recipe. An MCP client can use the tools
 in this order:
 
-1. `list_profiles`
-2. `list_integrations`
-3. `describe_integration`
-4. `list_ai_artifacts`
-5. `compose_recipe`
-6. `validate_recipe`
-7. `explain_recipe`
-8. `dry_run_apply`
-9. `apply_recipe`
+1. `inspect_project`
+2. `list_profiles`
+3. `list_integrations`
+4. `describe_integration`
+5. `list_ai_artifacts`
+6. `compose_recipe`
+7. `validate_recipe`
+8. `explain_recipe`
+9. `dry_run_apply`
+10. `apply_recipe`
 
 `dry_run_apply` returns structured JSON with the package manager, integrations,
-dependency packages, file changes, and AI artifact changes that would be made.
-Agents should present that dry-run summary to the user first. `apply_recipe`
-is intentionally the approval boundary: call it only after the user explicitly
+dependency packages, project inspection findings, omitted script explanations,
+file ownership/action notes, and AI artifact changes that would be made. Agents
+should present that dry-run summary to the user first. `apply_recipe` is
+intentionally the approval boundary: call it only after the user explicitly
 approves the proposed recipe and dry-run result.
 
 ## Agent-First Flow
@@ -259,8 +261,9 @@ and `--dry-run`. Yarn requires Yarn 2+ for `dlx`; Yarn 1.x users can use
 `npx --package create-project-calavera create-project-calavera --init`.
 
 Agents should treat `dry_run_apply` as the approval boundary. They should show
-the package manager, integrations, dependency packages, file changes, and AI
-artifact changes before calling `apply_recipe`.
+the package manager, integrations, dependency packages, inspection findings,
+omitted script explanations, ownership notes, file changes, and AI artifact
+changes before calling `apply_recipe`.
 
 If the agent finds likely conflicts, it should pause and list whether each one
 is a hard stop or a migration decision the user can still approve. A dry run is

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ the package manager, integrations, dependency packages, inspection findings,
 omitted script explanations, ownership notes, file changes, and AI artifact
 changes before calling `apply_recipe`.
 
+Choose one formatter for the project. Calavera rejects recipes that include both
+Oxfmt and Prettier because they would compete for the same formatting scripts
+and config ownership.
+
 If the agent finds likely conflicts, it should pause and list whether each one
 is a hard stop or a migration decision the user can still approve. A dry run is
 the best next step when adoption is still possible and the user wants to see the

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -347,6 +347,20 @@ test("shared composition output validates against the published schema", () => {
   assert.equal(validateRecipe(recipe), recipe);
 });
 
+test("shared recipe validation rejects mixed formatter integrations", () => {
+  const mixedFormatterRecipe = buildRecipe("modern", ["oxfmt", "prettier"], "npm");
+
+  assert.throws(
+    () => validateRecipe(mixedFormatterRecipe),
+    /Choose either Oxfmt or Prettier, not both/,
+  );
+  assert.equal(validateRecipeResponse(mixedFormatterRecipe).ok, false);
+  assert.match(
+    validateRecipeResponse(mixedFormatterRecipe).errors?.[0] ?? "",
+    /Choose either Oxfmt or Prettier, not both/,
+  );
+});
+
 test("shared catalog helpers expose WebMCP-ready profile scoped options", () => {
   const modernToolIds = listIntegrationOptions("modern").map(({ id }) => id);
   const classicToolIds = listIntegrationOptions("classic").map(({ id }) => id);
@@ -805,6 +819,7 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.match(fallbackGuidance, /reports `-32000`/);
     assert.match(fallbackGuidance, /treat the outcome as unknown instead of failed/);
     assert.match(fallbackGuidance, /\.calavera\/state\.json/);
+    assert.match(fallbackGuidance, /Choose either Oxfmt or Prettier/);
     assert.match(mcpGuidance, /create-project-calavera-mcp/);
     assert.match(mcpGuidance, /"command": "pnpm"/);
     assert.match(
@@ -852,6 +867,7 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.match(mcpGuidance, /inspect_project/);
     assert.match(mcpGuidance, /omitted\s+script explanations/);
     assert.match(mcpGuidance, /ownership notes/);
+    assert.match(mcpGuidance, /Do not combine Oxfmt and Prettier/);
     assert.match(mcpGuidance, /bun is unable to write files to tempdir: PermissionDenied/);
     assert.match(mcpGuidance, /TMPDIR/);
     assert.match(mcpGuidance, /BUN_INSTALL_CACHE_DIR/);
@@ -868,6 +884,7 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.match(skill, /devEngines\.packageManager/);
     assert.match(skill, /inspect_project/);
     assert.match(skill, /omitted script explanations/);
+    assert.match(skill, /Choose either Oxfmt or Prettier/);
     assert.match(
       skill,
       /npx --package create-project-calavera@<version> create-project-calavera-mcp/,
@@ -1040,6 +1057,29 @@ test("apply dry runs explain omitted scripts and managed ownership", async () =>
     );
     assert.equal(editorConfigChange?.ownership, "calavera");
     assert.equal(editorConfigChange?.action, "write");
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("apply dry runs reject mixed formatter integrations", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-dry-run-formatter-conflict-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile("package.json", `${JSON.stringify({ scripts: {} }, null, 2)}\n`);
+
+    await assert.rejects(
+      () =>
+        applyRecipeObject(buildRecipe("modern", ["oxfmt", "prettier"], "npm"), {
+          dryRun: true,
+          json: true,
+          noInstall: true,
+          assumeYes: true,
+        }),
+      /Choose either Oxfmt or Prettier, not both/,
+    );
   } finally {
     process.chdir(originalDirectory);
   }

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -15,7 +15,13 @@ import packageJson from "../package.json" with { type: "json" };
 import { buildAiApplyResult, createCodexAgentToml } from "../src/ai/artifacts.js";
 import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "../src/ai/catalog.js";
 import { integrationCatalog } from "../src/catalog.js";
-import { agentBootstrap, applyRecipeObject, initRecipe, parseArgs } from "../src/index.js";
+import {
+  agentBootstrap,
+  applyRecipeObject,
+  initRecipe,
+  inspectProject,
+  parseArgs,
+} from "../src/index.js";
 import { callMcpTool, createMcpServer } from "../src/mcp.js";
 import { createEmptyState } from "../src/state.js";
 import {
@@ -600,6 +606,10 @@ test("standard MCP server exposes Calavera recipe composition tools", async () =
 
     assert.deepEqual(toolNames, [...standardMcpToolNames].sort());
     assert.equal(
+      tools.find(({ name }) => name === "inspect_project")?.description,
+      recipeToolDescriptions.inspect_project,
+    );
+    assert.equal(
       tools.find(({ name }) => name === "compose_recipe")?.description,
       recipeToolDescriptions.compose_recipe,
     );
@@ -658,6 +668,87 @@ test("standard MCP validation and dry-run tools return agent-readable JSON", asy
     dryRun.result.changes.some(({ path }) => path === ".agents/skills/semantic-html"),
     true,
   );
+});
+
+test("project inspection reports package manager, files, and conflict hints", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-project-inspection-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile(
+      "package.json",
+      `${JSON.stringify(
+        {
+          packageManager: "pnpm@11.3.0",
+          scripts: {
+            lint: "eslint .",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeFile("pnpm-lock.yaml", "");
+    await writeFile("eslint.config.js", "export default [];\n");
+    await writeFile(".editorconfig", "local edits\n");
+
+    const recipe = buildRecipe("modern", ["editorconfig", "oxlint"], "npm");
+    const inspection = await inspectProject(recipe);
+
+    assert.equal(inspection.packageManager, "pnpm");
+    assert.equal(inspection.files.includes("package.json"), true);
+    assert.equal(inspection.files.includes("eslint.config.js"), true);
+    assert.equal(
+      inspection.findings.some(
+        ({ kind, message }) => kind === "package-manager" && message.includes("pnpm"),
+      ),
+      true,
+    );
+    assert.equal(
+      inspection.findings.some(({ kind }) => kind === "package-manager-mismatch"),
+      true,
+    );
+    assert.equal(
+      inspection.findings.some(
+        ({ kind, path, severity }) =>
+          kind === "managed-file-conflict" && path === ".editorconfig" && severity === "error",
+      ),
+      true,
+    );
+    assert.equal(
+      inspection.findings.some(
+        ({ kind, path }) => kind === "equivalent-tooling" && path === "eslint.config.js",
+      ),
+      true,
+    );
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("MCP inspect_project exposes current project conflict hints", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-mcp-inspect-project-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile("package.json", JSON.stringify({ packageManager: "bun@1.3.14" }));
+    await writeFile("bun.lock", "");
+
+    const response = await callMcpTool("inspect_project", {
+      recipe: composeRecipe({ profile: "minimal", packageManager: "npm" }),
+    });
+
+    assert.equal(response.packageManager, "bun");
+    assert.equal(response.files.includes("bun.lock"), true);
+    assert.equal(
+      response.findings.some(({ kind }) => kind === "package-manager-mismatch"),
+      true,
+    );
+  } finally {
+    process.chdir(originalDirectory);
+  }
 });
 
 test("agent bootstrap dry-run previews guidance without writing files", async () => {
@@ -758,6 +849,9 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.match(mcpGuidance, /persistent code-execution change/);
     assert.match(mcpGuidance, /explicit user approval/);
     assert.match(mcpGuidance, /AskUserTool|approval/);
+    assert.match(mcpGuidance, /inspect_project/);
+    assert.match(mcpGuidance, /omitted\s+script explanations/);
+    assert.match(mcpGuidance, /ownership notes/);
     assert.match(mcpGuidance, /bun is unable to write files to tempdir: PermissionDenied/);
     assert.match(mcpGuidance, /TMPDIR/);
     assert.match(mcpGuidance, /BUN_INSTALL_CACHE_DIR/);
@@ -772,6 +866,8 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.match(skill, /name: calavera/);
     assert.match(skill, /MCP Setup/);
     assert.match(skill, /devEngines\.packageManager/);
+    assert.match(skill, /inspect_project/);
+    assert.match(skill, /omitted script explanations/);
     assert.match(
       skill,
       /npx --package create-project-calavera@<version> create-project-calavera-mcp/,
@@ -891,6 +987,99 @@ test("apply dry runs surface managed file overwrite conflicts", async () => {
           assumeYes: true,
         }),
       /Refusing to overwrite existing managed file: \.editorconfig/,
+    );
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("apply dry runs explain omitted scripts and managed ownership", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-dry-run-omitted-scripts-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile("package.json", `${JSON.stringify({ scripts: {} }, null, 2)}\n`);
+
+    const result = await applyRecipeObject(
+      {
+        ...buildRecipe("minimal", ["editorconfig"], "npm"),
+        scripts: {
+          lint: true,
+          format: true,
+          typecheck: true,
+          quality: true,
+        },
+      },
+      {
+        dryRun: true,
+        json: true,
+        noInstall: true,
+        assumeYes: true,
+      },
+    );
+    const packageChange = result.changes.find(
+      ({ type, path }) => type === "update" && path === "package.json",
+    );
+    const editorConfigChange = result.changes.find(
+      ({ type, path }) => type === "write" && path === ".editorconfig",
+    );
+
+    assert.deepEqual(packageChange?.scripts, []);
+    assert.equal(
+      packageChange?.omittedScripts?.some(
+        ({ script, reason }) =>
+          script === "format" &&
+          reason === "format was requested but no formatter integration is selected.",
+      ),
+      true,
+    );
+    assert.equal(
+      packageChange?.omittedScripts?.some(({ script }) => script === "typecheck"),
+      true,
+    );
+    assert.equal(editorConfigChange?.ownership, "calavera");
+    assert.equal(editorConfigChange?.action, "write");
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("apply dry-run human output distinguishes owned writes and omitted scripts", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-cli-dry-run-output-"));
+  const binPath = join(projectDirectory, "create-project-calavera");
+
+  try {
+    process.chdir(projectDirectory);
+    await symlink(fileURLToPath(new URL("../src/index.js", import.meta.url)), binPath);
+    await writeFile("package.json", `${JSON.stringify({ scripts: {} }, null, 2)}\n`);
+    await writeFile(
+      "calavera.config.json",
+      `${JSON.stringify(
+        {
+          ...buildRecipe("minimal", ["editorconfig"], "npm"),
+          scripts: {
+            lint: true,
+            format: true,
+            typecheck: true,
+            quality: true,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const { stdout } = await execFileAsync(process.execPath, [binPath, "apply", "--dry-run"], {
+      env: { ...process.env, NO_COLOR: "1" },
+    });
+
+    assert.match(stdout, /Would update package\.json/);
+    assert.match(stdout, /Would write and own \.editorconfig/);
+    assert.match(
+      stdout,
+      /Would omit script format: format was requested but no formatter integration is selected\./,
     );
   } finally {
     process.chdir(originalDirectory);

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -9,14 +9,14 @@ Use Calavera to compose and apply project tooling through its MCP tools whenever
 
 ## Start Here
 
-1. Confirm whether Calavera MCP tools are available. Look for tools named `list_profiles`, `list_integrations`, `list_ai_artifacts`, `compose_recipe`, `dry_run_apply`, and `apply_recipe`.
-2. Inspect the project for existing tooling and likely conflicts before composing a recipe. Check files such as `package.json`, `calavera.config.json`, `.editorconfig`, `eslint.config.js`, `oxlint.json`, `.prettierrc.json`, `.stylelintrc.json`, and `tsconfig.json`.
+1. Confirm whether Calavera MCP tools are available. Look for tools named `inspect_project`, `list_profiles`, `list_integrations`, `list_ai_artifacts`, `compose_recipe`, `dry_run_apply`, and `apply_recipe`.
+2. Call `inspect_project` when available, or inspect the project manually for existing tooling and likely conflicts before composing a recipe. Check files such as `package.json`, `calavera.config.json`, `.editorconfig`, `eslint.config.js`, `oxlint.json`, `.prettierrc.json`, `.stylelintrc.json`, and `tsconfig.json`.
    If likely conflicts exist, pause before applying changes. List each conflict as a hard stop or a migration decision the user can approve, and use `dry_run_apply` to show concrete impact when adoption still looks possible.
 3. Use AskUserTool or the agent client's equivalent when available to clarify profile preferences, framework needs, conflict decisions, and apply approval. If no such tool exists, ask the user directly.
 4. List choices with `list_profiles`, `list_integrations`, and `list_ai_artifacts`. Use `describe_integration` when the user asks for more information or when you need to compare options.
 5. Once the profile and requirements are clear, compose the recipe with `compose_recipe`.
 6. Validate and explain it with `validate_recipe` and `explain_recipe`.
-7. Present `dry_run_apply` output to the user before changing files.
+7. Present `dry_run_apply` output to the user before changing files, including inspection findings, omitted script explanations, ownership notes, and planned file changes.
 8. Call `apply_recipe` only after the user explicitly approves the dry run.
 9. If the MCP transport closes or reports `-32000` during or immediately after `apply_recipe`, treat the outcome as unknown instead of failed. Inspect `calavera.config.json`, `.calavera/state.json`, generated files, and package metadata before retrying the apply.
 

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -14,11 +14,12 @@ Use Calavera to compose and apply project tooling through its MCP tools whenever
    If likely conflicts exist, pause before applying changes. List each conflict as a hard stop or a migration decision the user can approve, and use `dry_run_apply` to show concrete impact when adoption still looks possible.
 3. Use AskUserTool or the agent client's equivalent when available to clarify profile preferences, framework needs, conflict decisions, and apply approval. If no such tool exists, ask the user directly.
 4. List choices with `list_profiles`, `list_integrations`, and `list_ai_artifacts`. Use `describe_integration` when the user asks for more information or when you need to compare options.
-5. Once the profile and requirements are clear, compose the recipe with `compose_recipe`.
-6. Validate and explain it with `validate_recipe` and `explain_recipe`.
-7. Present `dry_run_apply` output to the user before changing files, including inspection findings, omitted script explanations, ownership notes, and planned file changes.
-8. Call `apply_recipe` only after the user explicitly approves the dry run.
-9. If the MCP transport closes or reports `-32000` during or immediately after `apply_recipe`, treat the outcome as unknown instead of failed. Inspect `calavera.config.json`, `.calavera/state.json`, generated files, and package metadata before retrying the apply.
+5. Choose either Oxfmt or Prettier for formatting, never both.
+6. Once the profile and requirements are clear, compose the recipe with `compose_recipe`.
+7. Validate and explain it with `validate_recipe` and `explain_recipe`.
+8. Present `dry_run_apply` output to the user before changing files, including inspection findings, omitted script explanations, ownership notes, and planned file changes.
+9. Call `apply_recipe` only after the user explicitly approves the dry run.
+10. If the MCP transport closes or reports `-32000` during or immediately after `apply_recipe`, treat the outcome as unknown instead of failed. Inspect `calavera.config.json`, `.calavera/state.json`, generated files, and package metadata before retrying the apply.
 
 Do not hand-author `calavera.config.json` when the Calavera MCP server is available. Let Calavera compose, validate, dry-run, and apply the recipe so generated files, package scripts, dependencies, AI artifacts, and managed state stay consistent.
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ import {
   profileIdsForRecipe,
   profileDefaults,
   resolveRecipeIntegrations,
+  validateRecipe,
   validateRecipeResponse,
 } from "./recipe.js";
 import { assertKnownValue } from "./utils/assertions.js";
@@ -767,6 +768,7 @@ function createAgentBootstrapGuidanceBody() {
 - Inspect existing project tooling before composing a recipe and raise likely config conflicts early.
 - If likely conflicts exist, pause before applying changes. List each conflict as a hard stop or a migration decision the user can approve, and use \`dry_run_apply\` to show concrete impact when adoption still looks possible.
 - Start with \`inspect_project\`, \`list_profiles\`, \`list_integrations\`, and \`list_ai_artifacts\`; use \`describe_integration\` when the user asks for more information or an option needs explanation.
+- Choose either Oxfmt or Prettier for formatting; do not select both in the same recipe.
 - Compose recipes with \`compose_recipe\`, validate them with \`validate_recipe\`, and explain the selected integrations with \`explain_recipe\`.
 - Always present \`dry_run_apply\` output to the user before changing files.
 - Call \`apply_recipe\` only after the user explicitly approves the dry-run result.
@@ -942,7 +944,7 @@ Calavera-managed helper for generated package scripts. Do not hand-write or edit
 that file; let \`apply_recipe\` or \`create-project-calavera apply\` create it
 after approval.
 
-Before composing a recipe, call \`inspect_project\` or inspect the project for existing tooling files such as \`package.json\`, \`calavera.config.json\`, \`.editorconfig\`, \`eslint.config.js\`, \`oxlint.json\`, \`.prettierrc.json\`, \`.stylelintrc.json\`, and \`tsconfig.json\`. Mention likely conflicts or local conventions before proposing changes. If conflicts exist, say whether they are hard stops or migration decisions, then use \`dry_run_apply\` to show the impact when adoption is still possible.
+Before composing a recipe, call \`inspect_project\` or inspect the project for existing tooling files such as \`package.json\`, \`calavera.config.json\`, \`.editorconfig\`, \`eslint.config.js\`, \`oxlint.json\`, \`.prettierrc.json\`, \`.stylelintrc.json\`, and \`tsconfig.json\`. Mention likely conflicts or local conventions before proposing changes. If conflicts exist, say whether they are hard stops or migration decisions, then use \`dry_run_apply\` to show the impact when adoption is still possible. Do not combine Oxfmt and Prettier in one recipe.
 
 If the MCP server cannot be registered, use the hosted Web UI to compose and download a recipe:
 
@@ -1475,6 +1477,8 @@ export async function applyRecipe(options) {
  * @returns {Promise<ApplyResult>}
  */
 export async function applyRecipeObject(recipe, options = {}) {
+  validateRecipe(recipe);
+
   const applyOptions = {
     dryRun: false,
     json: false,

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,11 @@ import {
   optionalStringArray,
 } from "./state.js";
 import {
+  integrationConfigFiles,
+  packageManagerLockfiles,
+  projectInspectionFiles,
+} from "./project-inspection.js";
+import {
   composeRecipe,
   explainRecipeResponse,
   listAiArtifactOptions,
@@ -424,19 +429,19 @@ function detectPackageManager(packageJSON = {}) {
     return /** @type {PackageManager} */ (devPackageManager);
   }
 
-  if (existsSync("pnpm-lock.yaml") || existsSync("shrinkwrap.yaml")) {
+  if (packageManagerLockfiles.pnpm.some((path) => existsSync(path))) {
     return "pnpm";
   }
 
-  if (existsSync("yarn.lock")) {
+  if (packageManagerLockfiles.yarn.some((path) => existsSync(path))) {
     return "yarn";
   }
 
-  if (existsSync("bun.lock") || existsSync("bun.lockb")) {
+  if (packageManagerLockfiles.bun.some((path) => existsSync(path))) {
     return "bun";
   }
 
-  if (existsSync("package-lock.json")) {
+  if (packageManagerLockfiles.npm.some((path) => existsSync(path))) {
     return "npm";
   }
 
@@ -944,7 +949,12 @@ Calavera-managed helper for generated package scripts. Do not hand-write or edit
 that file; let \`apply_recipe\` or \`create-project-calavera apply\` create it
 after approval.
 
-Before composing a recipe, call \`inspect_project\` or inspect the project for existing tooling files such as \`package.json\`, \`calavera.config.json\`, \`.editorconfig\`, \`eslint.config.js\`, \`oxlint.json\`, \`.prettierrc.json\`, \`.stylelintrc.json\`, and \`tsconfig.json\`. Mention likely conflicts or local conventions before proposing changes. If conflicts exist, say whether they are hard stops or migration decisions, then use \`dry_run_apply\` to show the impact when adoption is still possible. Do not combine Oxfmt and Prettier in one recipe.
+## Formatter choice
+
+Choose one formatter per project. Do not combine Oxfmt and Prettier in one
+recipe; they would compete for the same formatting scripts and config ownership.
+
+Before composing a recipe, call \`inspect_project\` or inspect the project for existing tooling files such as \`package.json\`, \`calavera.config.json\`, \`.editorconfig\`, \`eslint.config.js\`, \`oxlint.json\`, \`.prettierrc.json\`, \`.stylelintrc.json\`, and \`tsconfig.json\`. Mention likely conflicts or local conventions before proposing changes. If conflicts exist, say whether they are hard stops or migration decisions, then use \`dry_run_apply\` to show the impact when adoption is still possible.
 
 If the MCP server cannot be registered, use the hosted Web UI to compose and download a recipe:
 
@@ -1256,49 +1266,6 @@ function plannedManagedFiles(integrations) {
 
   return plans;
 }
-
-const projectInspectionFiles = [
-  "package.json",
-  "package-lock.json",
-  "npm-shrinkwrap.json",
-  "pnpm-lock.yaml",
-  "yarn.lock",
-  "bun.lock",
-  "bun.lockb",
-  "calavera.config.json",
-  ".editorconfig",
-  "eslint.config.js",
-  "oxlint.json",
-  ".prettierrc.json",
-  ".prettierignore",
-  ".stylelintrc.json",
-  "react-doctor.config.json",
-  "tsconfig.json",
-  "vite.config.js",
-  "vite.config.ts",
-  "next.config.js",
-  "next.config.mjs",
-  "astro.config.mjs",
-  "svelte.config.js",
-];
-
-const packageManagerLockfiles = {
-  npm: ["package-lock.json", "npm-shrinkwrap.json"],
-  pnpm: ["pnpm-lock.yaml"],
-  yarn: ["yarn.lock"],
-  bun: ["bun.lock", "bun.lockb"],
-};
-
-const integrationConfigFiles = {
-  editorconfig: [".editorconfig"],
-  eslint: ["eslint.config.js"],
-  oxlint: ["oxlint.json"],
-  oxfmt: [],
-  prettier: [".prettierrc.json", ".prettierignore"],
-  "react-doctor": ["react-doctor.config.json"],
-  stylelint: [".stylelintrc.json"],
-  typescript: ["tsconfig.json"],
-};
 
 /**
  * @param {string} path

--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,11 @@ import { pluralizeCount, style, titleCase } from "./utils/text.js";
  * @property {Record<string, boolean>} [scripts]
  * @property {unknown} [ai]
  *
- * @typedef {{ type: string, path: string, category?: "ai", aiType?: string, name?: string, reason?: string, scripts?: string[], removedDefaultTestScript?: boolean }} Change
+ * @typedef {{ script: string, reason: string }} ScriptOmission
+ * @typedef {{ severity: "info" | "warning" | "error", kind: string, message: string, path?: string }} ProjectInspectionFinding
+ * @typedef {{ packageManager?: PackageManager, files: string[], findings: ProjectInspectionFinding[] }} ProjectInspection
+ * @typedef {{ scripts: Record<string, string>, omittedScripts: ScriptOmission[] }} ScriptPlan
+ * @typedef {{ type: string, path: string, action?: "write" | "update" | "scaffold" | "merge", ownership?: "calavera" | "project", category?: "ai", aiType?: string, name?: string, reason?: string, scripts?: string[], omittedScripts?: ScriptOmission[], removedDefaultTestScript?: boolean }} Change
  *
  * @typedef {object} ApplyResult
  * @property {"apply"} command
@@ -113,6 +117,7 @@ import { pluralizeCount, style, titleCase } from "./utils/text.js";
  * @property {PackageManager} packageManager
  * @property {string[]} dependencies
  * @property {string[]} integrations
+ * @property {ProjectInspection} projectInspection
  * @property {Change[]} changes
  * @property {string[]} pointers
  *
@@ -426,7 +431,7 @@ function detectPackageManager(packageJSON = {}) {
     return "yarn";
   }
 
-  if (existsSync("bun.lockb")) {
+  if (existsSync("bun.lock") || existsSync("bun.lockb")) {
     return "bun";
   }
 
@@ -521,7 +526,7 @@ function runIfFiles(label, extensions, command) {
  * @param {Recipe} recipe
  * @param {Integration[]} integrations
  * @param {PackageManager} packageManager
- * @returns {Record<string, string>}
+ * @returns {ScriptPlan}
  */
 function buildScripts(recipe, integrations, packageManager) {
   const supportedPackageManager = assertSupportedPackageManager(packageManager);
@@ -555,13 +560,25 @@ function buildScripts(recipe, integrations, packageManager) {
 
   /** @type {Record<string, string>} */
   const scripts = {};
+  /** @type {ScriptOmission[]} */
+  const omittedScripts = [];
 
   if (recipe.scripts?.lint && lintParts.length > 0) {
     scripts.lint = lintParts.join(" && ");
+  } else if (recipe.scripts?.lint) {
+    omittedScripts.push({
+      script: "lint",
+      reason: "lint was requested but no linting integration is selected.",
+    });
   }
 
   if (recipe.scripts?.["lint:fix"] && lintFixParts.length > 0) {
     scripts["lint:fix"] = lintFixParts.join(" && ");
+  } else if (recipe.scripts?.["lint:fix"]) {
+    omittedScripts.push({
+      script: "lint:fix",
+      reason: "lint:fix was requested but no fix-capable linting integration is selected.",
+    });
   }
 
   if (recipe.scripts?.format) {
@@ -573,6 +590,11 @@ function buildScripts(recipe, integrations, packageManager) {
       );
     } else if (usesPrettier) {
       scripts.format = "prettier --write .";
+    } else {
+      omittedScripts.push({
+        script: "format",
+        reason: "format was requested but no formatter integration is selected.",
+      });
     }
   }
 
@@ -585,6 +607,11 @@ function buildScripts(recipe, integrations, packageManager) {
       );
     } else if (usesPrettier) {
       scripts["format:check"] = "prettier --check .";
+    } else {
+      omittedScripts.push({
+        script: "format:check",
+        reason: "format:check was requested but no formatter integration is selected.",
+      });
     }
   }
 
@@ -594,6 +621,11 @@ function buildScripts(recipe, integrations, packageManager) {
       SCRIPT_SOURCE_EXTENSIONS,
       "tsc --noEmit",
     );
+  } else if (recipe.scripts?.typecheck) {
+    omittedScripts.push({
+      script: "typecheck",
+      reason: "typecheck was requested but the TypeScript integration is not selected.",
+    });
   }
 
   if (usesReactDoctor) {
@@ -615,12 +647,19 @@ function buildScripts(recipe, integrations, packageManager) {
       .filter(isNotEmptyString)
       .filter((script) => Boolean(scripts[script]));
 
-    scripts.quality = qualityScripts
-      .map((script) => packageManagerCommands[supportedPackageManager].run(script))
-      .join(" && ");
+    if (qualityScripts.length > 0) {
+      scripts.quality = qualityScripts
+        .map((script) => packageManagerCommands[supportedPackageManager].run(script))
+        .join(" && ");
+    } else {
+      omittedScripts.push({
+        script: "quality",
+        reason: "quality was requested but no generated scripts are available to aggregate.",
+      });
+    }
   }
 
-  return scripts;
+  return { scripts, omittedScripts };
 }
 
 function createRunIfFilesHelper() {
@@ -727,7 +766,7 @@ function createAgentBootstrapGuidanceBody() {
 - If the Calavera MCP tools are not available, help the user register the MCP server from \`${AGENT_BOOTSTRAP_MCP_FILE}\` or fall back to the Calavera Web UI.
 - Inspect existing project tooling before composing a recipe and raise likely config conflicts early.
 - If likely conflicts exist, pause before applying changes. List each conflict as a hard stop or a migration decision the user can approve, and use \`dry_run_apply\` to show concrete impact when adoption still looks possible.
-- Start with \`list_profiles\`, \`list_integrations\`, and \`list_ai_artifacts\`; use \`describe_integration\` when the user asks for more information or an option needs explanation.
+- Start with \`inspect_project\`, \`list_profiles\`, \`list_integrations\`, and \`list_ai_artifacts\`; use \`describe_integration\` when the user asks for more information or an option needs explanation.
 - Compose recipes with \`compose_recipe\`, validate them with \`validate_recipe\`, and explain the selected integrations with \`explain_recipe\`.
 - Always present \`dry_run_apply\` output to the user before changing files.
 - Call \`apply_recipe\` only after the user explicitly approves the dry-run result.
@@ -878,17 +917,20 @@ runs \`${shellCommand}\`. Ask for explicit user approval before creating
 
 Use the tools in this order:
 
-1. \`list_profiles\`
-2. \`list_integrations\`
-3. \`describe_integration\`
-4. \`list_ai_artifacts\`
-5. \`compose_recipe\`
-6. \`validate_recipe\`
-7. \`explain_recipe\`
-8. \`dry_run_apply\`
-9. \`apply_recipe\`
+1. \`inspect_project\`
+2. \`list_profiles\`
+3. \`list_integrations\`
+4. \`describe_integration\`
+5. \`list_ai_artifacts\`
+6. \`compose_recipe\`
+7. \`validate_recipe\`
+8. \`explain_recipe\`
+9. \`dry_run_apply\`
+10. \`apply_recipe\`
 
-\`dry_run_apply\` is the review boundary. Show its result to the user and wait for explicit approval before calling \`apply_recipe\`.
+\`dry_run_apply\` is the review boundary. Show its inspection findings, omitted
+script explanations, ownership notes, and planned file changes to the user, then
+wait for explicit approval before calling \`apply_recipe\`.
 
 If the MCP transport closes or reports \`-32000\` during or immediately after
 \`apply_recipe\`, treat the apply outcome as unknown instead of failed. Inspect
@@ -900,7 +942,7 @@ Calavera-managed helper for generated package scripts. Do not hand-write or edit
 that file; let \`apply_recipe\` or \`create-project-calavera apply\` create it
 after approval.
 
-Before composing a recipe, inspect the project for existing tooling files such as \`package.json\`, \`calavera.config.json\`, \`.editorconfig\`, \`eslint.config.js\`, \`oxlint.json\`, \`.prettierrc.json\`, \`.stylelintrc.json\`, and \`tsconfig.json\`. Mention likely conflicts or local conventions before proposing changes. If conflicts exist, say whether they are hard stops or migration decisions, then use \`dry_run_apply\` to show the impact when adoption is still possible.
+Before composing a recipe, call \`inspect_project\` or inspect the project for existing tooling files such as \`package.json\`, \`calavera.config.json\`, \`.editorconfig\`, \`eslint.config.js\`, \`oxlint.json\`, \`.prettierrc.json\`, \`.stylelintrc.json\`, and \`tsconfig.json\`. Mention likely conflicts or local conventions before proposing changes. If conflicts exist, say whether they are hard stops or migration decisions, then use \`dry_run_apply\` to show the impact when adoption is still possible.
 
 If the MCP server cannot be registered, use the hosted Web UI to compose and download a recipe:
 
@@ -1114,7 +1156,7 @@ async function assertSafeManagedFileWrites(filePlans, previousState) {
  * @returns {Promise<ManagedFileState>}
  */
 async function writeManagedFile(path, contents, dryRun, changes, previousState) {
-  changes.push({ type: "write", path });
+  changes.push({ type: "write", path, action: "write", ownership: "calavera" });
 
   const managedFile = {
     path,
@@ -1213,6 +1255,210 @@ function plannedManagedFiles(integrations) {
   return plans;
 }
 
+const projectInspectionFiles = [
+  "package.json",
+  "package-lock.json",
+  "npm-shrinkwrap.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "bun.lock",
+  "bun.lockb",
+  "calavera.config.json",
+  ".editorconfig",
+  "eslint.config.js",
+  "oxlint.json",
+  ".prettierrc.json",
+  ".prettierignore",
+  ".stylelintrc.json",
+  "react-doctor.config.json",
+  "tsconfig.json",
+  "vite.config.js",
+  "vite.config.ts",
+  "next.config.js",
+  "next.config.mjs",
+  "astro.config.mjs",
+  "svelte.config.js",
+];
+
+const packageManagerLockfiles = {
+  npm: ["package-lock.json", "npm-shrinkwrap.json"],
+  pnpm: ["pnpm-lock.yaml"],
+  yarn: ["yarn.lock"],
+  bun: ["bun.lock", "bun.lockb"],
+};
+
+const integrationConfigFiles = {
+  editorconfig: [".editorconfig"],
+  eslint: ["eslint.config.js"],
+  oxlint: ["oxlint.json"],
+  oxfmt: [],
+  prettier: [".prettierrc.json", ".prettierignore"],
+  "react-doctor": ["react-doctor.config.json"],
+  stylelint: [".stylelintrc.json"],
+  typescript: ["tsconfig.json"],
+};
+
+/**
+ * @param {string} path
+ * @returns {Promise<boolean>}
+ */
+async function projectFileExists(path) {
+  return fileExists(resolve(path));
+}
+
+/**
+ * @param {{ path: string, contents: string }} filePlan
+ * @param {CalaveraState} previousState
+ * @returns {Promise<ProjectInspectionFinding | undefined>}
+ */
+async function inspectManagedFilePlan(filePlan, previousState) {
+  if (!(await projectFileExists(filePlan.path))) {
+    return undefined;
+  }
+
+  const targetHash = textHash(filePlan.contents);
+  const installedHash = textHash(await readFile(filePlan.path, "utf8"));
+
+  if (installedHash === targetHash) {
+    return undefined;
+  }
+
+  const stateFile = managedFileStateForPath(previousState, filePlan.path);
+
+  if (stateFile?.hash === installedHash) {
+    return undefined;
+  }
+
+  return {
+    severity: "error",
+    kind: "managed-file-conflict",
+    path: filePlan.path,
+    message: `${filePlan.path} already exists and is not a matching Calavera-managed file; review, remove, or migrate it before applying this recipe.`,
+  };
+}
+
+/**
+ * @param {Recipe} [recipe]
+ * @returns {Promise<ProjectInspection>}
+ */
+export async function inspectProject(recipe) {
+  const packageJSON = await readPackageJSONIfPresent();
+  const previousState = await readStateIfPresent();
+  const packageManager = detectPackageManager(packageJSON);
+  const integrations = recipe ? resolveRecipeIntegrations(recipe) : [];
+  const integrationIds = new Set(integrations.map((integration) => integration.id));
+  /** @type {string[]} */
+  const files = [];
+  /** @type {ProjectInspectionFinding[]} */
+  const findings = [];
+
+  for (const path of projectInspectionFiles) {
+    if (await projectFileExists(path)) {
+      files.push(path);
+    }
+  }
+
+  if (packageManager) {
+    findings.push({
+      severity: "info",
+      kind: "package-manager",
+      message: `Detected ${packageManager} as the project package manager.`,
+    });
+  }
+
+  const presentLockfiles = Object.values(packageManagerLockfiles)
+    .flat()
+    .filter((path) => files.includes(path));
+
+  if (presentLockfiles.length > 1) {
+    findings.push({
+      severity: "warning",
+      kind: "multiple-lockfiles",
+      message: `Multiple package-manager lockfiles are present: ${presentLockfiles.join(", ")}. Confirm which package manager owns installs before applying.`,
+    });
+  }
+
+  if (recipe?.packageManager && packageManager && recipe.packageManager !== packageManager) {
+    findings.push({
+      severity: "warning",
+      kind: "package-manager-mismatch",
+      path: "package.json",
+      message: `The recipe uses ${recipe.packageManager}, but project inspection detected ${packageManager}; this is a migration decision that should be approved before applying.`,
+    });
+  }
+
+  const packageScripts = packageJSON.scripts ?? {};
+  for (const scriptName of ["lint", "lint:fix", "format", "format:check", "typecheck"]) {
+    if (recipe?.scripts?.[scriptName] && typeof packageScripts[scriptName] === "string") {
+      findings.push({
+        severity: "warning",
+        kind: "existing-package-script",
+        path: "package.json",
+        message: `package.json already defines "${scriptName}"; Calavera will replace that script if this recipe is applied.`,
+      });
+    }
+  }
+
+  for (const filePlan of plannedManagedFiles(integrations)) {
+    const finding = await inspectManagedFilePlan(filePlan, previousState);
+
+    if (finding) {
+      findings.push(finding);
+    }
+  }
+
+  for (const [integrationId, paths] of Object.entries(integrationConfigFiles)) {
+    if (!integrationIds.has(integrationId)) {
+      continue;
+    }
+
+    for (const path of paths) {
+      if (files.includes(path)) {
+        findings.push({
+          severity: "warning",
+          kind: "existing-config",
+          path,
+          message: `${path} already exists; adopting the ${integrationId} integration may be a migration decision rather than a clean scaffold.`,
+        });
+      }
+    }
+  }
+
+  if (
+    integrationIds.has("oxlint") &&
+    files.includes("eslint.config.js") &&
+    !integrationIds.has("eslint")
+  ) {
+    findings.push({
+      severity: "warning",
+      kind: "equivalent-tooling",
+      path: "eslint.config.js",
+      message:
+        "eslint.config.js exists while Oxlint is selected; decide whether this project should migrate linting or keep the existing ESLint setup.",
+    });
+  }
+
+  if (
+    integrationIds.has("eslint") &&
+    files.includes("oxlint.json") &&
+    !integrationIds.has("oxlint")
+  ) {
+    findings.push({
+      severity: "warning",
+      kind: "equivalent-tooling",
+      path: "oxlint.json",
+      message:
+        "oxlint.json exists while ESLint is selected; decide whether this project should migrate linting or keep the existing Oxlint setup.",
+    });
+  }
+
+  return {
+    packageManager,
+    files,
+    findings,
+  };
+}
+
 /**
  * @param {CliOptions} options
  * @returns {Promise<ApplyResult>}
@@ -1249,7 +1495,10 @@ export async function applyRecipeObject(recipe, options = {}) {
     applyOptions.assumeYes,
     applyOptions.json,
   );
-  const scripts = buildScripts(recipe, integrations, packageManager);
+  const projectInspection = await inspectProject(recipe);
+  const scriptPlan = buildScripts(recipe, integrations, packageManager);
+  const { scripts, omittedScripts } = scriptPlan;
+  /** @type {Change[]} */
   const changes = [];
   /** @type {ManagedFileState[]} */
   const managedFiles = [];
@@ -1267,7 +1516,10 @@ export async function applyRecipeObject(recipe, options = {}) {
   changes.push({
     type: "update",
     path: "package.json",
+    action: "update",
+    ownership: "project",
     scripts: Object.keys(scripts),
+    omittedScripts,
     removedDefaultTestScript,
   });
 
@@ -1411,6 +1663,7 @@ export async function applyRecipeObject(recipe, options = {}) {
     packageManager,
     dependencies: dependencyList,
     integrations: integrations.map((integration) => integration.id),
+    projectInspection,
     changes: [...changes, ...aiResult.changes],
     pointers: aiResult.pointers,
   };
@@ -2371,13 +2624,23 @@ function printResult(result, asJSON = false) {
       logger.info("Dev dependencies: none");
     }
 
+    for (const finding of result.projectInspection.findings) {
+      logger.info(`Inspection ${finding.severity}: ${finding.message}`);
+    }
+
     for (const change of result.changes) {
       if (change.type === "write") {
-        logger.info(
-          change.category === "ai"
-            ? `Would write AI ${change.aiType} ${change.name} to ${change.path}`
-            : `Would write ${change.path}`,
-        );
+        if (change.category === "ai") {
+          logger.info(`Would write AI ${change.aiType} ${change.name} to ${change.path}`);
+        } else if (change.ownership === "calavera") {
+          logger.info(`Would write and own ${change.path}`);
+        } else if (change.action === "scaffold") {
+          logger.info(`Would scaffold ${change.path}`);
+        } else if (change.action === "merge") {
+          logger.info(`Would merge ${change.path}`);
+        } else {
+          logger.info(`Would write ${change.path}`);
+        }
       }
 
       if (change.type === "update") {
@@ -2389,6 +2652,10 @@ function printResult(result, asJSON = false) {
 
         if (change.removedDefaultTestScript) {
           logger.info("Would remove the default npm test placeholder script");
+        }
+
+        for (const omittedScript of change.omittedScripts ?? []) {
+          logger.info(`Would omit script ${omittedScript.script}: ${omittedScript.reason}`);
         }
       }
     }

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 import packageJson from "../package.json" with { type: "json" };
 import * as z from "zod";
 
-import { applyRecipeObject } from "./index.js";
+import { applyRecipeObject, inspectProject } from "./index.js";
 import {
   composeRecipeResponse,
   describeIntegrationResponse,
@@ -34,7 +34,7 @@ import { writeJSON } from "./utils/fs.js";
 const SERVER_NAME = "create-project-calavera";
 const SERVER_VERSION = packageJson.version;
 const SERVER_INSTRUCTIONS =
-  "Compose Calavera recipes for the current project. Start with list_profiles, list_integrations, describe_integration when details are needed, and list_ai_artifacts to discover valid IDs, then call compose_recipe, validate_recipe, explain_recipe, and dry_run_apply. Present the dry-run summary to the user and call apply_recipe only after explicit approval.";
+  "Compose Calavera recipes for the current project. Start with inspect_project, list_profiles, list_integrations, describe_integration when details are needed, and list_ai_artifacts to discover valid IDs, then call compose_recipe, validate_recipe, explain_recipe, and dry_run_apply. Present the dry-run summary to the user and call apply_recipe only after explicit approval.";
 
 const profileIds = profileIdsForRecipe();
 const packageManagerIds = packageManagerIdsForRecipe();
@@ -63,6 +63,13 @@ const toolConfigs = {
   list_profiles: {
     description: recipeToolDescriptions.list_profiles,
     inputSchema: {},
+    annotations: toolAnnotations.read,
+  },
+  inspect_project: {
+    description: recipeToolDescriptions.inspect_project,
+    inputSchema: {
+      recipe: recipeSchema.optional().describe(recipeToolInputDescriptions.recipe),
+    },
     annotations: toolAnnotations.read,
   },
   list_integrations: {
@@ -193,6 +200,14 @@ function listProfilesTool() {
 /**
  * @param {Record<string, unknown>} args
  */
+async function inspectProjectTool(args) {
+  const recipe = args.recipe === undefined ? undefined : assertRecipeInput(args.recipe);
+  return inspectProject(recipe);
+}
+
+/**
+ * @param {Record<string, unknown>} args
+ */
 function listIntegrationsTool(args) {
   return listIntegrationsResponse({ profile: /** @type {string | undefined} */ (args.profile) });
 }
@@ -301,6 +316,8 @@ export async function callMcpTool(name, input = {}) {
   switch (name) {
     case "list_profiles":
       return listProfilesTool();
+    case "inspect_project":
+      return inspectProjectTool(args);
     case "list_integrations":
       return listIntegrationsTool(args);
     case "describe_integration":

--- a/src/project-inspection.js
+++ b/src/project-inspection.js
@@ -1,0 +1,30 @@
+export const packageManagerLockfiles = Object.freeze({
+  npm: ["package-lock.json", "npm-shrinkwrap.json"],
+  pnpm: ["pnpm-lock.yaml", "shrinkwrap.yaml"],
+  yarn: ["yarn.lock"],
+  bun: ["bun.lock", "bun.lockb"],
+});
+
+export const integrationConfigFiles = Object.freeze({
+  editorconfig: [".editorconfig"],
+  eslint: ["eslint.config.js"],
+  oxlint: ["oxlint.json"],
+  oxfmt: [],
+  prettier: [".prettierrc.json", ".prettierignore"],
+  "react-doctor": ["react-doctor.config.json"],
+  stylelint: [".stylelintrc.json"],
+  typescript: ["tsconfig.json"],
+});
+
+export const projectInspectionFiles = Object.freeze([
+  "package.json",
+  "calavera.config.json",
+  ...Object.values(packageManagerLockfiles).flat(),
+  ...Object.values(integrationConfigFiles).flat(),
+  "vite.config.js",
+  "vite.config.ts",
+  "next.config.js",
+  "next.config.mjs",
+  "astro.config.mjs",
+  "svelte.config.js",
+]);

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -239,6 +239,18 @@ function integrationProfiles(id) {
   return profileSpecificIntegrations[id] ?? profileIds;
 }
 
+function assertNoFormatterConflict(integrationIds) {
+  const resolvedIntegrationIds = new Set(
+    resolveRecipeIntegrations({ integrations: integrationIds }).map(({ id }) => id),
+  );
+
+  if (resolvedIntegrationIds.has("oxfmt") && resolvedIntegrationIds.has("prettier")) {
+    throw new Error(
+      "Choose either Oxfmt or Prettier, not both. Calavera should not install two formatters for the same project.",
+    );
+  }
+}
+
 function integrationIdForInput(value, integrationOptions = integrationCatalog) {
   const token = normalizedToken(value);
   const match = integrationOptions.find(
@@ -419,6 +431,8 @@ export function validateRecipeCompositionInput({
     );
   }
 
+  assertNoFormatterConflict(integrationIds);
+
   return {
     profile,
     packageManager,
@@ -509,6 +523,8 @@ export function validateRecipe(recipe) {
   if (unknownIntegrationIds.length > 0) {
     throw new Error(`Unknown integrations: ${unknownIntegrationIds.join(", ")}.`);
   }
+
+  assertNoFormatterConflict(recipe.integrations);
 
   if (Object.hasOwn(recipe, "ai")) {
     assertObjectArray("ai", recipe.ai);

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -103,6 +103,7 @@ export const recipeCompositionToolNames = Object.freeze([
 ]);
 
 export const standardMcpToolNames = Object.freeze([
+  "inspect_project",
   ...recipeCompositionToolNames,
   "dry_run_apply",
   "apply_recipe",
@@ -111,6 +112,8 @@ export const standardMcpToolNames = Object.freeze([
 export const webMcpToolNames = Object.freeze([...recipeCompositionToolNames, "download_recipe"]);
 
 export const recipeToolDescriptions = Object.freeze({
+  inspect_project:
+    "Inspect the current project for package-manager signals, existing tooling files, and likely Calavera adoption conflicts before composing or applying a recipe.",
   list_profiles:
     "List Calavera profiles, package managers, and default integrations. Use this first when composing a recipe.",
   list_integrations:


### PR DESCRIPTION
## Summary

Add a grouped release pass for project inspection and clearer dry-run output:

- add a standard MCP `inspect_project` tool that reports package-manager signals, known tooling files, existing scripts, likely migration decisions, and managed-file hard stops
- include the same project inspection findings in apply/dry-run results
- explain requested script flags that are intentionally omitted because no selected integration can generate them
- annotate dry-run changes with ownership/action metadata and render managed writes as `Would write and own ...` in human output
- update README, generated agent/MCP guidance, bundled Calavera skill guidance, and changelog notes

## Validation

- `node --test scripts/check-config-schema.test.mjs`
- `pnpm test`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `git diff --check`

fix #227
fix #229
fix #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project inspection guidance and output so users can see detected tooling, potential conflicts, and planned changes before applying a recipe.
  * Expanded dry-run details to include omitted script explanations and ownership notes for generated files.

* **Bug Fixes**
  * Rejected recipes that try to combine Oxfmt and Prettier in the same project.
  * Improved package manager detection and conflict checks for more reliable project handling.

* **Documentation**
  * Updated the README and changelog with the latest workflow, CLI, and agent guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->