### PR TITLE
Clarify npm create agent init forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.1.2
+
+### Fixed
+
+- Clarify that `npm create` needs `-- --init` for agent bootstrap and add regression coverage for the forwarded npm flag shape.
+
 ## 2.1.1
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Find the equivalent commands for your package manager in the
 | Bun             | `bunx create-project-calavera --init`     | `bunx create-project-calavera apply --dry-run`     | `bunx create-project-calavera apply`     |
 
 `npm create` needs the `--` separator before Calavera flags such as `--init`
-and `--dry-run`. Yarn requires Yarn 2+ for `dlx`; Yarn 1.x users can use
+and `--dry-run`. Do not use `npm create project-calavera --init`; npm treats
+`--init` as its own option and Calavera falls back to the recipe CLI. Yarn
+requires Yarn 2+ for `dlx`; Yarn 1.x users can use
 `npx --package create-project-calavera create-project-calavera --init`.
 Direct binary launchers such as `npx --package` do not need an extra `--` before
 Calavera flags: use
@@ -233,8 +235,10 @@ scaffolding app code:
 npm create project-calavera -- --init
 ```
 
-`npm create` needs the `--` separator before Calavera flags. With other package
-managers, use `pnpm dlx create-project-calavera --init`,
+`npm create` needs the `--` separator before Calavera flags. Do not use
+`npm create project-calavera --init`; npm treats `--init` as its own option and
+Calavera falls back to the recipe CLI. With other package managers, use
+`pnpm dlx create-project-calavera --init`,
 `yarn dlx create-project-calavera --init`, or
 `bunx create-project-calavera --init`.
 The Yarn command requires Yarn 2+ because Yarn 1.x does not support `dlx`; Yarn

--- a/docs/agent-first-calavera-workflow.md
+++ b/docs/agent-first-calavera-workflow.md
@@ -19,6 +19,8 @@ npm create project-calavera -- --init
 ```
 
 `npm create` needs the `--` separator before Calavera flags such as `--init`.
+Do not use `npm create project-calavera --init`; npm treats `--init` as its own
+option and Calavera falls back to the recipe CLI.
 The other package-manager launchers run the Calavera binary directly, so their
 bootstrap commands are `pnpm dlx create-project-calavera --init`,
 `yarn dlx create-project-calavera --init`, and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-project-calavera",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Compose and apply modern tooling recipes for JavaScript and TypeScript projects.",
   "keywords": [
     "cli",

--- a/scripts/agent-bootstrap.test.mjs
+++ b/scripts/agent-bootstrap.test.mjs
@@ -26,6 +26,11 @@ test("parseArgs accepts an explicit AGENTS.md handling mode", () => {
   assert.throws(() => parseArgs(["--init", "--agents-md=overwrite"]), /Invalid agents-md/);
 });
 
+test("parseArgs accepts npm-create forwarded agent bootstrap flags", () => {
+  assert.equal(parseArgs(["--", "--init"]).command, "agent-init");
+  assert.equal(parseArgs(["--", "--init", "--dry-run", "--json"]).command, "agent-init");
+});
+
 test("parseArgs accepts conventional help commands", () => {
   assert.equal(parseArgs(["--help"]).command, "help");
   assert.equal(parseArgs(["-h"]).command, "help");

--- a/src/index.js
+++ b/src/index.js
@@ -798,6 +798,9 @@ npm create project-calavera -- --init
 npm create project-calavera apply -- --dry-run
 \`\`\`
 
+Do not use \`npm create project-calavera --init\`; npm treats \`--init\` as its own
+option and Calavera falls back to the recipe CLI.
+
 Direct binary launchers such as \`npx --package\` and MCP server registrations
 do not need an extra \`--\` before Calavera flags:
 


### PR DESCRIPTION
## Summary

- Bump the package version to 2.1.2 for the release that includes the npm create agent-init clarification.
- Document that npm users must run `npm create project-calavera -- --init`, because `npm create project-calavera --init` is consumed by npm before Calavera sees it.
- Add regression coverage for the forwarded `-- --init` argument shape and update generated MCP guidance.

## Validation

- `pnpm test`
- `./node_modules/.bin/oxfmt --check package.json CHANGELOG.md README.md docs/agent-first-calavera-workflow.md src/index.js scripts/agent-bootstrap.test.mjs`
- `git diff --check`

fix #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified the correct command syntax for bootstrap flows when using `npm create`, including the required `--` separator.
  * Added guidance to avoid a common command-line pitfall where `--init` is interpreted by npm instead of the app.
  * Improved consistency across docs and generated command guidance so users see the same instructions in one place.

* **Tests**
  * Added coverage for forwarded bootstrap flags to ensure the expected command is used with passthrough options.

* **Chores**
  * Bumped the release version to 2.1.2 and updated the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->