### PR TITLE
Configure project-local MCP during agent bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,11 +247,13 @@ The Yarn command requires Yarn 2+ because Yarn 1.x does not support `dlx`; Yarn
 or install `create-project-calavera` globally.
 
 The `--init` bootstrap installs the base Calavera skill, adds concise project
-guidance, writes MCP setup notes, and prints a recommended first prompt for the
-user to give their agent. When `AGENTS.md` already exists, interactive runs ask
-whether to append marked Calavera guidance directly to that file or leave it
-unchanged and write fallback guidance to `AGENTS.calavera.md`. Scripted runs
-keep the fallback-only behavior unless `--agents-md=append` is passed.
+guidance, optionally writes one project-local MCP config, and prints a
+recommended first prompt for the user to give their agent. It writes MCP setup
+notes only when the user chooses skip/manual or project-local MCP config cannot
+be written. When `AGENTS.md` already exists, interactive runs ask whether to
+append marked Calavera guidance directly to that file or leave it unchanged and
+write fallback guidance to `AGENTS.calavera.md`. Scripted runs keep the
+fallback-only behavior unless `--agents-md=append` is passed.
 
 ## MCP Server
 
@@ -262,8 +264,9 @@ npx --package create-project-calavera@<version> create-project-calavera-mcp
 ```
 
 During `--init`, Calavera can write one project-local MCP config for Claude
-Code, Codex, Cursor, or OpenCode. It never writes global/user MCP config. Choose
-`skip` if you want to configure MCP manually from `.agents/calavera/mcp.md`.
+Code, Codex, Cursor, or OpenCode. It never writes global/user MCP config. It
+writes `.agents/calavera/mcp.md` only when you choose `skip` or the selected
+local config cannot be written.
 
 Project-local config targets:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Vite, another scaffold tool, or a manually maintained repository:
 
 1. Open the project directory.
 2. Run `npm create project-calavera -- --init`.
-3. Register the MCP server using the generated `.agents/calavera/mcp.md` notes.
+3. Choose exactly one project-local MCP host when prompted: Claude Code, Codex,
+   Cursor, OpenCode, or skip/manual.
 4. Restart or reload the agent session if your MCP host does not discover new tools dynamically.
 5. Confirm the Calavera MCP tools are exposed: `inspect_project`, `list_profiles`, `list_integrations`, `list_ai_artifacts`, `compose_recipe`, `validate_recipe`, `explain_recipe`, `dry_run_apply`, and `apply_recipe`.
 6. Start the agent from the project root.
@@ -260,19 +261,27 @@ Calavera also ships a standard MCP server for agent-native recipe composition:
 npx --package create-project-calavera@<version> create-project-calavera-mcp
 ```
 
-Most users will register the equivalent command with their AI agent harness of
-choice, usually with the harness configured to run the command from the project
-root. Use the package manager declared by the target project's `package.json`.
-When configuring the MCP server manually, choose the matching command and put
-the first word in the MCP `command` field and the remaining words in `args`:
+During `--init`, Calavera can write one project-local MCP config for Claude
+Code, Codex, Cursor, or OpenCode. It never writes global/user MCP config. Choose
+`skip` if you want to configure MCP manually from `.agents/calavera/mcp.md`.
+
+Project-local config targets:
+
+- Claude Code: `.mcp.json`
+- Codex: `.codex/config.toml`
+- Cursor: `.cursor/mcp.json`
+- OpenCode: `opencode.json`
+
+Use the package manager declared by the target project's `package.json`.
+When configuring MCP manually, choose the matching command and put the first
+word in the MCP `command` field and the remaining words in `args`:
 
 - npm: `npx --package create-project-calavera@<version> create-project-calavera-mcp`
 - pnpm: `pnpm dlx --package create-project-calavera@<version> create-project-calavera-mcp`
 - Yarn: `yarn dlx --package create-project-calavera@<version> create-project-calavera-mcp`
 - Bun: `bunx --package create-project-calavera@<version> create-project-calavera-mcp`
 
-For npm-managed projects, pin the package version that is current when you
-register the MCP server:
+JSON-based MCP hosts use this shape:
 
 ```json
 {
@@ -285,21 +294,35 @@ register the MCP server:
 }
 ```
 
-For Bun-managed projects, pin the package version that is current when you
-register the MCP server:
+Codex uses TOML:
+
+```toml
+[mcp_servers.calavera]
+command = "npx"
+args = ["--package", "create-project-calavera@<version>", "create-project-calavera-mcp"]
+```
+
+OpenCode stores local MCP servers under `mcp`:
 
 ```json
 {
-  "mcpServers": {
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
     "calavera": {
-      "command": "bunx",
-      "args": ["--package", "create-project-calavera@<version>", "create-project-calavera-mcp"]
+      "type": "local",
+      "command": [
+        "npx",
+        "--package",
+        "create-project-calavera@<version>",
+        "create-project-calavera-mcp"
+      ],
+      "enabled": true
     }
   }
 }
 ```
 
-Project-scoped MCP servers run from the project root. Matching the project
+Project-local MCP servers run from the project root. Matching the project
 package manager prevents package-manager preflight failures before Calavera can
 start, such as npm 11 rejecting a Bun-managed project through
 `devEngines.packageManager`.
@@ -313,14 +336,6 @@ If the package cache is also restricted, set `BUN_INSTALL_CACHE_DIR` to an
 absolute writable directory such as an absolute path to
 `.calavera/bun-install-cache`. Keep these as Bun-only recovery settings rather
 than default MCP config.
-
-For Claude Code, use a project-scoped `.mcp.json` in the project root when the
-registration should be shared with teammates, or use `claude mcp add` to let
-Claude Code manage the same command. Do not put MCP server registrations in
-`.claude/settings.json`; Claude Code does not load MCP servers from that file.
-Because this registration runs an external package persistently, expect Claude
-Code to ask for explicit approval before creating the config or launching the
-server for the first time.
 
 Agent guidance should tell the harness to use Calavera when a user wants to
 inspect available project tooling, compose `calavera.config.json`, preview a
@@ -356,6 +371,8 @@ approves the proposed recipe and dry-run result.
   and agent targets, or omit this flag to select from the interactive option list
 - `--agents-md append|fallback` with `--init` to script how existing `AGENTS.md`
   files are handled
+- `--mcp-harness claude-code|codex|cursor|opencode|skip` with `--init` to
+  script project-local MCP auto-config
 - `--apply` with `init` to preview and then confirm applying the composed recipe
 - `--dry-run`
 - `--no-install`

