### PR TITLE
Harden Calavera MCP-first agent guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Vite, another scaffold tool, or a manually maintained repository:
 2. Run `npm create project-calavera -- --init`.
 3. Register the MCP server using the generated `.agents/calavera/mcp.md` notes.
 4. Restart or reload the agent session if your MCP host does not discover new tools dynamically.
-5. Confirm the Calavera MCP tools are exposed: `inspect_project`, `list_profiles`, `list_integrations`, `list_ai_artifacts`, `compose_recipe`, `dry_run_apply`, and `apply_recipe`.
+5. Confirm the Calavera MCP tools are exposed: `inspect_project`, `list_profiles`, `list_integrations`, `list_ai_artifacts`, `compose_recipe`, `validate_recipe`, `explain_recipe`, `dry_run_apply`, and `apply_recipe`.
 6. Start the agent from the project root.
-7. Agent prompt: `Use Calavera for this project. First verify that the Calavera MCP tools are available. If they are not available, stop and help me configure the MCP server before composing or applying anything. Once the tools are available, inspect the current project for existing tooling and possible config conflicts, list the available profiles, integrations, and AI artifacts, compose a recipe, show me the dry-run result, and apply it only after I approve.`
+7. Agent prompt: `Use Calavera for this project. First verify that the Calavera MCP tools are available. If they are not available, stop and help me configure the MCP server before composing or applying anything. Once the tools are available, inspect the current project for existing tooling and possible config conflicts, list the available profiles, integrations, and AI artifacts, compose a recipe, validate and explain it, show me the dry-run result, and apply it only after I approve.`
 
 Find the equivalent commands for your package manager in the
 [agent-first command table](#agent-first-command-table).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ JavaScript, TypeScript, and library projects, and it works as a complement to
 framework scaffolding tools like Vite+ and `vp create`, giving any project a
 consistent, repeatable setup through a single recipe file.
 
-## Agent-First Flow
+## MCP-First Agent Flow
 
 Use Calavera after a project already exists, whether it came from `vp create`,
 Vite, another scaffold tool, or a manually maintained repository:
@@ -18,8 +18,10 @@ Vite, another scaffold tool, or a manually maintained repository:
 1. Open the project directory.
 2. Run `npm create project-calavera -- --init`.
 3. Register the MCP server using the generated `.agents/calavera/mcp.md` notes.
-4. Start the agent from the project root.
-5. Agent prompt: `Use Calavera for this project. Inspect the current project for existing tooling and possible config conflicts, then list the available profiles, integrations, and AI artifacts. Once the profile and requirements are clear, compose a recipe, show me the dry-run result, and apply it only after I approve.`
+4. Restart or reload the agent session if your MCP host does not discover new tools dynamically.
+5. Confirm the Calavera MCP tools are exposed: `inspect_project`, `list_profiles`, `list_integrations`, `list_ai_artifacts`, `compose_recipe`, `dry_run_apply`, and `apply_recipe`.
+6. Start the agent from the project root.
+7. Agent prompt: `Use Calavera for this project. First verify that the Calavera MCP tools are available. If they are not available, stop and help me configure the MCP server before composing or applying anything. Once the tools are available, inspect the current project for existing tooling and possible config conflicts, list the available profiles, integrations, and AI artifacts, compose a recipe, show me the dry-run result, and apply it only after I approve.`
 
 Find the equivalent commands for your package manager in the
 [agent-first command table](#agent-first-command-table).
@@ -36,11 +38,20 @@ Find the equivalent commands for your package manager in the
 `npm create` needs the `--` separator before Calavera flags such as `--init`
 and `--dry-run`. Yarn requires Yarn 2+ for `dlx`; Yarn 1.x users can use
 `npx --package create-project-calavera create-project-calavera --init`.
+Direct binary launchers such as `npx --package` do not need an extra `--` before
+Calavera flags: use
+`npx --package create-project-calavera create-project-calavera --help`, not
+`npx --package create-project-calavera create-project-calavera -- --help`.
+MCP server registrations launch `create-project-calavera-mcp` directly and
+should not add `--help`.
 
 Agents should treat `dry_run_apply` as the approval boundary. They should show
 the package manager, integrations, dependency packages, inspection findings,
 omitted script explanations, ownership notes, file changes, and AI artifact
 changes before calling `apply_recipe`.
+If MCP tools are not exposed, agents should configure or repair MCP setup first;
+they should not inspect npm cache internals or import Calavera source files from
+package cache paths as a substitute for MCP setup.
 
 Choose one formatter for the project. Calavera rejects recipes that include both
 Oxfmt and Prettier because they would compete for the same formatting scripts

--- a/docs/agent-first-calavera-workflow.md
+++ b/docs/agent-first-calavera-workflow.md
@@ -10,7 +10,7 @@ managed state, `doctor`, `update`, `clean`, and apply dry-run output. Vite+ and
 other starters own routes, components, framework files, starter dependencies,
 and project-specific app commands.
 
-## Recommended Agent Flow
+## Recommended MCP-First Agent Flow
 
 From the project root:
 
@@ -74,10 +74,43 @@ manage the entry. Because the server command runs an external package, Claude
 Code may require explicit approval before creating the persistent registration
 or launching the server for the first time.
 
+After registration, restart or reload the agent session if the MCP host does not
+discover new tools dynamically. Before composing a recipe, confirm these
+Calavera MCP tools are exposed: `inspect_project`, `list_profiles`,
+`list_integrations`, `list_ai_artifacts`, `compose_recipe`, `dry_run_apply`, and
+`apply_recipe`.
+
+Agents should not work around missing MCP tools by reading npm cache internals
+or importing Calavera source files from package cache paths. Configure or repair
+the MCP registration first. If MCP cannot be registered, use the Web UI fallback
+below to compose a recipe, then run the local dry-run command before applying.
+
+### Package-Runner Syntax
+
+`npm create` needs `--` before Calavera flags:
+
+```bash
+npm create project-calavera -- --init
+npm create project-calavera apply -- --dry-run
+```
+
+Direct binary launchers such as `npx --package` do not need an extra `--` before
+Calavera flags:
+
+```bash
+npx --package create-project-calavera create-project-calavera --help
+npx --package create-project-calavera create-project-calavera --init
+```
+
+Avoid `npx --package create-project-calavera create-project-calavera -- --help`;
+that command shape is a package-runner probing mistake, not the recommended
+Calavera workflow. MCP registrations launch `create-project-calavera-mcp`
+directly and should not add `--help`.
+
 Then ask the agent to inspect the project before composing a recipe:
 
 ```text
-Use Calavera for this project. Inspect the current project for existing tooling and possible config conflicts, then list the available profiles, integrations, and AI artifacts. Once the profile and requirements are clear, compose a recipe, show me the dry-run result, and apply it only after I approve.
+Use Calavera for this project. First verify that the Calavera MCP tools are available. If they are not available, stop and help me configure the MCP server before composing or applying anything. Once the tools are available, inspect the current project for existing tooling and possible config conflicts, list the available profiles, integrations, and AI artifacts, compose a recipe, show me the dry-run result, and apply it only after I approve.
 ```
 
 The approval boundary is the dry run. Agents should call `dry_run_apply`, show

--- a/scripts/agent-bootstrap.test.mjs
+++ b/scripts/agent-bootstrap.test.mjs
@@ -26,6 +26,13 @@ test("parseArgs accepts an explicit AGENTS.md handling mode", () => {
   assert.throws(() => parseArgs(["--init", "--agents-md=overwrite"]), /Invalid agents-md/);
 });
 
+test("parseArgs accepts conventional help commands", () => {
+  assert.equal(parseArgs(["--help"]).command, "help");
+  assert.equal(parseArgs(["-h"]).command, "help");
+  assert.equal(parseArgs(["help"]).command, "help");
+  assert.equal(parseArgs(["--", "--help"]).command, "help");
+});
+
 test("agent bootstrap keeps scripted existing AGENTS.md handling non-destructive", async () => {
   await withTempProject(async () => {
     await writeFile("AGENTS.md", "# Existing project guidance\n");
@@ -46,6 +53,22 @@ test("agent bootstrap keeps scripted existing AGENTS.md handling non-destructive
         (change) => change.type === "write" && change.path === "AGENTS.calavera.md",
       ),
     );
+  });
+});
+
+test("agent bootstrap writes MCP-first guardrails", async () => {
+  await withTempProject(async () => {
+    const result = await agentBootstrap();
+    const agentsMd = await readFile("AGENTS.md", "utf8");
+    const mcpNotes = await readFile(".agents/calavera/mcp.md", "utf8");
+
+    assert.match(result.nextPrompt, /First verify that the Calavera MCP tools are available/);
+    assert.match(agentsMd, /Verify the Calavera MCP tools are available/);
+    assert.match(agentsMd, /Do not inspect npm cache internals/);
+    assert.match(mcpNotes, /Confirm the Calavera tools are visible before/);
+    assert.match(mcpNotes, /Do not work around missing MCP tools by reading npm cache internals/);
+    assert.match(mcpNotes, /npx --package create-project-calavera@/);
+    assert.match(mcpNotes, /create-project-calavera --help/);
   });
 });
 

--- a/scripts/agent-bootstrap.test.mjs
+++ b/scripts/agent-bootstrap.test.mjs
@@ -67,6 +67,7 @@ test("agent bootstrap writes MCP-first guardrails", async () => {
     assert.match(agentsMd, /Do not inspect npm cache internals/);
     assert.match(mcpNotes, /Confirm the Calavera tools are visible before/);
     assert.match(mcpNotes, /Do not work around missing MCP tools by reading npm cache internals/);
+    assert.match(mcpNotes, /Do not use it to bypass managed-file conflicts/);
     assert.match(mcpNotes, /npx --package create-project-calavera@/);
     assert.match(mcpNotes, /create-project-calavera --help/);
   });

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -1010,6 +1010,53 @@ test("apply dry runs surface managed file overwrite conflicts", async () => {
   }
 });
 
