### PR TITLE
[codex] Bump package version to 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.1.1
+
+### Fixed
+
+- Improve agent-facing MCP setup, help output, and package-runner guidance so agents configure Calavera before composing recipes.
+- Allow formatting-only drift in managed JSON files while still protecting against real local edits.
+- Preserve existing managed tooling state when applying AI-artifact-only recipes.
+
 ## 2.1.0
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-project-calavera",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Compose and apply modern tooling recipes for JavaScript and TypeScript projects.",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary
- Bump `create-project-calavera` from `2.1.0` to `2.1.1`.
- Add the `2.1.1` changelog entry for the merged agent/MCP reliability fixes.

## Validation
- `npm test`
- `npm run format:check`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

fix #255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup and guidance for using the assistant with managed tools.
  * Better handling of formatting-only changes in managed JSON files while still preventing unintended local edits.
  * Preserved existing managed tool state when applying AI-generated artifact updates.

* **Chores**
  * Bumped the app version to 2.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->