--- a/docs/agent-first-calavera-workflow.md
+++ b/docs/agent-first-calavera-workflow.md
@@ -28,13 +28,26 @@ bootstrap commands are `pnpm dlx create-project-calavera --init`,
 See [Package-Manager Commands](#package-manager-commands) below for the full
 command table.
 
-The bootstrap writes Calavera guidance for agents, MCP setup notes, and the base
-Calavera skill. It does not scaffold app code. When `AGENTS.md` already exists,
-interactive runs ask whether to append marked Calavera guidance directly to that
-file or write `AGENTS.calavera.md` for manual merging. Scripted runs keep
-`AGENTS.md` unchanged unless `--agents-md=append` is passed.
+The bootstrap writes Calavera guidance for agents, MCP setup notes, the base
+Calavera skill, and optionally one project-local MCP config. It does not
+scaffold app code. When `AGENTS.md` already exists, interactive runs ask whether
+to append marked Calavera guidance directly to that file or write
+`AGENTS.calavera.md` for manual merging. Scripted runs keep `AGENTS.md`
+unchanged unless `--agents-md=append` is passed.
 
-Register the MCP server from the generated `.agents/calavera/mcp.md` notes:
+After any `AGENTS.md` question, interactive runs ask which project-local MCP
+host to configure. Choose exactly one of Claude Code, Codex, Cursor, OpenCode,
+or skip/manual. Calavera never writes global/user MCP config.
+
+Project-local config targets:
+
+- Claude Code: `.mcp.json`
+- Codex: `.codex/config.toml`
+- Cursor: `.cursor/mcp.json`
+- OpenCode: `opencode.json`
+
+If you choose skip/manual, use the generated `.agents/calavera/mcp.md` notes.
+JSON-based MCP hosts use this shape:
 
 ```json
 {
@@ -47,11 +60,39 @@ Register the MCP server from the generated `.agents/calavera/mcp.md` notes:
 }
 ```
 
+Codex uses TOML:
+
+```toml
+[mcp_servers.calavera]
+command = "npx"
+args = ["--package", "create-project-calavera@<version>", "create-project-calavera-mcp"]
+```
+
+OpenCode stores local MCP servers under `mcp`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "calavera": {
+      "type": "local",
+      "command": [
+        "npx",
+        "--package",
+        "create-project-calavera@<version>",
+        "create-project-calavera-mcp"
+      ],
+      "enabled": true
+    }
+  }
+}
+```
+
 Use the package manager declared by the target project's `package.json` when
 creating the MCP registration. The generated notes choose the matching command,
 such as `npx` for npm-managed projects, `pnpm dlx` for pnpm, `yarn dlx` for
-Yarn, or `bunx` for Bun. Project-scoped MCP servers run from the project root,
-so matching the package manager avoids preflight failures before Calavera can
+Yarn, or `bunx` for Bun. Project-local MCP servers run from the project root, so
+matching the package manager avoids preflight failures before Calavera can
 start.
 
 For manual MCP setup, choose the matching command and split it into the harness
@@ -67,14 +108,6 @@ words become `args`.
 Keep an explicit package version specifier so package-manager launchers resolve
 the `create-project-calavera-mcp` bin reliably without making the persistent MCP
 registration float to a later package release.
-
-For Claude Code, prefer a project-scoped `.mcp.json` in the project root when
-the team should share the registration. Do not put MCP server registrations in
-`.claude/settings.json`; Claude Code does not load MCP servers from that file.
-`claude mcp add` can also register the same command if you want Claude Code to
-manage the entry. Because the server command runs an external package, Claude
-Code may require explicit approval before creating the persistent registration
-or launching the server for the first time.
 
 After registration, restart or reload the agent session if the MCP host does not
 discover new tools dynamically. Before composing a recipe, confirm these

--- a/docs/agent-first-calavera-workflow.md
+++ b/docs/agent-first-calavera-workflow.md
@@ -114,8 +114,8 @@ registration float to a later package release.
 After registration, restart or reload the agent session if the MCP host does not
 discover new tools dynamically. Before composing a recipe, confirm these
 Calavera MCP tools are exposed: `inspect_project`, `list_profiles`,
-`list_integrations`, `list_ai_artifacts`, `compose_recipe`, `dry_run_apply`, and
-`apply_recipe`.
+`list_integrations`, `list_ai_artifacts`, `compose_recipe`, `validate_recipe`,
+`explain_recipe`, `dry_run_apply`, and `apply_recipe`.
 
 Agents should not work around missing MCP tools by reading npm cache internals
 or importing Calavera source files from package cache paths. Configure or repair

--- a/docs/agent-first-calavera-workflow.md
+++ b/docs/agent-first-calavera-workflow.md
@@ -28,10 +28,11 @@ bootstrap commands are `pnpm dlx create-project-calavera --init`,
 See [Package-Manager Commands](#package-manager-commands) below for the full
 command table.
 
-The bootstrap writes Calavera guidance for agents, MCP setup notes, the base
-Calavera skill, and optionally one project-local MCP config. It does not
-scaffold app code. When `AGENTS.md` already exists, interactive runs ask whether
-to append marked Calavera guidance directly to that file or write
+The bootstrap writes Calavera guidance for agents, the base Calavera skill, and
+optionally one project-local MCP config. It writes MCP setup notes only when the
+user chooses skip/manual or project-local MCP config cannot be written. It does
+not scaffold app code. When `AGENTS.md` already exists, interactive runs ask
+whether to append marked Calavera guidance directly to that file or write
 `AGENTS.calavera.md` for manual merging. Scripted runs keep `AGENTS.md`
 unchanged unless `--agents-md=append` is passed.
 
@@ -46,8 +47,9 @@ Project-local config targets:
 - Cursor: `.cursor/mcp.json`
 - OpenCode: `opencode.json`
 
-If you choose skip/manual, use the generated `.agents/calavera/mcp.md` notes.
-JSON-based MCP hosts use this shape:
+If you choose skip/manual, or Calavera cannot write the selected local config,
+use the generated `.agents/calavera/mcp.md` notes. JSON-based MCP hosts use this
+shape:
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-project-calavera",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Compose and apply modern tooling recipes for JavaScript and TypeScript projects.",
   "keywords": [
     "cli",

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -63,6 +63,10 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 const schemaUrl = CONFIG_SCHEMA_URL;
 const rootProperties = [
   "$schema",
@@ -801,6 +805,30 @@ test("agent bootstrap dry-run previews guidance without writing files", async ()
   }
 });
 
+test("agent bootstrap assume-yes skips MCP auto-config without explicit harness", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-assume-yes-"));
+
+  try {
+    process.chdir(projectDirectory);
+
+    const result = await agentBootstrap({ assumeYes: true, json: true });
+
+    assert.equal(result.mcp.harness, "skip");
+    assert.equal(result.mcp.action, "manual");
+    assert.equal(
+      result.changes.some(({ path }) => path === ".agents/calavera/mcp.md"),
+      true,
+    );
+    await assert.rejects(() => stat(".mcp.json"), /ENOENT/);
+    await assert.rejects(() => stat(".codex/config.toml"), /ENOENT/);
+    await assert.rejects(() => stat(".cursor/mcp.json"), /ENOENT/);
+    await assert.rejects(() => stat("opencode.json"), /ENOENT/);
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
 test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance", async () => {
   const originalDirectory = process.cwd();
   const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-"));
@@ -1026,10 +1054,58 @@ test("agent bootstrap writes Codex project MCP config", async () => {
     assert.match(
       config,
       new RegExp(
-        `args = \\["dlx", "--package", "create-project-calavera@${packageJson.version}", "create-project-calavera-mcp"\\]`,
+        `args = \\["dlx", "--package", "create-project-calavera@${escapeRegExp(packageJson.version)}", "create-project-calavera-mcp"\\]`,
       ),
     );
     await assert.rejects(() => stat(".agents/calavera/mcp.md"), /ENOENT/);
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("agent bootstrap updates existing Codex MCP config idempotently", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-codex-idempotent-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await mkdir(".codex", { recursive: true });
+    await writeFile(
+      ".codex/config.toml",
+      [
+        "[approval]",
+        'mode = "manual"',
+        "",
+        "[mcp_servers.calavera]",
+        'command = "old-command"',
+        'args = ["old-arg"]',
+        "",
+        "[mcp_servers.other]",
+        'command = "node"',
+        "",
+      ].join("\n"),
+    );
+
+    const result = await agentBootstrap({
+      json: true,
+      mcpHarness: "codex",
+      packageManager: "npm",
+    });
+    const config = await readFile(".codex/config.toml", "utf8");
+
+    assert.equal(result.mcp.harness, "codex");
+    assert.equal(result.mcp.action, "update");
+    assert.equal(config.match(/\[mcp_servers\.calavera\]/g)?.length, 1);
+    assert.match(config, /\[approval\]\nmode = "manual"/);
+    assert.match(config, /\[mcp_servers\.other\]\ncommand = "node"/);
+    assert.match(config, /\[mcp_servers\.calavera\]\ncommand = "npx"/);
+    assert.doesNotMatch(config, /old-command|old-arg/);
+    assert.match(
+      config,
+      new RegExp(
+        `args = \\["--package", "create-project-calavera@${escapeRegExp(packageJson.version)}", "create-project-calavera-mcp"\\]`,
+      ),
+    );
   } finally {
     process.chdir(originalDirectory);
   }
@@ -1045,6 +1121,7 @@ test("agent bootstrap writes and merges OpenCode project MCP config", async () =
       "opencode.json",
       `${JSON.stringify(
         {
+          $schema: 42,
           theme: "system",
           mcp: {
             existing: {

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -789,6 +789,11 @@ test("agent bootstrap dry-run previews guidance without writing files", async ()
       result.changes.some(({ path }) => path === ".agents/calavera/mcp.md"),
       true,
     );
+    assert.deepEqual(result.mcp, {
+      harness: "skip",
+      action: "manual",
+      reason: "Skipped project MCP auto-config. Follow .agents/calavera/mcp.md for manual setup.",
+    });
     assert.match(result.nextPrompt, /Use Calavera for this project/);
     await assert.rejects(() => stat("AGENTS.md"), /ENOENT/);
   } finally {
@@ -805,7 +810,7 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     await writeFile("AGENTS.md", "Existing project guidance.\n");
     await writeFile("package.json", JSON.stringify({ packageManager: "pnpm@11.3.0" }));
 
-    const result = await agentBootstrap({ json: true });
+    const result = await agentBootstrap({ json: true, mcpHarness: "skip" });
     const existingGuidance = await readFile("AGENTS.md", "utf8");
     const fallbackGuidance = await readFile("AGENTS.calavera.md", "utf8");
     const mcpGuidance = await readFile(".agents/calavera/mcp.md", "utf8");
@@ -830,10 +835,9 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
       ),
     );
     assert.doesNotMatch(mcpGuidance, /"command": "npx"/);
-    assert.match(mcpGuidance, /using this project's package manager \(pnpm\)/);
+    assert.match(mcpGuidance, /detected package manager is pnpm/);
     assert.match(mcpGuidance, /devEngines\.packageManager/);
     assert.match(mcpGuidance, /When configuring an MCP server manually/);
-    assert.match(mcpGuidance, /first word in the MCP `command` field/);
     assert.match(
       mcpGuidance,
       new RegExp(
@@ -860,11 +864,13 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     );
     assert.match(mcpGuidance, /Claude Code/);
     assert.match(mcpGuidance, /\.mcp\.json/);
-    assert.match(mcpGuidance, /claude mcp add/);
-    assert.match(mcpGuidance, /\.claude\/settings\.json/);
-    assert.match(mcpGuidance, /persistent code-execution change/);
-    assert.match(mcpGuidance, /explicit user approval/);
-    assert.match(mcpGuidance, /AskUserTool|approval/);
+    assert.match(mcpGuidance, /Cursor/);
+    assert.match(mcpGuidance, /\.cursor\/mcp\.json/);
+    assert.match(mcpGuidance, /Codex/);
+    assert.match(mcpGuidance, /\.codex\/config\.toml/);
+    assert.match(mcpGuidance, /OpenCode/);
+    assert.match(mcpGuidance, /opencode\.json/);
+    assert.match(mcpGuidance, /never writes global\/user MCP config/);
     assert.match(mcpGuidance, /inspect_project/);
     assert.match(mcpGuidance, /omitted\s+script explanations/);
     assert.match(mcpGuidance, /ownership notes/);
@@ -914,6 +920,8 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
       ),
       true,
     );
+    assert.equal(result.mcp.harness, "skip");
+    assert.equal(result.mcp.action, "manual");
     assert.equal(
       state.aiArtifacts.some(
         ({ type, name, path }) =>
@@ -926,7 +934,190 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
   }
 });
 
-test("agent bootstrap uses devEngines package manager for MCP guidance", async () => {
+test("agent bootstrap writes Claude Code project MCP config", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-claude-mcp-"));
+
+  try {
+    process.chdir(projectDirectory);
+
+    const result = await agentBootstrap({
+      json: true,
+      mcpHarness: "claude-code",
+      packageManager: "pnpm",
+    });
+    const config = JSON.parse(await readFile(".mcp.json", "utf8"));
+
+    assert.equal(result.mcp.harness, "claude-code");
+    assert.equal(result.mcp.action, "write");
+    assert.equal(result.mcp.path, ".mcp.json");
+    assert.deepEqual(config.mcpServers.calavera, {
+      command: "pnpm",
+      args: [
+        "dlx",
+        "--package",
+        `create-project-calavera@${packageJson.version}`,
+        "create-project-calavera-mcp",
+      ],
+    });
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("agent bootstrap writes Cursor project MCP config", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-cursor-mcp-"));
+
+  try {
+    process.chdir(projectDirectory);
+
+    const result = await agentBootstrap({
+      json: true,
+      mcpHarness: "cursor",
+      packageManager: "npm",
+    });
+    const config = JSON.parse(await readFile(".cursor/mcp.json", "utf8"));
+
+    assert.equal(result.mcp.harness, "cursor");
+    assert.equal(result.mcp.action, "write");
+    assert.equal(result.mcp.path, ".cursor/mcp.json");
+    assert.deepEqual(config.mcpServers.calavera, {
+      command: "npx",
+      args: [
+        "--package",
+        `create-project-calavera@${packageJson.version}`,
+        "create-project-calavera-mcp",
+      ],
+    });
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("agent bootstrap writes Codex project MCP config", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-codex-mcp-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await mkdir(".codex", { recursive: true });
+    await writeFile(
+      ".codex/config.toml",
+      "[approval]\nmode = \"manual\"\n\n[mcp_servers.other]\ncommand = \"node\"\n",
+    );
+
+    const result = await agentBootstrap({
+      json: true,
+      mcpHarness: "codex",
+      packageManager: "yarn",
+    });
+    const config = await readFile(".codex/config.toml", "utf8");
+
+    assert.equal(result.mcp.harness, "codex");
+    assert.equal(result.mcp.action, "update");
+    assert.equal(result.mcp.path, ".codex/config.toml");
+    assert.match(config, /\[approval\]\nmode = "manual"/);
+    assert.match(config, /\[mcp_servers\.other\]\ncommand = "node"/);
+    assert.match(config, /\[mcp_servers\.calavera\]/);
+    assert.match(config, /command = "yarn"/);
+    assert.match(
+      config,
+      new RegExp(
+        `args = \\["dlx", "--package", "create-project-calavera@${packageJson.version}", "create-project-calavera-mcp"\\]`,
+      ),
+    );
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("agent bootstrap writes and merges OpenCode project MCP config", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-opencode-mcp-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile(
+      "opencode.json",
+      `${JSON.stringify(
+        {
+          theme: "system",
+          mcp: {
+            existing: {
+              type: "local",
+              command: ["node", "server.js"],
+              enabled: true,
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const result = await agentBootstrap({
+      json: true,
+      mcpHarness: "opencode",
+      packageManager: "bun",
+    });
+    const config = JSON.parse(await readFile("opencode.json", "utf8"));
+
+    assert.equal(result.mcp.harness, "opencode");
+    assert.equal(result.mcp.action, "update");
+    assert.equal(result.mcp.path, "opencode.json");
+    assert.equal(config.$schema, "https://opencode.ai/config.json");
+    assert.equal(config.theme, "system");
+    assert.deepEqual(config.mcp.existing, {
+      type: "local",
+      command: ["node", "server.js"],
+      enabled: true,
+    });
+    assert.deepEqual(config.mcp.calavera, {
+      type: "local",
+      command: [
+        "bunx",
+        "--package",
+        `create-project-calavera@${packageJson.version}`,
+        "create-project-calavera-mcp",
+      ],
+      enabled: true,
+    });
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("agent bootstrap dry-run reports MCP config without writing it", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-mcp-dry-run-"));
+
+  try {
+    process.chdir(projectDirectory);
+
+    const result = await agentBootstrap({
+      dryRun: true,
+      json: true,
+      mcpHarness: "cursor",
+      packageManager: "npm",
+    });
+
+    assert.deepEqual(result.mcp, {
+      harness: "cursor",
+      action: "write",
+      path: ".cursor/mcp.json",
+    });
+    assert.equal(
+      result.changes.some(({ type, path }) => type === "write" && path === ".cursor/mcp.json"),
+      true,
+    );
+    await assert.rejects(() => stat(".cursor/mcp.json"), /ENOENT/);
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("agent bootstrap uses devEngines package manager for MCP guidance and config", async () => {
   const originalDirectory = process.cwd();
   const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-bun-mcp-"));
 
@@ -945,8 +1136,9 @@ test("agent bootstrap uses devEngines package manager for MCP guidance", async (
       }),
     );
 
-    await agentBootstrap({ json: true });
+    await agentBootstrap({ json: true, mcpHarness: "claude-code" });
     const mcpGuidance = await readFile(".agents/calavera/mcp.md", "utf8");
+    const config = JSON.parse(await readFile(".mcp.json", "utf8"));
 
     assert.match(mcpGuidance, /"command": "bunx"/);
     assert.match(
@@ -955,15 +1147,23 @@ test("agent bootstrap uses devEngines package manager for MCP guidance", async (
         `"args": \\[\\s+"--package",\\s+"create-project-calavera@${packageJson.version}",\\s+"create-project-calavera-mcp"\\s+\\]`,
       ),
     );
-    assert.match(mcpGuidance, /using this project's package manager \(Bun\)/);
+    assert.match(mcpGuidance, /detected package manager is Bun/);
     assert.match(
       mcpGuidance,
-      /npm rejecting a Bun-managed\s+project through `devEngines\.packageManager`/,
+      /npm rejecting a Bun-managed project\s+through `devEngines\.packageManager`/,
     );
     assert.match(mcpGuidance, /bun is unable to write files to tempdir: PermissionDenied/);
     assert.match(mcpGuidance, /TMPDIR/);
     assert.match(mcpGuidance, /BUN_INSTALL_CACHE_DIR/);
     assert.doesNotMatch(mcpGuidance, /"command": "npx"/);
+    assert.deepEqual(config.mcpServers.calavera, {
+      command: "bunx",
+      args: [
+        "--package",
+        `create-project-calavera@${packageJson.version}`,
+        "create-project-calavera-mcp",
+      ],
+    });
   } finally {
     process.chdir(originalDirectory);
   }

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -960,6 +960,7 @@ test("agent bootstrap writes Claude Code project MCP config", async () => {
         "create-project-calavera-mcp",
       ],
     });
+    await assert.rejects(() => stat(".agents/calavera/mcp.md"), /ENOENT/);
   } finally {
     process.chdir(originalDirectory);
   }
@@ -990,6 +991,7 @@ test("agent bootstrap writes Cursor project MCP config", async () => {
         "create-project-calavera-mcp",
       ],
     });
+    await assert.rejects(() => stat(".agents/calavera/mcp.md"), /ENOENT/);
   } finally {
     process.chdir(originalDirectory);
   }
@@ -1027,6 +1029,7 @@ test("agent bootstrap writes Codex project MCP config", async () => {
         `args = \\["dlx", "--package", "create-project-calavera@${packageJson.version}", "create-project-calavera-mcp"\\]`,
       ),
     );
+    await assert.rejects(() => stat(".agents/calavera/mcp.md"), /ENOENT/);
   } finally {
     process.chdir(originalDirectory);
   }
@@ -1083,6 +1086,7 @@ test("agent bootstrap writes and merges OpenCode project MCP config", async () =
       ],
       enabled: true,
     });
+    await assert.rejects(() => stat(".agents/calavera/mcp.md"), /ENOENT/);
   } finally {
     process.chdir(originalDirectory);
   }
@@ -1111,13 +1115,43 @@ test("agent bootstrap dry-run reports MCP config without writing it", async () =
       result.changes.some(({ type, path }) => type === "write" && path === ".cursor/mcp.json"),
       true,
     );
+    assert.equal(
+      result.changes.some(({ path }) => path === ".agents/calavera/mcp.md"),
+      false,
+    );
     await assert.rejects(() => stat(".cursor/mcp.json"), /ENOENT/);
   } finally {
     process.chdir(originalDirectory);
   }
 });
 
-test("agent bootstrap uses devEngines package manager for MCP guidance and config", async () => {
+test("agent bootstrap falls back to manual MCP guidance when config write fails", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-mcp-fallback-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await mkdir(".cursor", { recursive: true });
+    await writeFile(".cursor/mcp.json", "[]\n");
+
+    const result = await agentBootstrap({
+      json: true,
+      mcpHarness: "cursor",
+      packageManager: "npm",
+    });
+    const mcpGuidance = await readFile(".agents/calavera/mcp.md", "utf8");
+
+    assert.equal(result.mcp.harness, "cursor");
+    assert.equal(result.mcp.action, "manual");
+    assert.match(result.mcp.reason, /Could not write project MCP config at \.cursor\/mcp\.json/);
+    assert.match(result.mcp.reason, /mcp\.json must contain a JSON object/);
+    assert.match(mcpGuidance, /Calavera MCP Setup/);
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("agent bootstrap uses devEngines package manager for MCP config", async () => {
   const originalDirectory = process.cwd();
   const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-bun-mcp-"));
 
@@ -1137,8 +1171,43 @@ test("agent bootstrap uses devEngines package manager for MCP guidance and confi
     );
 
     await agentBootstrap({ json: true, mcpHarness: "claude-code" });
-    const mcpGuidance = await readFile(".agents/calavera/mcp.md", "utf8");
     const config = JSON.parse(await readFile(".mcp.json", "utf8"));
+
+    assert.deepEqual(config.mcpServers.calavera, {
+      command: "bunx",
+      args: [
+        "--package",
+        `create-project-calavera@${packageJson.version}`,
+        "create-project-calavera-mcp",
+      ],
+    });
+    await assert.rejects(() => stat(".agents/calavera/mcp.md"), /ENOENT/);
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("agent bootstrap uses devEngines package manager for manual MCP guidance", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-agent-init-bun-mcp-guidance-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile(
+      "package.json",
+      JSON.stringify({
+        devEngines: {
+          packageManager: {
+            name: "bun",
+            version: "1.3.14",
+            onFail: "download",
+          },
+        },
+      }),
+    );
+
+    await agentBootstrap({ json: true, mcpHarness: "skip" });
+    const mcpGuidance = await readFile(".agents/calavera/mcp.md", "utf8");
 
     assert.match(mcpGuidance, /"command": "bunx"/);
     assert.match(
@@ -1156,14 +1225,6 @@ test("agent bootstrap uses devEngines package manager for MCP guidance and confi
     assert.match(mcpGuidance, /TMPDIR/);
     assert.match(mcpGuidance, /BUN_INSTALL_CACHE_DIR/);
     assert.doesNotMatch(mcpGuidance, /"command": "npx"/);
-    assert.deepEqual(config.mcpServers.calavera, {
-      command: "bunx",
-      args: [
-        "--package",
-        `create-project-calavera@${packageJson.version}`,
-        "create-project-calavera-mcp",
-      ],
-    });
   } finally {
     process.chdir(originalDirectory);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,15 @@ import { fileExists, readJSON, writeJSON } from "./utils/fs.js";
 import { isNotEmptyString, isPlainObject } from "./utils/guards.js";
 import { textHash } from "./utils/hash.js";
 import { logger } from "./utils/logger.js";
+import {
+  createCodexMcpTomlBlock,
+  createMcpServersJsonConfig,
+  createOpenCodeMcpJsonConfig,
+  projectMcpConfigPath,
+  writeCodexMcpConfig,
+  writeMcpServersJsonConfig,
+  writeOpenCodeMcpConfig,
+} from "./utils/mcp-config.js";
 import { groupedPromptOptions } from "./utils/prompt-options.js";
 import { pluralizeCount, style, titleCase } from "./utils/text.js";
 
@@ -220,7 +229,6 @@ const cliParseOptions = {
   json: { type: "boolean" },
   "agents-md": { type: "string" },
   "mcp-harness": { type: "string" },
-  "mcp-host": { type: "string" },
   "no-install": { type: "boolean" },
   yes: { type: "boolean" },
   "package-manager": { type: "string" },
@@ -328,7 +336,7 @@ export function parseArgs(rawArgs) {
   const profile = optionalStringValue(values.profile);
   const packageManager = optionalStringValue(values["package-manager"]);
   const agentsMd = optionalStringValue(values["agents-md"]);
-  const mcpHarness = optionalStringValue(values["mcp-harness"] ?? values["mcp-host"]);
+  const mcpHarness = optionalStringValue(values["mcp-harness"]);
   /** @type {CliOptions} */
   const parsed = {
     command: values.help ? "help" : values.init ? "agent-init" : (positionals[0] ?? "init"),
@@ -764,253 +772,7 @@ function createMcpManualCommandReference() {
  * @returns {string}
  */
 function createMcpServerConfigSnippet(launchCommand) {
-  return JSON.stringify(
-    {
-      mcpServers: {
-        calavera: launchCommand,
-      },
-    },
-    null,
-    2,
-  );
-}
-
-/**
- * @param {unknown} value
- * @param {string} path
- * @returns {Record<string, unknown>}
- */
-function assertJsonObjectConfig(value, path) {
-  if (!isPlainObject(value)) {
-    throw new Error(`${path} must contain a JSON object.`);
-  }
-
-  return /** @type {Record<string, unknown>} */ (value);
-}
-
-/**
- * @param {string} path
- * @param {Record<string, unknown>} nextConfig
- * @param {boolean} dryRun
- * @param {Change[]} changes
- * @returns {Promise<"write" | "update" | "skip">}
- */
-async function writeProjectJsonConfig(path, nextConfig, dryRun, changes) {
-  if (!(await fileExists(path))) {
-    changes.push({ type: "write", path });
-
-    if (!dryRun) {
-      const directory = dirname(path);
-      if (directory !== ".") {
-        await mkdir(directory, { recursive: true });
-      }
-      await writeJSON(path, nextConfig, false);
-    }
-
-    return "write";
-  }
-
-  assertJsonObjectConfig(await readJSON(path), path);
-  const nextContents = `${JSON.stringify(nextConfig, null, 2)}\n`;
-  const currentContents = await readFile(path, "utf8");
-
-  if (currentContents === nextContents) {
-    changes.push({ type: "skip", path, reason: "Already up to date." });
-    return "skip";
-  }
-
-  changes.push({ type: "update", path, reason: "Add or update Calavera MCP server." });
-
-  if (!dryRun) {
-    await writeFile(path, nextContents);
-  }
-
-  return "update";
-}
-
-/**
- * @param {string} path
- * @param {{ command: string, args: string[] }} launchCommand
- * @param {boolean} dryRun
- * @param {Change[]} changes
- * @returns {Promise<"write" | "update" | "skip">}
- */
-async function writeMcpServersJsonConfig(path, launchCommand, dryRun, changes) {
-  /** @type {Record<string, unknown>} */
-  const currentConfig = (await fileExists(path))
-    ? assertJsonObjectConfig(await readJSON(path), path)
-    : {};
-  const mcpServers = currentConfig.mcpServers;
-
-  if (mcpServers !== undefined && !isPlainObject(mcpServers)) {
-    throw new Error(`${path} mcpServers must be an object.`);
-  }
-
-  return writeProjectJsonConfig(
-    path,
-    {
-      ...currentConfig,
-      mcpServers: {
-        ...(isPlainObject(mcpServers) ? mcpServers : {}),
-        calavera: launchCommand,
-      },
-    },
-    dryRun,
-    changes,
-  );
-}
-
-/**
- * @param {string} value
- * @returns {string}
- */
-function tomlString(value) {
-  return JSON.stringify(value);
-}
-
-/**
- * @param {string[]} values
- * @returns {string}
- */
-function tomlStringArray(values) {
-  return `[${values.map(tomlString).join(", ")}]`;
-}
-
-/**
- * @param {{ command: string, args: string[] }} launchCommand
- * @returns {string}
- */
-function createCodexMcpTomlBlock(launchCommand) {
-  return [
-    "[mcp_servers.calavera]",
-    `command = ${tomlString(launchCommand.command)}`,
-    `args = ${tomlStringArray(launchCommand.args)}`,
-    "",
-  ].join("\n");
-}
-
-/**
- * @param {string} contents
- * @param {string} header
- * @returns {{ start: number, end: number } | undefined}
- */
-function findTomlTableRange(contents, header) {
-  const lines = contents.split("\n");
-  const start = lines.findIndex((line) => line.trim() === header);
-
-  if (start === -1) {
-    return undefined;
-  }
-
-  const nextHeaderOffset = lines
-    .slice(start + 1)
-    .findIndex((line) => line.trim().startsWith("[") && line.trim().endsWith("]"));
-
-  return {
-    start,
-    end: nextHeaderOffset === -1 ? lines.length : start + 1 + nextHeaderOffset,
-  };
-}
-
-/**
- * @param {string} path
- * @param {{ command: string, args: string[] }} launchCommand
- * @param {boolean} dryRun
- * @param {Change[]} changes
- * @returns {Promise<"write" | "update" | "skip">}
- */
-async function writeCodexMcpConfig(path, launchCommand, dryRun, changes) {
-  const block = createCodexMcpTomlBlock(launchCommand);
-
-  if (!(await fileExists(path))) {
-    changes.push({ type: "write", path });
-
-    if (!dryRun) {
-      await mkdir(dirname(path), { recursive: true });
-      await writeFile(path, block);
-    }
-
-    return "write";
-  }
-
-  const contents = await readFile(path, "utf8");
-  const range = findTomlTableRange(contents, "[mcp_servers.calavera]");
-  const nextContents = range
-    ? [
-        ...contents.split("\n").slice(0, range.start),
-        block.trimEnd(),
-        ...contents.split("\n").slice(range.end),
-      ].join("\n")
-    : `${contents.trimEnd()}\n\n${block}`;
-
-  if (nextContents === contents) {
-    changes.push({ type: "skip", path, reason: "Already up to date." });
-    return "skip";
-  }
-
-  changes.push({ type: "update", path, reason: "Add or update Calavera MCP server." });
-
-  if (!dryRun) {
-    await writeFile(path, nextContents.endsWith("\n") ? nextContents : `${nextContents}\n`);
-  }
-
-  return "update";
-}
-
-/**
- * @param {string} path
- * @param {{ command: string, args: string[] }} launchCommand
- * @param {boolean} dryRun
- * @param {Change[]} changes
- * @returns {Promise<"write" | "update" | "skip">}
- */
-async function writeOpenCodeMcpConfig(path, launchCommand, dryRun, changes) {
-  /** @type {Record<string, unknown>} */
-  const currentConfig = (await fileExists(path))
-    ? assertJsonObjectConfig(await readJSON(path), path)
-    : {};
-  const mcp = currentConfig.mcp;
-
-  if (mcp !== undefined && !isPlainObject(mcp)) {
-    throw new Error(`${path} mcp must be an object.`);
-  }
-
-  return writeProjectJsonConfig(
-    path,
-    {
-      $schema: typeof currentConfig.$schema === "string" ? currentConfig.$schema : "https://opencode.ai/config.json",
-      ...currentConfig,
-      mcp: {
-        ...(isPlainObject(mcp) ? mcp : {}),
-        calavera: {
-          type: "local",
-          command: [launchCommand.command, ...launchCommand.args],
-          enabled: true,
-        },
-      },
-    },
-    dryRun,
-    changes,
-  );
-}
-
-/**
- * @param {McpHarness} harness
- * @returns {string | undefined}
- */
-function projectMcpConfigPath(harness) {
-  switch (harness) {
-    case "claude-code":
-      return ".mcp.json";
-    case "codex":
-      return ".codex/config.toml";
-    case "cursor":
-      return ".cursor/mcp.json";
-    case "opencode":
-      return "opencode.json";
-    default:
-      return undefined;
-  }
+  return JSON.stringify(createMcpServersJsonConfig(launchCommand), null, 2);
 }
 
 /**
@@ -1022,20 +784,7 @@ function createAgentBootstrapMcpInstructions(packageManager) {
   const launchCommand = createMcpLaunchCommand(packageManager);
   const mcpConfig = createMcpServerConfigSnippet(launchCommand);
   const codexConfig = createCodexMcpTomlBlock(launchCommand).trimEnd();
-  const opencodeConfig = JSON.stringify(
-    {
-      $schema: "https://opencode.ai/config.json",
-      mcp: {
-        calavera: {
-          type: "local",
-          command: [launchCommand.command, ...launchCommand.args],
-          enabled: true,
-        },
-      },
-    },
-    null,
-    2,
-  );
+  const opencodeConfig = JSON.stringify(createOpenCodeMcpJsonConfig(launchCommand), null, 2);
   const shellCommand = formatShellCommand(launchCommand);
   const manualCommandReference = createMcpManualCommandReference();
 
@@ -2085,20 +1834,32 @@ async function writeAgentBootstrapMcpConfig(harness, launchCommand, dryRun, chan
 
   /** @type {"write" | "update" | "skip"} */
   let action;
+  const initialChangeCount = changes.length;
 
-  switch (harness) {
-    case "claude-code":
-    case "cursor":
-      action = await writeMcpServersJsonConfig(path, launchCommand, dryRun, changes);
-      break;
-    case "codex":
-      action = await writeCodexMcpConfig(path, launchCommand, dryRun, changes);
-      break;
-    case "opencode":
-      action = await writeOpenCodeMcpConfig(path, launchCommand, dryRun, changes);
-      break;
-    default:
-      action = "skip";
+  try {
+    switch (harness) {
+      case "claude-code":
+      case "cursor":
+        action = await writeMcpServersJsonConfig(path, launchCommand, dryRun, changes);
+        break;
+      case "codex":
+        action = await writeCodexMcpConfig(path, launchCommand, dryRun, changes);
+        break;
+      case "opencode":
+        action = await writeOpenCodeMcpConfig(path, launchCommand, dryRun, changes);
+        break;
+      default:
+        action = "skip";
+    }
+  } catch (error) {
+    changes.splice(initialChangeCount);
+    return {
+      harness,
+      action: "manual",
+      reason: `Could not write project MCP config at ${path}: ${
+        error instanceof Error ? error.message : String(error)
+      }. Follow ${AGENT_BOOTSTRAP_MCP_FILE} for manual setup.`,
+    };
   }
 
   return { harness, action, path };
@@ -2267,13 +2028,6 @@ export async function agentBootstrap(options = {}) {
   const changes = [...aiResult.changes];
 
   await writeAgentBootstrapGuidance(bootstrapOptions, changes);
-  await writeBootstrapTextFile(
-    AGENT_BOOTSTRAP_MCP_FILE,
-    createAgentBootstrapMcpInstructions(packageManager),
-    bootstrapOptions.dryRun,
-    changes,
-    "Existing Calavera MCP setup notes differ and were left unchanged.",
-  );
   const mcpHarness = await resolveAgentBootstrapMcpHarness(bootstrapOptions);
   const mcp = await writeAgentBootstrapMcpConfig(
     mcpHarness,
@@ -2281,6 +2035,16 @@ export async function agentBootstrap(options = {}) {
     bootstrapOptions.dryRun,
     changes,
   );
+
+  if (mcp.action === "manual") {
+    await writeBootstrapTextFile(
+      AGENT_BOOTSTRAP_MCP_FILE,
+      createAgentBootstrapMcpInstructions(packageManager),
+      bootstrapOptions.dryRun,
+      changes,
+      "Existing Calavera MCP setup notes differ and were left unchanged.",
+    );
+  }
 
   const wroteFallbackGuidance = changes.some(
     (change) => change.path === AGENT_BOOTSTRAP_FALLBACK_GUIDANCE_FILE,
@@ -2310,7 +2074,7 @@ export async function agentBootstrap(options = {}) {
       ...aiResult.pointers,
       agentGuidancePointer,
       mcpPointer,
-      `MCP setup notes: ${AGENT_BOOTSTRAP_MCP_FILE}`,
+      ...(mcp.action === "manual" ? [`MCP setup notes: ${AGENT_BOOTSTRAP_MCP_FILE}`] : []),
     ],
     nextPrompt: AGENT_BOOTSTRAP_NEXT_PROMPT,
     mcp,
@@ -2877,7 +2641,6 @@ Options:
   --ai-artifact <id>   Add a bundled AI artifact; repeatable
   --agents-md <mode>   append or fallback when AGENTS.md already exists
   --mcp-harness <host> claude-code, codex, cursor, opencode, or skip
-  --mcp-host <host>    Alias for --mcp-harness
   --json               Print JSON output
   --yes                Use defaults and skip prompts
   --no-install         Write files without installing dependencies during apply

--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ import { pluralizeCount, style, titleCase } from "./utils/text.js";
 
 /**
  * @typedef {"npm" | "pnpm" | "yarn" | "bun"} PackageManager
+ * @typedef {"claude-code" | "codex" | "cursor" | "opencode" | "skip"} McpHarness
  * @typedef {import("./ai/artifacts.js").AiArtifactState} AiArtifactState
  * @typedef {import("./state.js").CalaveraState} CalaveraState
  * @typedef {import("./state.js").ManagedFileState} ManagedFileState
@@ -77,6 +78,7 @@ import { pluralizeCount, style, titleCase } from "./utils/text.js";
  * @property {boolean} apply
  * @property {PackageManager} [packageManager]
  * @property {"append" | "fallback"} [agentsMd]
+ * @property {McpHarness} [mcpHarness]
  * @property {string} [profile]
  * @property {string[]} integrations
  * @property {{ id: string, target?: string }[]} aiArtifacts
@@ -154,6 +156,7 @@ import { pluralizeCount, style, titleCase } from "./utils/text.js";
  * @property {Change[]} changes
  * @property {string[]} pointers
  * @property {string} nextPrompt
+ * @property {{ harness: McpHarness, action: "manual" | "write" | "update" | "skip", path?: string, reason?: string }} mcp
  *
  * @typedef {ApplyResult | CleanResult | DoctorResult | InitResult | AgentInitResult} CommandResult
  */
@@ -202,6 +205,8 @@ const packageManagerCommands = {
 const supportedPackageManagers = /** @type {PackageManager[]} */ (
   Object.keys(packageManagerCommands)
 );
+/** @type {McpHarness[]} */
+const supportedMcpHarnesses = ["claude-code", "codex", "cursor", "opencode", "skip"];
 const supportedProfiles = profileIdsForRecipe();
 const recipePackageManagers = packageManagerIdsForRecipe();
 const args = process.argv.slice(2);
@@ -214,6 +219,8 @@ const cliParseOptions = {
   init: { type: "boolean" },
   json: { type: "boolean" },
   "agents-md": { type: "string" },
+  "mcp-harness": { type: "string" },
+  "mcp-host": { type: "string" },
   "no-install": { type: "boolean" },
   yes: { type: "boolean" },
   "package-manager": { type: "string" },
@@ -294,6 +301,20 @@ function assertSupportedPackageManager(packageManager) {
 }
 
 /**
+ * @param {string | undefined} harness
+ * @returns {McpHarness}
+ */
+function assertSupportedMcpHarness(harness) {
+  if (!harness || !supportedMcpHarnesses.includes(/** @type {McpHarness} */ (harness))) {
+    throw new Error(
+      `Invalid MCP harness: ${harness ?? "<missing>"}. Allowed values: ${supportedMcpHarnesses.join(", ")}.`,
+    );
+  }
+
+  return /** @type {McpHarness} */ (harness);
+}
+
+/**
  * @param {string[]} rawArgs
  * @returns {CliOptions}
  */
@@ -307,6 +328,7 @@ export function parseArgs(rawArgs) {
   const profile = optionalStringValue(values.profile);
   const packageManager = optionalStringValue(values["package-manager"]);
   const agentsMd = optionalStringValue(values["agents-md"]);
+  const mcpHarness = optionalStringValue(values["mcp-harness"] ?? values["mcp-host"]);
   /** @type {CliOptions} */
   const parsed = {
     command: values.help ? "help" : values.init ? "agent-init" : (positionals[0] ?? "init"),
@@ -339,6 +361,10 @@ export function parseArgs(rawArgs) {
   if (agentsMd !== undefined) {
     assertKnownValue("agents-md", agentsMd, ["append", "fallback"]);
     parsed.agentsMd = /** @type {"append" | "fallback"} */ (agentsMd);
+  }
+
+  if (mcpHarness !== undefined) {
+    parsed.mcpHarness = assertSupportedMcpHarness(mcpHarness);
   }
 
   return parsed;
@@ -750,6 +776,244 @@ function createMcpServerConfigSnippet(launchCommand) {
 }
 
 /**
+ * @param {unknown} value
+ * @param {string} path
+ * @returns {Record<string, unknown>}
+ */
+function assertJsonObjectConfig(value, path) {
+  if (!isPlainObject(value)) {
+    throw new Error(`${path} must contain a JSON object.`);
+  }
+
+  return /** @type {Record<string, unknown>} */ (value);
+}
+
+/**
+ * @param {string} path
+ * @param {Record<string, unknown>} nextConfig
+ * @param {boolean} dryRun
+ * @param {Change[]} changes
+ * @returns {Promise<"write" | "update" | "skip">}
+ */
+async function writeProjectJsonConfig(path, nextConfig, dryRun, changes) {
+  if (!(await fileExists(path))) {
+    changes.push({ type: "write", path });
+
+    if (!dryRun) {
+      const directory = dirname(path);
+      if (directory !== ".") {
+        await mkdir(directory, { recursive: true });
+      }
+      await writeJSON(path, nextConfig, false);
+    }
+
+    return "write";
+  }
+
+  assertJsonObjectConfig(await readJSON(path), path);
+  const nextContents = `${JSON.stringify(nextConfig, null, 2)}\n`;
+  const currentContents = await readFile(path, "utf8");
+
+  if (currentContents === nextContents) {
+    changes.push({ type: "skip", path, reason: "Already up to date." });
+    return "skip";
+  }
+
+  changes.push({ type: "update", path, reason: "Add or update Calavera MCP server." });
+
+  if (!dryRun) {
+    await writeFile(path, nextContents);
+  }
+
+  return "update";
+}
+
+/**
+ * @param {string} path
+ * @param {{ command: string, args: string[] }} launchCommand
+ * @param {boolean} dryRun
+ * @param {Change[]} changes
+ * @returns {Promise<"write" | "update" | "skip">}
+ */
+async function writeMcpServersJsonConfig(path, launchCommand, dryRun, changes) {
+  /** @type {Record<string, unknown>} */
+  const currentConfig = (await fileExists(path))
+    ? assertJsonObjectConfig(await readJSON(path), path)
+    : {};
+  const mcpServers = currentConfig.mcpServers;
+
+  if (mcpServers !== undefined && !isPlainObject(mcpServers)) {
+    throw new Error(`${path} mcpServers must be an object.`);
+  }
+
+  return writeProjectJsonConfig(
+    path,
+    {
+      ...currentConfig,
+      mcpServers: {
+        ...(isPlainObject(mcpServers) ? mcpServers : {}),
+        calavera: launchCommand,
+      },
+    },
+    dryRun,
+    changes,
+  );
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function tomlString(value) {
+  return JSON.stringify(value);
+}
+
+/**
+ * @param {string[]} values
+ * @returns {string}
+ */
+function tomlStringArray(values) {
+  return `[${values.map(tomlString).join(", ")}]`;
+}
+
+/**
+ * @param {{ command: string, args: string[] }} launchCommand
+ * @returns {string}
+ */
+function createCodexMcpTomlBlock(launchCommand) {
+  return [
+    "[mcp_servers.calavera]",
+    `command = ${tomlString(launchCommand.command)}`,
+    `args = ${tomlStringArray(launchCommand.args)}`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * @param {string} contents
+ * @param {string} header
+ * @returns {{ start: number, end: number } | undefined}
+ */
+function findTomlTableRange(contents, header) {
+  const lines = contents.split("\n");
+  const start = lines.findIndex((line) => line.trim() === header);
+
+  if (start === -1) {
+    return undefined;
+  }
+
+  const nextHeaderOffset = lines
+    .slice(start + 1)
+    .findIndex((line) => line.trim().startsWith("[") && line.trim().endsWith("]"));
+
+  return {
+    start,
+    end: nextHeaderOffset === -1 ? lines.length : start + 1 + nextHeaderOffset,
+  };
+}
+
+/**
+ * @param {string} path
+ * @param {{ command: string, args: string[] }} launchCommand
+ * @param {boolean} dryRun
+ * @param {Change[]} changes
+ * @returns {Promise<"write" | "update" | "skip">}
+ */
+async function writeCodexMcpConfig(path, launchCommand, dryRun, changes) {
+  const block = createCodexMcpTomlBlock(launchCommand);
+
+  if (!(await fileExists(path))) {
+    changes.push({ type: "write", path });
+
+    if (!dryRun) {
+      await mkdir(dirname(path), { recursive: true });
+      await writeFile(path, block);
+    }
+
+    return "write";
+  }
+
+  const contents = await readFile(path, "utf8");
+  const range = findTomlTableRange(contents, "[mcp_servers.calavera]");
+  const nextContents = range
+    ? [
+        ...contents.split("\n").slice(0, range.start),
+        block.trimEnd(),
+        ...contents.split("\n").slice(range.end),
+      ].join("\n")
+    : `${contents.trimEnd()}\n\n${block}`;
+
+  if (nextContents === contents) {
+    changes.push({ type: "skip", path, reason: "Already up to date." });
+    return "skip";
+  }
+
+  changes.push({ type: "update", path, reason: "Add or update Calavera MCP server." });
+
+  if (!dryRun) {
+    await writeFile(path, nextContents.endsWith("\n") ? nextContents : `${nextContents}\n`);
+  }
+
+  return "update";
+}
+
+/**
+ * @param {string} path
+ * @param {{ command: string, args: string[] }} launchCommand
+ * @param {boolean} dryRun
+ * @param {Change[]} changes
+ * @returns {Promise<"write" | "update" | "skip">}
+ */
+async function writeOpenCodeMcpConfig(path, launchCommand, dryRun, changes) {
+  /** @type {Record<string, unknown>} */
+  const currentConfig = (await fileExists(path))
+    ? assertJsonObjectConfig(await readJSON(path), path)
+    : {};
+  const mcp = currentConfig.mcp;
+
+  if (mcp !== undefined && !isPlainObject(mcp)) {
+    throw new Error(`${path} mcp must be an object.`);
+  }
+
+  return writeProjectJsonConfig(
+    path,
+    {
+      $schema: typeof currentConfig.$schema === "string" ? currentConfig.$schema : "https://opencode.ai/config.json",
+      ...currentConfig,
+      mcp: {
+        ...(isPlainObject(mcp) ? mcp : {}),
+        calavera: {
+          type: "local",
+          command: [launchCommand.command, ...launchCommand.args],
+          enabled: true,
+        },
+      },
+    },
+    dryRun,
+    changes,
+  );
+}
+
+/**
+ * @param {McpHarness} harness
+ * @returns {string | undefined}
+ */
+function projectMcpConfigPath(harness) {
+  switch (harness) {
+    case "claude-code":
+      return ".mcp.json";
+    case "codex":
+      return ".codex/config.toml";
+    case "cursor":
+      return ".cursor/mcp.json";
+    case "opencode":
+      return "opencode.json";
+    default:
+      return undefined;
+  }
+}
+
+/**
  * @param {PackageManager} packageManager
  * @returns {string}
  */
@@ -757,32 +1021,76 @@ function createAgentBootstrapMcpInstructions(packageManager) {
   const commands = projectLocalCommandCatalog[packageManager];
   const launchCommand = createMcpLaunchCommand(packageManager);
   const mcpConfig = createMcpServerConfigSnippet(launchCommand);
+  const codexConfig = createCodexMcpTomlBlock(launchCommand).trimEnd();
+  const opencodeConfig = JSON.stringify(
+    {
+      $schema: "https://opencode.ai/config.json",
+      mcp: {
+        calavera: {
+          type: "local",
+          command: [launchCommand.command, ...launchCommand.args],
+          enabled: true,
+        },
+      },
+    },
+    null,
+    2,
+  );
   const shellCommand = formatShellCommand(launchCommand);
   const manualCommandReference = createMcpManualCommandReference();
 
   return `# Calavera MCP Setup
 
-Register the Calavera MCP server from the project root using this project's package manager (${commands.label}):
+Calavera can configure MCP automatically during \`--init\` for one project-local
+agent harness. It never writes global/user MCP config. If you skipped
+auto-config or need to repair a setup manually, use the project-local target for
+your harness.
+
+This project's detected package manager is ${commands.label}; the launch command
+is:
+
+\`\`\`bash
+${shellCommand}
+\`\`\`
+
+## Project-local targets
+
+### Claude Code: \`.mcp.json\`
 
 \`\`\`json
 ${mcpConfig}
 \`\`\`
 
-Project-scoped MCP servers run with the project root as their working directory.
-Using the package manager declared by the project avoids package-manager
-preflight failures before Calavera can start, such as npm rejecting a Bun-managed
-project through \`devEngines.packageManager\`.
+### Cursor: \`.cursor/mcp.json\`
+
+\`\`\`json
+${mcpConfig}
+\`\`\`
+
+### Codex: \`.codex/config.toml\`
+
+\`\`\`toml
+${codexConfig}
+\`\`\`
+
+### OpenCode: \`opencode.json\`
+
+\`\`\`json
+${opencodeConfig}
+\`\`\`
+
+Project-local MCP servers should be registered from the project root. Using the
+package manager declared by the project avoids package-manager preflight
+failures before Calavera can start, such as npm rejecting a Bun-managed project
+through \`devEngines.packageManager\`.
 
 When configuring an MCP server manually, choose the command that matches the
-project's package manager. Put the first word in the MCP \`command\` field and
-the remaining words in \`args\`:
+project's package manager:
 
 ${manualCommandReference}
 
-If your agent exposes an MCP setup UI or config writer, use the snippet above.
-If the agent needs approval before editing its own config, ask first.
-After registration, reload or restart the agent session if your MCP host does
-not discover new tools dynamically. Confirm the Calavera tools are visible before
+After registration, reload or restart the agent session if your MCP host does not
+discover new tools dynamically. Confirm the Calavera tools are visible before
 composing a recipe.
 
 Do not work around missing MCP tools by reading npm cache internals or importing
@@ -823,21 +1131,9 @@ path to \`.calavera/bun-install-cache\`. Keep these environment overrides on Bun
 MCP registrations only; they are recovery settings for restricted hosts, not
 part of the default Calavera MCP config.
 
-## Claude Code
+## Calavera MCP workflow
 
-For Claude Code, prefer a project-scoped \`.mcp.json\` in the project root when
-the team should share the Calavera server registration. Use the same package
-manager-specific snippet above.
-
-Do not put this server registration in \`.claude/settings.json\`; Claude Code
-does not load MCP servers from that file. You can also register the same command
-with \`claude mcp add\` if you want Claude Code to manage the entry.
-
-Registering this MCP server is a persistent code-execution change because it
-runs \`${shellCommand}\`. Ask for explicit user approval before creating
-\`.mcp.json\`, running \`claude mcp add\`, or approving the first server launch.
-
-Use the tools in this order:
+Use the tools in this order when they are available:
 
 1. \`inspect_project\`
 2. \`list_profiles\`
@@ -1721,6 +2017,94 @@ async function resolveAgentBootstrapGuidanceMode(options) {
 }
 
 /**
+ * @param {CliOptions} options
+ * @returns {Promise<McpHarness>}
+ */
+async function resolveAgentBootstrapMcpHarness(options) {
+  if (options.mcpHarness) {
+    return options.mcpHarness;
+  }
+
+  if (options.json || options.assumeYes || !process.stdin.isTTY) {
+    return "skip";
+  }
+
+  const selected = await select({
+    message: "Configure the Calavera MCP server for which agent harness?",
+    options: [
+      {
+        value: "claude-code",
+        label: "Claude Code",
+        hint: "Write project .mcp.json",
+      },
+      {
+        value: "codex",
+        label: "Codex",
+        hint: "Write project .codex/config.toml",
+      },
+      {
+        value: "cursor",
+        label: "Cursor",
+        hint: "Write project .cursor/mcp.json",
+      },
+      {
+        value: "opencode",
+        label: "OpenCode",
+        hint: "Write project opencode.json",
+      },
+      {
+        value: "skip",
+        label: "Skip auto-config",
+        hint: `Use ${AGENT_BOOTSTRAP_MCP_FILE} for manual setup`,
+      },
+    ],
+  });
+
+  exitIfCancel(selected);
+
+  return assertSupportedMcpHarness(typeof selected === "string" ? selected : "skip");
+}
+
+/**
+ * @param {McpHarness} harness
+ * @param {{ command: string, args: string[] }} launchCommand
+ * @param {boolean} dryRun
+ * @param {Change[]} changes
+ * @returns {Promise<{ harness: McpHarness, action: "manual" | "write" | "update" | "skip", path?: string, reason?: string }>}
+ */
+async function writeAgentBootstrapMcpConfig(harness, launchCommand, dryRun, changes) {
+  const path = projectMcpConfigPath(harness);
+
+  if (!path) {
+    return {
+      harness,
+      action: "manual",
+      reason: `Skipped project MCP auto-config. Follow ${AGENT_BOOTSTRAP_MCP_FILE} for manual setup.`,
+    };
+  }
+
+  /** @type {"write" | "update" | "skip"} */
+  let action;
+
+  switch (harness) {
+    case "claude-code":
+    case "cursor":
+      action = await writeMcpServersJsonConfig(path, launchCommand, dryRun, changes);
+      break;
+    case "codex":
+      action = await writeCodexMcpConfig(path, launchCommand, dryRun, changes);
+      break;
+    case "opencode":
+      action = await writeOpenCodeMcpConfig(path, launchCommand, dryRun, changes);
+      break;
+    default:
+      action = "skip";
+  }
+
+  return { harness, action, path };
+}
+
+/**
  * @param {string} contents
  * @param {string} section
  * @returns {{ contents: string, changed: boolean }}
@@ -1869,6 +2253,7 @@ export async function agentBootstrap(options = {}) {
   const packageManager = assertSupportedPackageManager(
     bootstrapOptions.packageManager ?? detectPackageManager(detectedPackageJSON) ?? "npm",
   );
+  const launchCommand = createMcpLaunchCommand(packageManager);
 
   await assertBootstrapDirectoryAvailable(".calavera");
 
@@ -1889,6 +2274,13 @@ export async function agentBootstrap(options = {}) {
     changes,
     "Existing Calavera MCP setup notes differ and were left unchanged.",
   );
+  const mcpHarness = await resolveAgentBootstrapMcpHarness(bootstrapOptions);
+  const mcp = await writeAgentBootstrapMcpConfig(
+    mcpHarness,
+    launchCommand,
+    bootstrapOptions.dryRun,
+    changes,
+  );
 
   const wroteFallbackGuidance = changes.some(
     (change) => change.path === AGENT_BOOTSTRAP_FALLBACK_GUIDANCE_FILE,
@@ -1896,6 +2288,10 @@ export async function agentBootstrap(options = {}) {
   const agentGuidancePointer = wroteFallbackGuidance
     ? `Agent guidance: ${AGENT_BOOTSTRAP_FALLBACK_GUIDANCE_FILE} for manual merge with ${AGENT_BOOTSTRAP_GUIDANCE_FILE}`
     : `Agent guidance: ${AGENT_BOOTSTRAP_GUIDANCE_FILE}`;
+  const mcpPointer =
+    mcp.action === "manual"
+      ? `MCP setup: manual (${AGENT_BOOTSTRAP_MCP_FILE})`
+      : `MCP setup: ${mcp.path}`;
 
   if (!bootstrapOptions.dryRun) {
     await mkdir(".calavera", { recursive: true });
@@ -1913,9 +2309,11 @@ export async function agentBootstrap(options = {}) {
     pointers: [
       ...aiResult.pointers,
       agentGuidancePointer,
+      mcpPointer,
       `MCP setup notes: ${AGENT_BOOTSTRAP_MCP_FILE}`,
     ],
     nextPrompt: AGENT_BOOTSTRAP_NEXT_PROMPT,
+    mcp,
   };
 }
 
@@ -2478,6 +2876,8 @@ Options:
   --tool <id>          Add an integration by id or label; repeatable
   --ai-artifact <id>   Add a bundled AI artifact; repeatable
   --agents-md <mode>   append or fallback when AGENTS.md already exists
+  --mcp-harness <host> claude-code, codex, cursor, opencode, or skip
+  --mcp-host <host>    Alias for --mcp-harness
   --json               Print JSON output
   --yes                Use defaults and skip prompts
   --no-install         Write files without installing dependencies during apply
@@ -2491,7 +2891,7 @@ Agent-first setup:
 
 MCP-first workflow:
   1. Run the agent bootstrap command above from the project root.
-  2. Register the MCP server from .agents/calavera/mcp.md.
+  2. Choose exactly one project-local MCP host when prompted, or skip for manual setup.
   3. Reload or restart the agent session if required by your MCP host.
   4. Confirm these tools are visible before composing a recipe:
      inspect_project, list_profiles, list_integrations, list_ai_artifacts,
@@ -2507,7 +2907,9 @@ Package-runner syntax:
     npx --package create-project-calavera@${packageJson.version} create-project-calavera --init
 
   MCP launch commands run create-project-calavera-mcp directly; do not add --help
-  or inspect npm cache internals as a substitute for MCP setup.`;
+  or inspect npm cache internals as a substitute for MCP setup.
+
+  Calavera only writes project-local MCP config. Global host config is manual.`;
 }
 
 function printHelp() {
@@ -2574,6 +2976,11 @@ function printResult(result, asJSON = false) {
       logger.info(pointer);
     }
 
+    logger.info(
+      result.mcp.action === "manual"
+        ? `MCP auto-config skipped: ${result.mcp.reason}`
+        : `MCP auto-config ${result.mcp.action}: ${result.mcp.path}`,
+    );
     logger.info("Review the files above to confirm what Calavera changed or skipped.");
     logger.info(`Next prompt: ${result.nextPrompt}`);
     return;

--- a/src/utils/mcp-config.js
+++ b/src/utils/mcp-config.js
@@ -2,7 +2,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
-import { fileExists, readJSON, writeJSON } from "./fs.js";
+import { fileExists, writeJSON } from "./fs.js";
 import { isPlainObject } from "./guards.js";
 
 /**
@@ -41,15 +41,32 @@ function normalizeConfigPath(path) {
 
 /**
  * @param {string} path
+ * @returns {Promise<{ currentConfig: Record<string, unknown>, currentContents?: string }>}
+ */
+async function readProjectJsonConfigIfPresent(path) {
+  if (!(await fileExists(path))) {
+    return { currentConfig: {} };
+  }
+
+  const currentContents = await readFile(path, "utf8");
+  return {
+    currentConfig: assertJsonObjectConfig(JSON.parse(currentContents), path),
+    currentContents,
+  };
+}
+
+/**
+ * @param {string} path
  * @param {Record<string, unknown>} nextConfig
  * @param {boolean} dryRun
  * @param {McpConfigChange[]} changes
+ * @param {string} [currentContents]
  * @returns {Promise<McpConfigAction>}
  */
-async function writeProjectJsonConfig(path, nextConfig, dryRun, changes) {
+async function writeProjectJsonConfig(path, nextConfig, dryRun, changes, currentContents) {
   const targetPath = normalizeConfigPath(path);
 
-  if (!(await fileExists(targetPath))) {
+  if (currentContents === undefined) {
     changes.push({ type: "write", path: targetPath });
 
     if (!dryRun) {
@@ -63,9 +80,7 @@ async function writeProjectJsonConfig(path, nextConfig, dryRun, changes) {
     return "write";
   }
 
-  assertJsonObjectConfig(await readJSON(targetPath), targetPath);
   const nextContents = `${JSON.stringify(nextConfig, null, 2)}\n`;
-  const currentContents = await readFile(targetPath, "utf8");
 
   if (currentContents === nextContents) {
     changes.push({ type: "skip", path: targetPath, reason: "Already up to date." });
@@ -102,10 +117,7 @@ export function createMcpServersJsonConfig(launchCommand) {
  */
 export async function writeMcpServersJsonConfig(path, launchCommand, dryRun, changes) {
   const targetPath = normalizeConfigPath(path);
-  /** @type {Record<string, unknown>} */
-  const currentConfig = (await fileExists(targetPath))
-    ? assertJsonObjectConfig(await readJSON(targetPath), targetPath)
-    : {};
+  const { currentConfig, currentContents } = await readProjectJsonConfigIfPresent(targetPath);
   const mcpServers = currentConfig.mcpServers;
 
   if (mcpServers !== undefined && !isPlainObject(mcpServers)) {
@@ -123,6 +135,7 @@ export async function writeMcpServersJsonConfig(path, launchCommand, dryRun, cha
     },
     dryRun,
     changes,
+    currentContents,
   );
 }
 
@@ -253,10 +266,7 @@ export function createOpenCodeMcpJsonConfig(launchCommand) {
  */
 export async function writeOpenCodeMcpConfig(path, launchCommand, dryRun, changes) {
   const targetPath = normalizeConfigPath(path);
-  /** @type {Record<string, unknown>} */
-  const currentConfig = (await fileExists(targetPath))
-    ? assertJsonObjectConfig(await readJSON(targetPath), targetPath)
-    : {};
+  const { currentConfig, currentContents } = await readProjectJsonConfigIfPresent(targetPath);
   const mcp = currentConfig.mcp;
 
   if (mcp !== undefined && !isPlainObject(mcp)) {
@@ -282,6 +292,7 @@ export async function writeOpenCodeMcpConfig(path, launchCommand, dryRun, change
     },
     dryRun,
     changes,
+    currentContents,
   );
 }
 

--- a/src/utils/mcp-config.js
+++ b/src/utils/mcp-config.js
@@ -266,8 +266,11 @@ export async function writeOpenCodeMcpConfig(path, launchCommand, dryRun, change
   return writeProjectJsonConfig(
     targetPath,
     {
-      ...createOpenCodeMcpJsonConfig(launchCommand),
       ...currentConfig,
+      $schema:
+        typeof currentConfig.$schema === "string"
+          ? currentConfig.$schema
+          : "https://opencode.ai/config.json",
       mcp: {
         ...(isPlainObject(mcp) ? mcp : {}),
         calavera: {

--- a/src/utils/mcp-config.js
+++ b/src/utils/mcp-config.js
@@ -1,0 +1,302 @@
+// @ts-check
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import { fileExists, readJSON, writeJSON } from "./fs.js";
+import { isPlainObject } from "./guards.js";
+
+/**
+ * @typedef {{ command: string, args: string[] }} McpLaunchCommand
+ * @typedef {"claude-code" | "codex" | "cursor" | "opencode" | "skip"} McpHarness
+ * @typedef {"write" | "update" | "skip"} McpConfigAction
+ * @typedef {{ type: string, path: string, reason?: string }} McpConfigChange
+ */
+
+/**
+ * @param {unknown} value
+ * @param {string} path
+ * @returns {Record<string, unknown>}
+ */
+function assertJsonObjectConfig(value, path) {
+  if (!isPlainObject(value)) {
+    throw new Error(`${path} must contain a JSON object.`);
+  }
+
+  return /** @type {Record<string, unknown>} */ (value);
+}
+
+/**
+ * @param {string} path
+ * @returns {string}
+ */
+function normalizeConfigPath(path) {
+  const targetPath = path.trim();
+
+  if (!targetPath) {
+    throw new Error("MCP config path must be a non-empty string.");
+  }
+
+  return targetPath;
+}
+
+/**
+ * @param {string} path
+ * @param {Record<string, unknown>} nextConfig
+ * @param {boolean} dryRun
+ * @param {McpConfigChange[]} changes
+ * @returns {Promise<McpConfigAction>}
+ */
+async function writeProjectJsonConfig(path, nextConfig, dryRun, changes) {
+  const targetPath = normalizeConfigPath(path);
+
+  if (!(await fileExists(targetPath))) {
+    changes.push({ type: "write", path: targetPath });
+
+    if (!dryRun) {
+      const directory = dirname(targetPath).trim();
+      if (directory !== ".") {
+        await mkdir(directory, { recursive: true });
+      }
+      await writeJSON(targetPath, nextConfig, false);
+    }
+
+    return "write";
+  }
+
+  assertJsonObjectConfig(await readJSON(targetPath), targetPath);
+  const nextContents = `${JSON.stringify(nextConfig, null, 2)}\n`;
+  const currentContents = await readFile(targetPath, "utf8");
+
+  if (currentContents === nextContents) {
+    changes.push({ type: "skip", path: targetPath, reason: "Already up to date." });
+    return "skip";
+  }
+
+  changes.push({ type: "update", path: targetPath, reason: "Add or update Calavera MCP server." });
+
+  if (!dryRun) {
+    await writeFile(targetPath, nextContents);
+  }
+
+  return "update";
+}
+
+/**
+ * @param {McpLaunchCommand} launchCommand
+ * @returns {Record<string, unknown>}
+ */
+export function createMcpServersJsonConfig(launchCommand) {
+  return {
+    mcpServers: {
+      calavera: launchCommand,
+    },
+  };
+}
+
+/**
+ * @param {string} path
+ * @param {McpLaunchCommand} launchCommand
+ * @param {boolean} dryRun
+ * @param {McpConfigChange[]} changes
+ * @returns {Promise<McpConfigAction>}
+ */
+export async function writeMcpServersJsonConfig(path, launchCommand, dryRun, changes) {
+  const targetPath = normalizeConfigPath(path);
+  /** @type {Record<string, unknown>} */
+  const currentConfig = (await fileExists(targetPath))
+    ? assertJsonObjectConfig(await readJSON(targetPath), targetPath)
+    : {};
+  const mcpServers = currentConfig.mcpServers;
+
+  if (mcpServers !== undefined && !isPlainObject(mcpServers)) {
+    throw new Error(`${targetPath} mcpServers must be an object.`);
+  }
+
+  return writeProjectJsonConfig(
+    targetPath,
+    {
+      ...currentConfig,
+      mcpServers: {
+        ...(isPlainObject(mcpServers) ? mcpServers : {}),
+        calavera: launchCommand,
+      },
+    },
+    dryRun,
+    changes,
+  );
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function tomlString(value) {
+  return JSON.stringify(value);
+}
+
+/**
+ * @param {string[]} values
+ * @returns {string}
+ */
+function tomlStringArray(values) {
+  return `[${values.map(tomlString).join(", ")}]`;
+}
+
+/**
+ * @param {McpLaunchCommand} launchCommand
+ * @returns {string}
+ */
+export function createCodexMcpTomlBlock(launchCommand) {
+  return [
+    "[mcp_servers.calavera]",
+    `command = ${tomlString(launchCommand.command)}`,
+    `args = ${tomlStringArray(launchCommand.args)}`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * @param {string} contents
+ * @param {string} header
+ * @returns {{ start: number, end: number } | undefined}
+ */
+function findTomlTableRange(contents, header) {
+  const lines = contents.split("\n");
+  const start = lines.findIndex((line) => line.trim() === header);
+
+  if (start === -1) {
+    return undefined;
+  }
+
+  const nextHeaderOffset = lines
+    .slice(start + 1)
+    .findIndex((line) => line.trim().startsWith("[") && line.trim().endsWith("]"));
+
+  return {
+    start,
+    end: nextHeaderOffset === -1 ? lines.length : start + 1 + nextHeaderOffset,
+  };
+}
+
+/**
+ * @param {string} path
+ * @param {McpLaunchCommand} launchCommand
+ * @param {boolean} dryRun
+ * @param {McpConfigChange[]} changes
+ * @returns {Promise<McpConfigAction>}
+ */
+export async function writeCodexMcpConfig(path, launchCommand, dryRun, changes) {
+  const targetPath = normalizeConfigPath(path);
+  const block = createCodexMcpTomlBlock(launchCommand);
+
+  if (!(await fileExists(targetPath))) {
+    changes.push({ type: "write", path: targetPath });
+
+    if (!dryRun) {
+      const directory = dirname(targetPath).trim();
+      if (directory !== ".") {
+        await mkdir(directory, { recursive: true });
+      }
+      await writeFile(targetPath, block);
+    }
+
+    return "write";
+  }
+
+  const contents = await readFile(targetPath, "utf8");
+  const range = findTomlTableRange(contents, "[mcp_servers.calavera]");
+  const nextContents = range
+    ? [
+        ...contents.split("\n").slice(0, range.start),
+        block.trimEnd(),
+        ...contents.split("\n").slice(range.end),
+      ].join("\n")
+    : `${contents.trimEnd()}\n\n${block}`;
+
+  if (nextContents === contents) {
+    changes.push({ type: "skip", path: targetPath, reason: "Already up to date." });
+    return "skip";
+  }
+
+  changes.push({ type: "update", path: targetPath, reason: "Add or update Calavera MCP server." });
+
+  if (!dryRun) {
+    await writeFile(targetPath, nextContents.endsWith("\n") ? nextContents : `${nextContents}\n`);
+  }
+
+  return "update";
+}
+
+/**
+ * @param {McpLaunchCommand} launchCommand
+ * @returns {Record<string, unknown>}
+ */
+export function createOpenCodeMcpJsonConfig(launchCommand) {
+  return {
+    $schema: "https://opencode.ai/config.json",
+    mcp: {
+      calavera: {
+        type: "local",
+        command: [launchCommand.command, ...launchCommand.args],
+        enabled: true,
+      },
+    },
+  };
+}
+
+/**
+ * @param {string} path
+ * @param {McpLaunchCommand} launchCommand
+ * @param {boolean} dryRun
+ * @param {McpConfigChange[]} changes
+ * @returns {Promise<McpConfigAction>}
+ */
+export async function writeOpenCodeMcpConfig(path, launchCommand, dryRun, changes) {
+  const targetPath = normalizeConfigPath(path);
+  /** @type {Record<string, unknown>} */
+  const currentConfig = (await fileExists(targetPath))
+    ? assertJsonObjectConfig(await readJSON(targetPath), targetPath)
+    : {};
+  const mcp = currentConfig.mcp;
+
+  if (mcp !== undefined && !isPlainObject(mcp)) {
+    throw new Error(`${targetPath} mcp must be an object.`);
+  }
+
+  return writeProjectJsonConfig(
+    targetPath,
+    {
+      ...createOpenCodeMcpJsonConfig(launchCommand),
+      ...currentConfig,
+      mcp: {
+        ...(isPlainObject(mcp) ? mcp : {}),
+        calavera: {
+          type: "local",
+          command: [launchCommand.command, ...launchCommand.args],
+          enabled: true,
+        },
+      },
+    },
+    dryRun,
+    changes,
+  );
+}
+
+/**
+ * @param {McpHarness} harness
+ * @returns {string | undefined}
+ */
+export function projectMcpConfigPath(harness) {
+  switch (harness) {
+    case "claude-code":
+      return ".mcp.json";
+    case "codex":
+      return ".codex/config.toml";
+    case "cursor":
+      return ".cursor/mcp.json";
+    case "opencode":
+      return "opencode.json";
+    default:
+      return undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- prompt/select one project-local MCP harness during agent bootstrap, with skip/manual as the non-interactive default
- write local MCP config for Claude Code, Codex, Cursor, and OpenCode without touching global config
- clean up MCP setup docs and bump the package version to 2.2.0

## Verification
- npm test
- npm run typecheck
- npm run lint:js (fails on pre-existing src/utils/logger.js no-console errors)

fix #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project-local MCP auto-configuration during `agent-init`/bootstrap with interactive host selection (Claude Code, Codex, Cursor, OpenCode) plus manual/skip mode.
  * Added `--mcp-harness` flag and enhanced output to summarize whether MCP config was written, updated, skipped, or left for manual setup.
* **Documentation**
  * Updated MCP-first workflow and README with host-specific config formats, clarified local-only config behavior, and improved package-manager-based registration guidance.
* **Tests**
  * Expanded bootstrap/schema coverage for structured dry-run results, harness-specific config writing/updating (including idempotency), and fallback to manual guidance when existing configs are invalid.
* **Chores**
  * Bumped version to **2.2.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->