+test("apply dry runs allow formatting-only drift in managed JSON files", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-dry-run-json-format-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile("package.json", `${JSON.stringify({ scripts: {} }, null, 2)}\n`);
+
+    const recipe = buildRecipe("modern", ["oxlint"], "npm");
+    await applyRecipeObject(recipe, {
+      json: true,
+      noInstall: true,
+      assumeYes: true,
+    });
+
+    const formattedOxlintConfig = `${JSON.stringify(
+      JSON.parse(await readFile("oxlint.json", "utf8")),
+      null,
+      4,
+    )}\n`;
+    await writeFile("oxlint.json", formattedOxlintConfig);
+
+    const inspection = await inspectProject(recipe);
+    assert.equal(
+      inspection.findings.some(
+        (finding) => finding.kind === "managed-file-conflict" && finding.path === "oxlint.json",
+      ),
+      false,
+    );
+
+    const result = await applyRecipeObject(recipe, {
+      dryRun: true,
+      json: true,
+      noInstall: true,
+      assumeYes: true,
+    });
+
+    assert.equal(result.dryRun, true);
+    assert.equal(
+      result.changes.some((change) => change.type === "write" && change.path === "oxlint.json"),
+      true,
+    );
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
 test("apply dry runs explain omitted scripts and managed ownership", async () => {
   const originalDirectory = process.cwd();
   const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-dry-run-omitted-scripts-"));
@@ -1356,6 +1403,52 @@ test("MCP apply_recipe rejects config paths outside the current workspace", asyn
           noInstall: true,
         }),
       /config path must stay inside the current project workspace/,
+    );
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("MCP AI-only apply preserves existing managed tooling state", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-mcp-ai-only-apply-"));
+  const oxlintConfig = `${JSON.stringify({ plugins: ["typescript"] }, null, 2)}\n`;
+
+  try {
+    process.chdir(projectDirectory);
+    await mkdir(".calavera");
+    await writeFile("package.json", `${JSON.stringify({ scripts: {} }, null, 2)}\n`);
+    await writeFile("oxlint.json", oxlintConfig);
+    await writeFile(
+      ".calavera/state.json",
+      `${JSON.stringify(
+        {
+          version: 1,
+          profile: "modern",
+          integrations: ["oxlint"],
+          files: ["oxlint.json"],
+          managedFiles: [{ path: "oxlint.json", hash: textHash(oxlintConfig) }],
+          aiArtifacts: [],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    await callMcpTool("apply_recipe", {
+      recipe: buildRecipe("minimal", [], "npm", [{ type: "skill", src: "skills/semantic-html" }]),
+      writeConfig: false,
+      noInstall: true,
+    });
+
+    await assert.rejects(readFile("calavera.config.json", "utf8"), { code: "ENOENT" });
+
+    const state = JSON.parse(await readFile(".calavera/state.json", "utf8"));
+    assert.deepEqual(state.files, ["oxlint.json"]);
+    assert.deepEqual(state.managedFiles, [{ path: "oxlint.json", hash: textHash(oxlintConfig) }]);
+    assert.equal(
+      state.aiArtifacts.some((artifact) => artifact.path === ".agents/skills/semantic-html"),
+      true,
     );
   } finally {
     process.chdir(originalDirectory);

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -1444,6 +1444,8 @@ test("MCP AI-only apply preserves existing managed tooling state", async () => {
     await assert.rejects(readFile("calavera.config.json", "utf8"), { code: "ENOENT" });
 
     const state = JSON.parse(await readFile(".calavera/state.json", "utf8"));
+    assert.equal(state.profile, "modern");
+    assert.deepEqual(state.integrations, ["oxlint"]);
     assert.deepEqual(state.files, ["oxlint.json"]);
     assert.deepEqual(state.managedFiles, [{ path: "oxlint.json", hash: textHash(oxlintConfig) }]);
     assert.equal(

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -10,16 +10,17 @@ Use Calavera to compose and apply project tooling through its MCP tools whenever
 ## Start Here
 
 1. Confirm whether Calavera MCP tools are available. Look for tools named `inspect_project`, `list_profiles`, `list_integrations`, `list_ai_artifacts`, `compose_recipe`, `dry_run_apply`, and `apply_recipe`.
-2. Call `inspect_project` when available, or inspect the project manually for existing tooling and likely conflicts before composing a recipe. Check files such as `package.json`, `calavera.config.json`, `.editorconfig`, `eslint.config.js`, `oxlint.json`, `.prettierrc.json`, `.stylelintrc.json`, and `tsconfig.json`.
+2. If the Calavera MCP tools are not available, stop and help the user register or repair the MCP server before composing or applying anything. Do not inspect npm cache internals or import Calavera source files from package cache paths as a substitute for MCP setup.
+3. Call `inspect_project` when available, or inspect the project manually only when the MCP server cannot be registered and the user chooses a fallback flow. Check files such as `package.json`, `calavera.config.json`, `.editorconfig`, `eslint.config.js`, `oxlint.json`, `.prettierrc.json`, `.stylelintrc.json`, and `tsconfig.json`.
    If likely conflicts exist, pause before applying changes. List each conflict as a hard stop or a migration decision the user can approve, and use `dry_run_apply` to show concrete impact when adoption still looks possible.
-3. Use AskUserTool or the agent client's equivalent when available to clarify profile preferences, framework needs, conflict decisions, and apply approval. If no such tool exists, ask the user directly.
-4. List choices with `list_profiles`, `list_integrations`, and `list_ai_artifacts`. Use `describe_integration` when the user asks for more information or when you need to compare options.
-5. Choose either Oxfmt or Prettier for formatting, never both.
-6. Once the profile and requirements are clear, compose the recipe with `compose_recipe`.
-7. Validate and explain it with `validate_recipe` and `explain_recipe`.
-8. Present `dry_run_apply` output to the user before changing files, including inspection findings, omitted script explanations, ownership notes, and planned file changes.
-9. Call `apply_recipe` only after the user explicitly approves the dry run.
-10. If the MCP transport closes or reports `-32000` during or immediately after `apply_recipe`, treat the outcome as unknown instead of failed. Inspect `calavera.config.json`, `.calavera/state.json`, generated files, and package metadata before retrying the apply.
+4. Use AskUserTool or the agent client's equivalent when available to clarify profile preferences, framework needs, conflict decisions, and apply approval. If no such tool exists, ask the user directly.
+5. List choices with `list_profiles`, `list_integrations`, and `list_ai_artifacts`. Use `describe_integration` when the user asks for more information or when you need to compare options.
+6. Choose either Oxfmt or Prettier for formatting, never both.
+7. Once the profile and requirements are clear, compose the recipe with `compose_recipe`.
+8. Validate and explain it with `validate_recipe` and `explain_recipe`.
+9. Present `dry_run_apply` output to the user before changing files, including inspection findings, omitted script explanations, ownership notes, and planned file changes.
+10. Call `apply_recipe` only after the user explicitly approves the dry run.
+11. If the MCP transport closes or reports `-32000` during or immediately after `apply_recipe`, treat the outcome as unknown instead of failed. Inspect `calavera.config.json`, `.calavera/state.json`, generated files, and package metadata before retrying the apply.
 
 Do not hand-author `calavera.config.json` when the Calavera MCP server is available. Let Calavera compose, validate, dry-run, and apply the recipe so generated files, package scripts, dependencies, AI artifacts, and managed state stay consistent.
 
@@ -42,6 +43,10 @@ If the Calavera MCP tools are not available, help the user register this server 
 
 For manual MCP setup, use `npx --package create-project-calavera@<version> create-project-calavera-mcp` for npm-managed projects, `pnpm dlx --package create-project-calavera@<version> create-project-calavera-mcp` for pnpm, `yarn dlx --package create-project-calavera@<version> create-project-calavera-mcp` for Yarn, and `bunx --package create-project-calavera@<version> create-project-calavera-mcp` for Bun. In JSON-based MCP configs, put the first word in `command` and the remaining words in `args`. Matching the project package manager prevents package-manager preflight failures before Calavera can start, such as npm rejecting a Bun-managed project. Keep an explicit version so package-manager launchers resolve the `create-project-calavera-mcp` bin reliably without making the persistent MCP registration float to a later package release.
 
+After registering the MCP server, reload or restart the agent session if the MCP host does not discover new tools dynamically. Confirm the Calavera tools are visible before composing a recipe.
+
+`npm create` needs `--` before Calavera flags, for example `npm create project-calavera -- --init`. Direct binary launchers such as `npx --package create-project-calavera create-project-calavera --help` do not need an extra `--` before Calavera flags. Avoid `npx --package create-project-calavera create-project-calavera -- --help`; MCP registrations launch `create-project-calavera-mcp` directly and should not add `--help`.
+
 If a Bun-based MCP launch fails before Calavera starts with `error: bun is unable to write files to tempdir: PermissionDenied`, configure the MCP host to set `TMPDIR` to an absolute writable directory for that server. If Bun's package cache is also restricted, set `BUN_INSTALL_CACHE_DIR` to an absolute writable cache directory. Keep these overrides on Bun registrations only; they are recovery settings for restricted hosts, not default Calavera MCP config.
 
 If this project was bootstrapped with `create-project-calavera --init`, also check `.agents/calavera/mcp.md` for local setup notes.
@@ -63,5 +68,5 @@ After a recipe exists, preview local changes with the package-manager-specific a
 When the user wants to start from a scaffolded or existing project, suggest:
 
 ```text
-Use Calavera for this project. Inspect the current project for existing tooling and possible config conflicts, then list the available profiles, integrations, and AI artifacts. Once the profile and requirements are clear, compose a recipe, show me the dry-run result, and apply it only after I approve.
+Use Calavera for this project. First verify that the Calavera MCP tools are available. If they are not available, stop and help me configure the MCP server before composing or applying anything. Once the tools are available, inspect the current project for existing tooling and possible config conflicts, list the available profiles, integrations, and AI artifacts, compose a recipe, show me the dry-run result, and apply it only after I approve.
 ```

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -26,6 +26,8 @@ Do not hand-author `calavera.config.json` when the Calavera MCP server is availa
 
 Treat files listed by `dry_run_apply` as Calavera-managed outputs. Do not hand-write or edit them; let `apply_recipe` or `create-project-calavera apply` create them after approval.
 
+`apply_recipe.writeConfig: false` only skips writing `calavera.config.json`. Do not use it to bypass managed-file conflicts, stale state hashes, or an unapproved dry-run result.
+
 ## MCP Setup
 
 If the Calavera MCP tools are not available, help the user register this server from the project root. Check the target project's `package.json` first and use the package manager declared by `packageManager` or `devEngines.packageManager`.

--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,7 @@ const AGENT_BOOTSTRAP_SKILL_RECIPE = {
   ai: [{ type: "skill", src: "skills/calavera" }],
 };
 const AGENT_BOOTSTRAP_NEXT_PROMPT =
-  "Use Calavera for this project. Inspect the current project for existing tooling and possible config conflicts, then list the available profiles, integrations, and AI artifacts. Once the profile and requirements are clear, compose a recipe, show me the dry-run result, and apply it only after I approve.";
+  "Use Calavera for this project. First verify that the Calavera MCP tools are available. If they are not available, stop and help me configure the MCP server before composing or applying anything. Once the tools are available, inspect the current project for existing tooling and possible config conflicts, list the available profiles, integrations, and AI artifacts, compose a recipe, show me the dry-run result, and apply it only after I approve.";
 const SCRIPT_SOURCE_EXTENSIONS = ["js", "jsx", "ts", "tsx", "mjs", "cjs"];
 const TSC_INCLUDE_PATTERNS = SCRIPT_SOURCE_EXTENSIONS.map((extension) => `src/**/*.${extension}`);
 
@@ -210,6 +210,7 @@ const cliParseOptions = {
   config: { type: "string", default: CONFIG_FILE },
   apply: { type: "boolean" },
   "dry-run": { type: "boolean" },
+  help: { type: "boolean", short: "h" },
   init: { type: "boolean" },
   json: { type: "boolean" },
   "agents-md": { type: "string" },
@@ -308,7 +309,7 @@ export function parseArgs(rawArgs) {
   const agentsMd = optionalStringValue(values["agents-md"]);
   /** @type {CliOptions} */
   const parsed = {
-    command: values.init ? "agent-init" : (positionals[0] ?? "init"),
+    command: values.help ? "help" : values.init ? "agent-init" : (positionals[0] ?? "init"),
     config: optionalStringValue(values.config) ?? CONFIG_FILE,
     dryRun: values["dry-run"] === true,
     json: values.json === true,
@@ -653,8 +654,10 @@ function createAgentBootstrapGuidanceBody() {
   return `# Calavera Agent Guidance
 
 - Use Calavera when the user wants to inspect, compose, preview, apply, or update project tooling.
+- Verify the Calavera MCP tools are available before composing a recipe.
 - Prefer the Calavera MCP server over hand-authoring \`calavera.config.json\`.
-- If the Calavera MCP tools are not available, help the user register the MCP server from \`${AGENT_BOOTSTRAP_MCP_FILE}\` or fall back to the Calavera Web UI.
+- If the Calavera MCP tools are not available, stop and help the user register the MCP server from \`${AGENT_BOOTSTRAP_MCP_FILE}\`, then reload the agent session if the MCP host requires it.
+- Do not inspect npm cache internals or import Calavera source files from a package cache as a substitute for MCP setup.
 - Inspect existing project tooling before composing a recipe and raise likely config conflicts early.
 - If likely conflicts exist, pause before applying changes. List each conflict as a hard stop or a migration decision the user can approve, and use \`dry_run_apply\` to show concrete impact when adoption still looks possible.
 - Start with \`inspect_project\`, \`list_profiles\`, \`list_integrations\`, and \`list_ai_artifacts\`; use \`describe_integration\` when the user asks for more information or an option needs explanation.
@@ -778,6 +781,30 @@ ${manualCommandReference}
 
 If your agent exposes an MCP setup UI or config writer, use the snippet above.
 If the agent needs approval before editing its own config, ask first.
+After registration, reload or restart the agent session if your MCP host does
+not discover new tools dynamically. Confirm the Calavera tools are visible before
+composing a recipe.
+
+Do not work around missing MCP tools by reading npm cache internals or importing
+Calavera source files from package cache paths. That bypasses the supported MCP
+setup and can use the wrong cached package version.
+
+## Command syntax for agents
+
+\`npm create\` uses \`--\` to forward flags to Calavera:
+
+\`\`\`bash
+npm create project-calavera -- --init
+npm create project-calavera apply -- --dry-run
+\`\`\`
+
+Direct binary launchers such as \`npx --package\` and MCP server registrations
+do not need an extra \`--\` before Calavera flags:
+
+\`\`\`bash
+npx --package create-project-calavera@${packageJson.version} create-project-calavera --help
+${shellCommand}
+\`\`\`
 
 ## Bun temp and cache directories
 
@@ -2337,6 +2364,65 @@ async function clean(options) {
   };
 }
 
+function formatHelp() {
+  return `create-project-calavera ${packageJson.version}
+
+Usage:
+  create-project-calavera [command] [options]
+
+Commands:
+  init                 Compose calavera.config.json interactively or from flags
+  apply                Apply the recipe in calavera.config.json
+  doctor               Check whether Calavera-managed files are present
+  clean                Remove stale Calavera-managed files when safe
+  help                 Show this help
+
+Options:
+  --init               Bootstrap agent guidance, MCP notes, and the Calavera skill
+  --dry-run            Preview writes without changing files
+  --apply              Preview and optionally apply after composing a recipe
+  --config <path>      Recipe path, defaults to calavera.config.json
+  --package-manager    npm, pnpm, yarn, or bun
+  --profile            modern, classic, or minimal
+  --tool <id>          Add an integration by id or label; repeatable
+  --ai-artifact <id>   Add a bundled AI artifact; repeatable
+  --agents-md <mode>   append or fallback when AGENTS.md already exists
+  --json               Print JSON output
+  --yes                Use defaults and skip prompts
+  --no-install         Write files without installing dependencies during apply
+  -h, --help           Show this help
+
+Agent-first setup:
+  npm create project-calavera -- --init
+  pnpm dlx create-project-calavera --init
+  yarn dlx create-project-calavera --init
+  bunx create-project-calavera --init
+
+MCP-first workflow:
+  1. Run the agent bootstrap command above from the project root.
+  2. Register the MCP server from .agents/calavera/mcp.md.
+  3. Reload or restart the agent session if required by your MCP host.
+  4. Confirm these tools are visible before composing a recipe:
+     inspect_project, list_profiles, list_integrations, list_ai_artifacts,
+     compose_recipe, validate_recipe, explain_recipe, dry_run_apply, apply_recipe.
+
+Package-runner syntax:
+  npm create needs -- before Calavera flags, for example:
+    npm create project-calavera -- --init
+    npm create project-calavera apply -- --dry-run
+
+  Direct binary launchers do not need an extra -- before Calavera flags:
+    npx --package create-project-calavera create-project-calavera --help
+    npx --package create-project-calavera create-project-calavera --init
+
+  MCP launch commands run create-project-calavera-mcp directly; do not add --help
+  or inspect npm cache internals as a substitute for MCP setup.`;
+}
+
+function printHelp() {
+  console.info(formatHelp());
+}
+
 /**
  * @param {CommandResult} result
  * @param {boolean} [asJSON]
@@ -2499,6 +2585,11 @@ function printResult(result, asJSON = false) {
 
 async function main() {
   const options = parseArgs(args);
+
+  if (options.command === "help") {
+    printHelp();
+    return;
+  }
 
   if (options.command === "init") {
     printResult(await initRecipe(options), options.json);

--- a/src/index.js
+++ b/src/index.js
@@ -851,6 +851,10 @@ Use the tools in this order:
 script explanations, ownership notes, and planned file changes to the user, then
 wait for explicit approval before calling \`apply_recipe\`.
 
+\`apply_recipe.writeConfig: false\` only skips writing \`calavera.config.json\`.
+Do not use it to bypass managed-file conflicts, stale state hashes, or an
+unapproved dry-run result.
+
 If the MCP transport closes or reports \`-32000\` during or immediately after
 \`apply_recipe\`, treat the apply outcome as unknown instead of failed. Inspect
 \`calavera.config.json\`, \`.calavera/state.json\`, generated files, and package
@@ -1024,8 +1028,9 @@ async function assertSafeManagedFileWrite(path, contents, previousState) {
     return;
   }
 
+  const installedContents = await readFile(path, "utf8");
   const targetHash = textHash(contents);
-  const installedHash = textHash(await readFile(path, "utf8"));
+  const installedHash = textHash(installedContents);
 
   if (installedHash === targetHash) {
     return;
@@ -1034,6 +1039,10 @@ async function assertSafeManagedFileWrite(path, contents, previousState) {
   const stateFile = managedFileStateForPath(previousState, path);
 
   if (stateFile?.hash === installedHash) {
+    return;
+  }
+
+  if (jsonContentsMatch(path, installedContents, contents)) {
     return;
   }
 
@@ -1051,6 +1060,47 @@ async function assertSafeManagedFileWrite(path, contents, previousState) {
 async function assertSafeManagedFileWrites(filePlans, previousState) {
   for (const filePlan of filePlans) {
     await assertSafeManagedFileWrite(filePlan.path, filePlan.contents, previousState);
+  }
+}
+
+/**
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function sortJsonValue(value) {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonValue);
+  }
+
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, sortJsonValue(item)]),
+    );
+  }
+
+  return value;
+}
+
+/**
+ * @param {string} path
+ * @param {string} installedContents
+ * @param {string} targetContents
+ * @returns {boolean}
+ */
+function jsonContentsMatch(path, installedContents, targetContents) {
+  if (!path.endsWith(".json")) {
+    return false;
+  }
+
+  try {
+    return (
+      JSON.stringify(sortJsonValue(JSON.parse(installedContents))) ===
+      JSON.stringify(sortJsonValue(JSON.parse(targetContents)))
+    );
+  } catch {
+    return false;
   }
 }
 
@@ -1177,7 +1227,8 @@ async function inspectManagedFilePlan(filePlan, previousState) {
   }
 
   const targetHash = textHash(filePlan.contents);
-  const installedHash = textHash(await readFile(filePlan.path, "utf8"));
+  const installedContents = await readFile(filePlan.path, "utf8");
+  const installedHash = textHash(installedContents);
 
   if (installedHash === targetHash) {
     return undefined;
@@ -1186,6 +1237,10 @@ async function inspectManagedFilePlan(filePlan, previousState) {
   const stateFile = managedFileStateForPath(previousState, filePlan.path);
 
   if (stateFile?.hash === installedHash) {
+    return undefined;
+  }
+
+  if (jsonContentsMatch(filePlan.path, installedContents, filePlan.contents)) {
     return undefined;
   }
 
@@ -1486,14 +1541,13 @@ export async function applyRecipeObject(recipe, options = {}) {
     await mkdir(".calavera", { recursive: true });
     await writeJSON(
       STATE_FILE,
-      {
-        version: 1,
-        profile: recipe.profile,
-        integrations: integrations.map((integration) => integration.id),
-        files: managedFiles.map((file) => file.path),
+      mergeRecipeIntoState(
+        previousState,
+        recipe.profile,
+        integrations.map((integration) => integration.id),
         managedFiles,
-        aiArtifacts: aiResult.artifacts,
-      },
+        aiResult.artifacts,
+      ),
       false,
     );
   }
@@ -1516,6 +1570,36 @@ export async function applyRecipeObject(recipe, options = {}) {
     projectInspection,
     changes: [...changes, ...aiResult.changes],
     pointers: aiResult.pointers,
+  };
+}
+
+/**
+ * @param {CalaveraState} previousState
+ * @param {string | undefined} profile
+ * @param {string[]} integrations
+ * @param {ManagedFileState[]} managedFiles
+ * @param {AiArtifactState[]} aiArtifacts
+ * @returns {CalaveraState}
+ */
+function mergeRecipeIntoState(previousState, profile, integrations, managedFiles, aiArtifacts) {
+  const managedFilesByPath = new Map(
+    managedFilesFromState(previousState).map((file) => [file.path, file]),
+  );
+
+  for (const managedFile of managedFiles) {
+    managedFilesByPath.set(managedFile.path, managedFile);
+  }
+
+  const nextManagedFiles = [...managedFilesByPath.values()];
+
+  return {
+    ...previousState,
+    version: 1,
+    profile,
+    integrations,
+    files: nextManagedFiles.map((file) => file.path),
+    managedFiles: nextManagedFiles,
+    aiArtifacts,
   };
 }
 
@@ -2372,8 +2456,11 @@ Usage:
 
 Commands:
   init                 Compose calavera.config.json interactively or from flags
+  agent-init           Bootstrap agent guidance, MCP notes, and the Calavera skill
+  bootstrap            Alias for agent-init
   apply                Apply the recipe in calavera.config.json
   doctor               Check whether Calavera-managed files are present
+  update               Re-apply the recipe in calavera.config.json
   clean                Remove stale Calavera-managed files when safe
   help                 Show this help
 
@@ -2412,8 +2499,8 @@ Package-runner syntax:
     npm create project-calavera apply -- --dry-run
 
   Direct binary launchers do not need an extra -- before Calavera flags:
-    npx --package create-project-calavera create-project-calavera --help
-    npx --package create-project-calavera create-project-calavera --init
+    npx --package create-project-calavera@${packageJson.version} create-project-calavera --help
+    npx --package create-project-calavera@${packageJson.version} create-project-calavera --init
 
   MCP launch commands run create-project-calavera-mcp directly; do not add --help
   or inspect npm cache internals as a substitute for MCP setup.`;

--- a/src/index.js
+++ b/src/index.js
@@ -1591,12 +1591,13 @@ function mergeRecipeIntoState(previousState, profile, integrations, managedFiles
   }
 
   const nextManagedFiles = [...managedFilesByPath.values()];
+  const preservesToolingRecipe = managedFiles.length === 0 && aiArtifacts.length > 0;
 
   return {
     ...previousState,
     version: 1,
-    profile,
-    integrations,
+    profile: preservesToolingRecipe ? previousState.profile : profile,
+    integrations: preservesToolingRecipe ? previousState.integrations : integrations,
     files: nextManagedFiles.map((file) => file.path),
     managedFiles: nextManagedFiles,
     aiArtifacts,


### PR DESCRIPTION
## Summary
- Clarify the MCP-first flow in README and workflow docs
- Add explicit guidance to verify Calavera MCP tools before composing or applying
- Teach the CLI to treat `help` and common help flags as a first-class command
- Add tests for help parsing and the new bootstrap guardrails

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI help view with versioned command/workflow and "agent-first" vs "MCP-first" syntax guidance.
  * Strengthened MCP-first guardrails in agent instructions, including stopping until Calavera MCP tools are verified.

* **Bug Fixes**
  * Improved handling of help requests across common flag/alias forms.
  * Enhanced managed JSON conflict detection to treat equivalent JSON content as non-conflicting.
  * Clarified that `writeConfig: false` only skips configuration and cannot bypass dry-run or managed-file protections.

* **Documentation**
  * Updated workflow docs and generated guidance to emphasize MCP setup verification, reload after registration when needed, and dry-run approval boundaries.

* **Tests**
  * Added coverage for managed JSON formatting drift and MCP AI-only apply behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->