### PR TITLE
Fix skill markdown guidance

### DIFF
--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -902,10 +902,11 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.match(skill, /reports `-32000`/);
     assert.match(skill, /outcome as unknown instead of failed/);
     assert.match(skill, /Fallbacks/);
-    assert.match(skill, /npm create project-calavera apply -- --dry-run/);
-    assert.match(skill, /pnpm dlx create-project-calavera apply --dry-run/);
-    assert.match(skill, /bunx create-project-calavera apply --dry-run/);
-    assert.doesNotMatch(skill, /npm create project-calavera apply --dry-run/);
+    assert.match(skill, /npm create project-calavera@<version> apply -- --dry-run/);
+    assert.match(skill, /pnpm dlx create-project-calavera@<version> apply --dry-run/);
+    assert.match(skill, /yarn dlx create-project-calavera@<version> apply --dry-run/);
+    assert.match(skill, /bunx create-project-calavera@<version> apply --dry-run/);
+    assert.doesNotMatch(skill, /npm create project-calavera apply -- --dry-run/);
     assert.equal(
       result.changes.some(
         ({ type, path, reason }) =>

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -63,7 +63,7 @@ If the MCP server cannot be registered, use the hosted Calavera Web UI to compos
 
 https://calavera.schalkneethling.com
 
-After a recipe exists, preview local changes with the package-manager-specific apply dry-run command: `npm create project-calavera apply -- --dry-run` for npm, `pnpm dlx create-project-calavera apply --dry-run` for pnpm, `yarn dlx create-project-calavera apply --dry-run` for Yarn, or `bunx create-project-calavera apply --dry-run` for Bun. Ask the user to approve the preview before running the matching apply command.
+After a recipe exists, preview local changes with the package-manager-specific apply dry-run command, pinned to the same explicit package version used for MCP setup: `npm create project-calavera@<version> apply -- --dry-run` for npm, `pnpm dlx create-project-calavera@<version> apply --dry-run` for pnpm, `yarn dlx create-project-calavera@<version> apply --dry-run` for Yarn, or `bunx create-project-calavera@<version> apply --dry-run` for Bun. Ask the user to approve the preview before running the matching apply command.
 
 ## User Prompt
 

--- a/src/ai/skills/semantic-html/references/element-decision-trees.md
+++ b/src/ai/skills/semantic-html/references/element-decision-trees.md
@@ -4,7 +4,7 @@ Quick decision frameworks for selecting the right HTML element.
 
 ## Is It a List?
 
-```
+```text
 Does knowing the count help the user?
 ├─ Yes → Are items sequential/ranked?
 │        ├─ Yes → <ol>
@@ -18,7 +18,7 @@ Does knowing the count help the user?
 
 ## Is It a Table?
 
-```
+```text
 Does data have meaningful rows AND columns?
 ├─ No → Not a table
 │       ├─ One dimension only → List or plain elements
@@ -31,7 +31,7 @@ Does data have meaningful rows AND columns?
 
 ## Button or Link?
 
-```
+```text
 Does this navigate to a new URL?
 ├─ Yes → <a href="...">
 └─ No → Does an action occur?
@@ -43,7 +43,7 @@ Does this navigate to a new URL?
 
 ## Section or Div?
 
-```
+```text
 Does this content form a thematic grouping?
 ├─ No → <div>
 └─ Yes → Can you provide a meaningful accessible name?
@@ -53,7 +53,7 @@ Does this content form a thematic grouping?
 
 ## Article Candidate?
 
-```
+```text
 Would this content make sense standalone?
 ├─ Yes → Could it be syndicated or extracted?
 │        ├─ Yes → <article>
@@ -63,7 +63,7 @@ Would this content make sense standalone?
 
 ## Which Landmark?
 
-```
+```text
 What is this section's purpose?
 ├─ Site/section header → <header>
 ├─ Site/section footer → <footer>
@@ -78,7 +78,7 @@ What is this section's purpose?
 
 ## Form Field Grouping
 
-```
+```text
 Do these fields form a logical/thematic group?
 ├─ Yes → Are they form controls (inputs, selects, checkboxes)?
 │        ├─ Yes → <fieldset> with <legend>
@@ -90,7 +90,7 @@ Do these fields form a logical/thematic group?
 
 ## Interactive Disclosure
 
-```
+```text
 Should content be expandable/collapsible?
 ├─ Yes → Does the disclosed content need ARIA roles (menu, dialog, etc.)?
 │        ├─ Yes → <button> controlling visibility + appropriate ARIA
@@ -103,7 +103,7 @@ Should content be expandable/collapsible?
 
 ## Skip Navigation
 
-```
+```text
 Does the page have a <nav> or repeated content before <main>?
 └─ Yes → Add <a href="#main-content"> as the first element in <body>
          Does the page have a prominent search bar or long sidebar?


### PR DESCRIPTION
## Summary
- Pin Calavera fallback apply launcher commands to the same explicit `@<version>` placeholder used for MCP setup.
- Add `text` language labels to the semantic HTML ASCII decision-tree fences.
- Update the schema/config test expectations for the pinned fallback apply examples.
- Leave the visual-heading example unchanged because it already uses an `html` fence in current code.

## Validation
- `pnpm run schema:check`
- `pnpm run format:check`
- `pnpm run lint`
- `git diff --check`

fix #255