### PR TITLE
Add managed-file reown support to apply and inspect flows

### DIFF
--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -1454,7 +1454,7 @@ test("apply can re-own approved managed file drift before writing recipe updates
     );
 
     const inspection = await inspectProject(nextRecipe, {
-      reownManagedFiles: ["oxlint.json"],
+      reownManagedFiles: [".\\oxlint.json"],
     });
     assert.equal(
       inspection.findings.some(
@@ -1474,7 +1474,7 @@ test("apply can re-own approved managed file drift before writing recipe updates
       json: true,
       noInstall: true,
       assumeYes: true,
-      reownManagedFiles: ["oxlint.json"],
+      reownManagedFiles: ["./oxlint.json"],
     });
     assert.equal(dryRun.dryRun, true);
     assert.equal(
@@ -1488,7 +1488,7 @@ test("apply can re-own approved managed file drift before writing recipe updates
       json: true,
       noInstall: true,
       assumeYes: true,
-      reownManagedFiles: ["oxlint.json"],
+      reownManagedFiles: [join(projectDirectory, "oxlint.json")],
     });
 
     const oxlintConfig = JSON.parse(await readFile("oxlint.json", "utf8"));
@@ -1622,6 +1622,10 @@ test("apply uses direct tool scripts without the run-if-files helper", async () 
     assert.equal(packageFile.scripts["format:check"], "oxfmt --check .");
     assert.equal(packageFile.scripts.typecheck, "tsc --noEmit");
     assert.doesNotMatch(JSON.stringify(packageFile.scripts), /run-if-files/);
+    const stylelintConfig = JSON.parse(await readFile(".stylelintrc.json", "utf8"));
+    assert.equal(stylelintConfig.ignoreFiles.includes("**/dist/**"), true);
+    assert.equal(stylelintConfig.ignoreFiles.includes("**/dist-types/**"), true);
+    assert.equal(stylelintConfig.ignoreFiles.includes("node_modules/**"), true);
     await assertPathMissing(".calavera/run-if-files.mjs");
   } finally {
     process.chdir(originalDirectory);

--- a/scripts/check-config-schema.test.mjs
+++ b/scripts/check-config-schema.test.mjs
@@ -458,6 +458,16 @@ test("CLI parser accepts scripted rich composer options", () => {
   ]);
   assert.equal(options.apply, true);
   assert.equal(options.assumeYes, true);
+  assert.deepEqual(
+    parseArgs([
+      "apply",
+      "--reown-managed-file",
+      "oxlint.json",
+      "--reown-managed-files",
+      ".prettierrc.json,tsconfig.json",
+    ]).reownManagedFiles,
+    ["oxlint.json", ".prettierrc.json", "tsconfig.json"],
+  );
 
   assert.deepEqual(
     parseArgs(["init", "--ai-artifact", "hook-block-dangerous-commands@team@codex"]).aiArtifacts,
@@ -1391,6 +1401,110 @@ test("apply dry runs allow formatting-only drift in managed JSON files", async (
       result.changes.some((change) => change.type === "write" && change.path === "oxlint.json"),
       true,
     );
+  } finally {
+    process.chdir(originalDirectory);
+  }
+});
+
+test("apply can re-own approved managed file drift before writing recipe updates", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-reown-managed-file-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile("package.json", `${JSON.stringify({ scripts: {} }, null, 2)}\n`);
+
+    const initialRecipe = buildRecipe("modern", ["oxlint"], "npm");
+    await applyRecipeObject(initialRecipe, {
+      json: true,
+      noInstall: true,
+      assumeYes: true,
+    });
+
+    const formattedOxlintConfig = `${JSON.stringify(
+      JSON.parse(await readFile("oxlint.json", "utf8")),
+      null,
+      4,
+    )}\n`;
+    await writeFile("oxlint.json", formattedOxlintConfig);
+
+    const nextRecipe = buildRecipe(
+      "modern",
+      [
+        "oxlint",
+        "oxlint-eslint",
+        "oxlint-typescript",
+        "oxlint-unicorn",
+        "oxlint-oxc",
+        "oxlint-react",
+        "oxlint-jsx-a11y",
+      ],
+      "npm",
+    );
+
+    await assert.rejects(
+      () =>
+        applyRecipeObject(nextRecipe, {
+          dryRun: true,
+          json: true,
+          noInstall: true,
+          assumeYes: true,
+        }),
+      /Refusing to overwrite existing managed file: oxlint\.json/,
+    );
+
+    const inspection = await inspectProject(nextRecipe, {
+      reownManagedFiles: ["oxlint.json"],
+    });
+    assert.equal(
+      inspection.findings.some(
+        (finding) => finding.kind === "managed-file-conflict" && finding.path === "oxlint.json",
+      ),
+      false,
+    );
+    assert.equal(
+      inspection.findings.some(
+        (finding) => finding.kind === "managed-file-reown" && finding.path === "oxlint.json",
+      ),
+      true,
+    );
+
+    const dryRun = await applyRecipeObject(nextRecipe, {
+      dryRun: true,
+      json: true,
+      noInstall: true,
+      assumeYes: true,
+      reownManagedFiles: ["oxlint.json"],
+    });
+    assert.equal(dryRun.dryRun, true);
+    assert.equal(
+      dryRun.projectInspection.findings.some(
+        (finding) => finding.kind === "managed-file-reown" && finding.path === "oxlint.json",
+      ),
+      true,
+    );
+
+    await applyRecipeObject(nextRecipe, {
+      json: true,
+      noInstall: true,
+      assumeYes: true,
+      reownManagedFiles: ["oxlint.json"],
+    });
+
+    const oxlintConfig = JSON.parse(await readFile("oxlint.json", "utf8"));
+    assert.deepEqual(oxlintConfig.plugins, [
+      "eslint",
+      "typescript",
+      "unicorn",
+      "oxc",
+      "react",
+      "jsx-a11y",
+    ]);
+
+    const state = JSON.parse(await readFile(".calavera/state.json", "utf8"));
+    assert.deepEqual(state.managedFiles, [
+      { path: "oxlint.json", hash: textHash(await readFile("oxlint.json", "utf8")) },
+    ]);
   } finally {
     process.chdir(originalDirectory);
   }

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -28,6 +28,8 @@ Treat files listed by `dry_run_apply` as Calavera-managed outputs. Do not hand-w
 
 `apply_recipe.writeConfig: false` only skips writing `calavera.config.json`. Do not use it to bypass managed-file conflicts, stale state hashes, or an unapproved dry-run result.
 
+Use `reownManagedFiles` only after the user explicitly approves treating listed Calavera-tracked files' current contents as intentional local state before dry-run/apply.
+
 ## MCP Setup
 
 If the Calavera MCP tools are not available, help the user register this server from the project root. Check the target project's `package.json` first and use the package manager declared by `packageManager` or `devEngines.packageManager`.

--- a/src/ai/skills/calavera/SKILL.md
+++ b/src/ai/skills/calavera/SKILL.md
@@ -9,7 +9,7 @@ Use Calavera to compose and apply project tooling through its MCP tools whenever
 
 ## Start Here
 
-1. Confirm whether Calavera MCP tools are available. Look for tools named `inspect_project`, `list_profiles`, `list_integrations`, `list_ai_artifacts`, `compose_recipe`, `dry_run_apply`, and `apply_recipe`.
+1. Confirm whether Calavera MCP tools are available. Look for tools named `inspect_project`, `list_profiles`, `list_integrations`, `list_ai_artifacts`, `compose_recipe`, `validate_recipe`, `explain_recipe`, `dry_run_apply`, and `apply_recipe`.
 2. If the Calavera MCP tools are not available, stop and help the user register or repair the MCP server before composing or applying anything. Do not inspect npm cache internals or import Calavera source files from package cache paths as a substitute for MCP setup.
 3. Call `inspect_project` when available, or inspect the project manually only when the MCP server cannot be registered and the user chooses a fallback flow. Check files such as `package.json`, `calavera.config.json`, `.editorconfig`, `eslint.config.js`, `oxlint.json`, `.prettierrc.json`, `.stylelintrc.json`, and `tsconfig.json`.
    If likely conflicts exist, pause before applying changes. List each conflict as a hard stop or a migration decision the user can approve, and use `dry_run_apply` to show concrete impact when adoption still looks possible.

--- a/src/ai/skills/frontend-security/references/file-upload-security.md
+++ b/src/ai/skills/frontend-security/references/file-upload-security.md
@@ -111,22 +111,22 @@ client controlled. Validate stored content with a maintained file-type detector
 or a parser for the expected domain before trusting the file.
 
 ```javascript
-const ALLOWED_MIME_TYPES = {
-  ".jpg": ["image/jpeg"],
-  ".jpeg": ["image/jpeg"],
-  ".png": ["image/png"],
-  ".gif": ["image/gif"],
-  ".webp": ["image/webp"],
-  ".pdf": ["application/pdf"],
-  ".docx": ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
-};
+const ALLOWED_UPLOAD_TYPES = new Map([
+  ["image/jpeg", ".jpg"],
+  ["image/png", ".png"],
+  ["image/gif", ".gif"],
+  ["image/webp", ".webp"],
+  ["application/pdf", ".pdf"],
+  ["application/vnd.openxmlformats-officedocument.wordprocessingml.document", ".docx"],
+]);
 
-function validateMimeType(file) {
-  const ext = path.extname(file.originalname).toLowerCase();
-  const allowedMimes = ALLOWED_MIME_TYPES[ext];
+function validateMimeType(detectedType) {
+  if (!detectedType) return null;
 
-  if (!allowedMimes) return false;
-  return allowedMimes.includes(file.mimetype);
+  const extension = ALLOWED_UPLOAD_TYPES.get(detectedType.mime);
+  if (!extension) return null;
+
+  return { mimeType: detectedType.mime, extension };
 }
 ```
 
@@ -151,49 +151,47 @@ domain-specific payloads may need deeper parsing, re-encoding, or manual review.
 
 ```javascript
 const multer = require("multer");
+const fs = require("fs");
 const path = require("path");
 const crypto = require("crypto");
 
 // Store OUTSIDE webroot
 const UPLOAD_DIR = "/var/app/uploads"; // Not in /public/
 
-const storage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    // Organize by date
-    const date = new Date().toISOString().split("T")[0];
-    const dir = path.join(UPLOAD_DIR, date);
-    fs.mkdirSync(dir, { recursive: true });
-    cb(null, dir);
-  },
-  filename: (req, file, cb) => {
-    // Generate random filename
-    const ext = path.extname(file.originalname).toLowerCase();
-    const name = crypto.randomBytes(16).toString("hex");
-    cb(null, `${name}${ext}`);
-  },
-});
-
 const upload = multer({
-  storage,
+  storage: multer.memoryStorage(),
   limits: {
     fileSize: 5 * 1024 * 1024, // 5MB
     files: 1,
   },
-  fileFilter: (req, file, cb) => {
-    // Early rejection only. Validate actual content after receiving the file.
-    if (!validateMimeType(file)) {
-      cb(new Error("Invalid file type"));
-      return;
-    }
-    cb(null, true);
-  },
 });
+
+async function saveValidatedUpload(file) {
+  const detected = await detectAllowedType(file.buffer, [...ALLOWED_UPLOAD_TYPES.keys()]);
+  const validatedType = validateMimeType(detected);
+  if (!validatedType) {
+    throw new Error("Invalid file type");
+  }
+
+  // Organize by date
+  const date = new Date().toISOString().split("T")[0];
+  const dir = path.join(UPLOAD_DIR, date);
+  fs.mkdirSync(dir, { recursive: true });
+
+  // Generate random filename with a suffix derived from trusted content detection
+  const name = `${crypto.randomBytes(16).toString("hex")}${validatedType.extension}`;
+  const storedPath = path.join(dir, name);
+  await fs.promises.writeFile(storedPath, file.buffer, { flag: "wx" });
+
+  return { path: storedPath, mimeType: validatedType.mimeType, storageName: name };
+}
 ```
 
 ## Secure File Serving
 
 ```javascript
 const contentDisposition = require("content-disposition");
+const { pipeline } = require("stream/promises");
 
 // Serve files through application, not directly
 app.get("/files/:id", async (req, res) => {
@@ -215,9 +213,16 @@ app.get("/files/:id", async (req, res) => {
   );
   res.setHeader("X-Content-Type-Options", "nosniff");
 
-  // Stream file
-  const stream = fs.createReadStream(fileRecord.path);
-  stream.pipe(res);
+  // Stream file with error handling for missing files and permission failures
+  try {
+    await pipeline(fs.createReadStream(fileRecord.path), res);
+  } catch (error) {
+    if (!res.headersSent) {
+      res.status(404).send("Not found");
+      return;
+    }
+    req.destroy(error);
+  }
 });
 ```
 

--- a/src/ai/skills/frontend-security/references/framework-patterns.md
+++ b/src/ai/skills/frontend-security/references/framework-patterns.md
@@ -135,7 +135,9 @@ export async function POST({ request }) {
   }
 
   // Process request
-  return new Response(JSON.stringify(result), {
+  const responsePayload = { ok: true };
+
+  return new Response(JSON.stringify(responsePayload), {
     headers: { "Content-Type": "application/json" },
   });
 }
@@ -272,10 +274,11 @@ window.addEventListener("message", (event) => {
   if (!allowedOrigins.includes(event.origin)) return;
 
   // Validate data structure
-  if (typeof event.data !== "object") return;
-  if (!["action1", "action2"].includes(event.data.type)) return;
+  const data = event.data;
+  if (data === null || typeof data !== "object" || Array.isArray(data)) return;
+  if (!["action1", "action2"].includes(data.type)) return;
 
-  handleMessage(event.data);
+  handleMessage(data);
 });
 
 // Always specify target origin when sending

--- a/src/ai/skills/frontend-security/references/jwt-security.md
+++ b/src/ai/skills/frontend-security/references/jwt-security.md
@@ -289,18 +289,9 @@ function authenticateToken(req, res, next) {
   }
 
   try {
-    // Verify with explicit algorithm
-    const decoded = jwt.verify(token, secret, {
-      algorithms: ["HS256"],
-      issuer: "myapp",
-      audience: "myapp-users",
-    });
-
-    // Validate fingerprint if using sidejacking protection
+    // Validate token and fingerprint when using sidejacking protection
     const fingerprint = req.cookies["__Secure-Fgp"];
-    if (!validateFingerprint(decoded, fingerprint)) {
-      throw new Error("Invalid fingerprint");
-    }
+    const decoded = validateToken(token, fingerprint);
 
     // Check revocation
     if (isTokenRevoked(decoded)) {

--- a/src/ai/skills/frontend-security/references/nodejs-npm-security.md
+++ b/src/ai/skills/frontend-security/references/nodejs-npm-security.md
@@ -72,13 +72,14 @@ new Function(userInput);
 vm.runInThisContext(userInput);
 require(userInput);
 
-// DANGEROUS - setTimeout/setInterval with strings
-setTimeout(userInput, 1000); // Executes as code
+// DANGEROUS - dynamic module loading with user-controlled specifiers
+await import(userInput);
 
-// SAFE - pass functions instead
-setTimeout(() => {
-  /* code */
-}, 1000);
+// SAFER - map user choices to fixed module specifiers
+const allowedModules = new Map([["csv", "./parsers/csv.js"]]);
+const modulePath = allowedModules.get(userInput);
+if (!modulePath) throw new Error("Invalid module");
+await import(modulePath);
 ```
 
 ### Child Process Injection

--- a/src/ai/skills/more-secure-dependabot-config/SKILL.md
+++ b/src/ai/skills/more-secure-dependabot-config/SKILL.md
@@ -119,5 +119,5 @@ without repeating every field verbatim.
 
 ## Reference
 
-See `references/ecosystems.md` for the full list of Dependabot-supported
+See `references/ecosystem.md` for the full list of Dependabot-supported
 `package-ecosystem` identifiers and their directory conventions.

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,7 @@ import { pluralizeCount, style, titleCase } from "./utils/text.js";
  * @property {string} [profile]
  * @property {string[]} integrations
  * @property {{ id: string, target?: string }[]} aiArtifacts
+ * @property {string[]} reownManagedFiles
  *
  * @typedef {object} PackageManagerCommands
  * @property {[string, string[]]} init
@@ -125,6 +126,7 @@ import { pluralizeCount, style, titleCase } from "./utils/text.js";
  * @typedef {{ script: string, reason: string }} ScriptOmission
  * @typedef {{ severity: "info" | "warning" | "error", kind: string, message: string, path?: string }} ProjectInspectionFinding
  * @typedef {{ packageManager?: PackageManager, files: string[], findings: ProjectInspectionFinding[] }} ProjectInspection
+ * @typedef {{ reownManagedFiles?: string[] }} ProjectInspectionOptions
  * @typedef {{ scripts: Record<string, string>, omittedScripts: ScriptOmission[] }} ScriptPlan
  * @typedef {{ type: string, path: string, action?: "write" | "update" | "scaffold" | "merge", ownership?: "calavera" | "project", category?: "ai", aiType?: string, name?: string, reason?: string, scripts?: string[], omittedScripts?: ScriptOmission[], removedDefaultTestScript?: boolean }} Change
  *
@@ -239,6 +241,8 @@ const cliParseOptions = {
   tools: { type: "string", multiple: true, default: [] },
   "ai-artifact": { type: "string", multiple: true, default: [] },
   "ai-artifacts": { type: "string", multiple: true, default: [] },
+  "reown-managed-file": { type: "string", multiple: true, default: [] },
+  "reown-managed-files": { type: "string", multiple: true, default: [] },
 };
 
 /**
@@ -354,6 +358,10 @@ export function parseArgs(rawArgs) {
     ),
     aiArtifacts: collectListValues(values["ai-artifact"], values["ai-artifacts"]).map(
       parseAiArtifactFlag,
+    ),
+    reownManagedFiles: collectListValues(
+      values["reown-managed-file"],
+      values["reown-managed-files"],
     ),
   };
 
@@ -1070,8 +1078,9 @@ function createReactDoctorConfig() {
  * @param {string} path
  * @param {string} contents
  * @param {CalaveraState} previousState
+ * @param {Set<string>} reownManagedFiles
  */
-async function assertSafeManagedFileWrite(path, contents, previousState) {
+async function assertSafeManagedFileWrite(path, contents, previousState, reownManagedFiles) {
   if (!(await fileExists(path))) {
     return;
   }
@@ -1094,6 +1103,10 @@ async function assertSafeManagedFileWrite(path, contents, previousState) {
     return;
   }
 
+  if (stateFile && reownManagedFiles.has(path)) {
+    return;
+  }
+
   const reason = stateFile
     ? `It appears to have local edits (installed=${installedHash}, state=${stateFile.hash}).`
     : "It is not recorded as Calavera-managed.";
@@ -1104,10 +1117,16 @@ async function assertSafeManagedFileWrite(path, contents, previousState) {
 /**
  * @param {{ path: string, contents: string }[]} filePlans
  * @param {CalaveraState} previousState
+ * @param {Set<string>} reownManagedFiles
  */
-async function assertSafeManagedFileWrites(filePlans, previousState) {
+async function assertSafeManagedFileWrites(filePlans, previousState, reownManagedFiles) {
   for (const filePlan of filePlans) {
-    await assertSafeManagedFileWrite(filePlan.path, filePlan.contents, previousState);
+    await assertSafeManagedFileWrite(
+      filePlan.path,
+      filePlan.contents,
+      previousState,
+      reownManagedFiles,
+    );
   }
 }
 
@@ -1158,9 +1177,10 @@ function jsonContentsMatch(path, installedContents, targetContents) {
  * @param {boolean} dryRun
  * @param {Change[]} changes
  * @param {CalaveraState} previousState
+ * @param {Set<string>} reownManagedFiles
  * @returns {Promise<ManagedFileState>}
  */
-async function writeManagedFile(path, contents, dryRun, changes, previousState) {
+async function writeManagedFile(path, contents, dryRun, changes, previousState, reownManagedFiles) {
   changes.push({ type: "write", path, action: "write", ownership: "calavera" });
 
   const managedFile = {
@@ -1172,7 +1192,7 @@ async function writeManagedFile(path, contents, dryRun, changes, previousState) 
     return managedFile;
   }
 
-  await assertSafeManagedFileWrite(path, contents, previousState);
+  await assertSafeManagedFileWrite(path, contents, previousState, reownManagedFiles);
 
   const directory = dirname(path);
   if (directory !== ".") {
@@ -1190,15 +1210,24 @@ async function writeManagedFile(path, contents, dryRun, changes, previousState) 
  * @param {boolean} dryRun
  * @param {Change[]} changes
  * @param {CalaveraState} previousState
+ * @param {Set<string>} reownManagedFiles
  * @returns {Promise<ManagedFileState>}
  */
-async function writeManagedJSONFile(path, value, dryRun, changes, previousState) {
+async function writeManagedJSONFile(
+  path,
+  value,
+  dryRun,
+  changes,
+  previousState,
+  reownManagedFiles,
+) {
   return writeManagedFile(
     path,
     `${JSON.stringify(value, null, 2)}\n`,
     dryRun,
     changes,
     previousState,
+    reownManagedFiles,
   );
 }
 
@@ -1267,9 +1296,10 @@ async function projectFileExists(path) {
 /**
  * @param {{ path: string, contents: string }} filePlan
  * @param {CalaveraState} previousState
+ * @param {Set<string>} reownManagedFiles
  * @returns {Promise<ProjectInspectionFinding | undefined>}
  */
-async function inspectManagedFilePlan(filePlan, previousState) {
+async function inspectManagedFilePlan(filePlan, previousState, reownManagedFiles) {
   if (!(await projectFileExists(filePlan.path))) {
     return undefined;
   }
@@ -1292,6 +1322,15 @@ async function inspectManagedFilePlan(filePlan, previousState) {
     return undefined;
   }
 
+  if (stateFile && reownManagedFiles.has(filePlan.path)) {
+    return {
+      severity: "warning",
+      kind: "managed-file-reown",
+      path: filePlan.path,
+      message: `${filePlan.path} has local edits relative to Calavera state; this run will treat the current contents as an approved managed-file baseline before applying the recipe.`,
+    };
+  }
+
   return {
     severity: "error",
     kind: "managed-file-conflict",
@@ -1302,11 +1341,13 @@ async function inspectManagedFilePlan(filePlan, previousState) {
 
 /**
  * @param {Recipe} [recipe]
+ * @param {ProjectInspectionOptions} [options]
  * @returns {Promise<ProjectInspection>}
  */
-export async function inspectProject(recipe) {
+export async function inspectProject(recipe, options = {}) {
   const packageJSON = await readPackageJSONIfPresent();
   const previousState = await readStateIfPresent();
+  const reownManagedFiles = new Set(options.reownManagedFiles ?? []);
   const packageManager = detectPackageManager(packageJSON);
   const integrations = recipe ? resolveRecipeIntegrations(recipe) : [];
   const integrationIds = new Set(integrations.map((integration) => integration.id));
@@ -1363,7 +1404,7 @@ export async function inspectProject(recipe) {
   }
 
   for (const filePlan of plannedManagedFiles(integrations)) {
-    const finding = await inspectManagedFilePlan(filePlan, previousState);
+    const finding = await inspectManagedFilePlan(filePlan, previousState, reownManagedFiles);
 
     if (finding) {
       findings.push(finding);
@@ -1445,9 +1486,11 @@ export async function applyRecipeObject(recipe, options = {}) {
     json: false,
     noInstall: false,
     assumeYes: false,
+    reownManagedFiles: [],
     ...options,
   };
   const previousState = await readStateIfPresent();
+  const reownManagedFiles = new Set(applyOptions.reownManagedFiles ?? []);
   const integrations = resolveRecipeIntegrations(recipe);
   const dependencyList = unique(
     integrations.flatMap((integration) => integration.dependencies ?? []),
@@ -1460,7 +1503,9 @@ export async function applyRecipeObject(recipe, options = {}) {
     applyOptions.assumeYes,
     applyOptions.json,
   );
-  const projectInspection = await inspectProject(recipe);
+  const projectInspection = await inspectProject(recipe, {
+    reownManagedFiles: applyOptions.reownManagedFiles,
+  });
   const scriptPlan = buildScripts(recipe, integrations, packageManager);
   const { scripts, omittedScripts } = scriptPlan;
   /** @type {Change[]} */
@@ -1470,7 +1515,7 @@ export async function applyRecipeObject(recipe, options = {}) {
   const removedDefaultTestScript = removeDefaultTestScript(packageJSON);
   const managedFilePlans = plannedManagedFiles(integrations);
 
-  await assertSafeManagedFileWrites(managedFilePlans, previousState);
+  await assertSafeManagedFileWrites(managedFilePlans, previousState, reownManagedFiles);
 
   const aiResult = await buildAiApplyResult(recipe, applyOptions, previousState);
 
@@ -1496,6 +1541,7 @@ export async function applyRecipeObject(recipe, options = {}) {
         applyOptions.dryRun,
         changes,
         previousState,
+        reownManagedFiles,
       ),
     );
   }
@@ -1508,6 +1554,7 @@ export async function applyRecipeObject(recipe, options = {}) {
         applyOptions.dryRun,
         changes,
         previousState,
+        reownManagedFiles,
       ),
     );
   }
@@ -1520,6 +1567,7 @@ export async function applyRecipeObject(recipe, options = {}) {
         applyOptions.dryRun,
         changes,
         previousState,
+        reownManagedFiles,
       ),
     );
   }
@@ -1532,6 +1580,7 @@ export async function applyRecipeObject(recipe, options = {}) {
         applyOptions.dryRun,
         changes,
         previousState,
+        reownManagedFiles,
       ),
     );
     managedFiles.push(
@@ -1541,6 +1590,7 @@ export async function applyRecipeObject(recipe, options = {}) {
         applyOptions.dryRun,
         changes,
         previousState,
+        reownManagedFiles,
       ),
     );
   }
@@ -1553,6 +1603,7 @@ export async function applyRecipeObject(recipe, options = {}) {
         applyOptions.dryRun,
         changes,
         previousState,
+        reownManagedFiles,
       ),
     );
   }
@@ -1565,6 +1616,7 @@ export async function applyRecipeObject(recipe, options = {}) {
         applyOptions.dryRun,
         changes,
         previousState,
+        reownManagedFiles,
       ),
     );
   }
@@ -1577,6 +1629,7 @@ export async function applyRecipeObject(recipe, options = {}) {
         applyOptions.dryRun,
         changes,
         previousState,
+        reownManagedFiles,
       ),
     );
   }
@@ -2009,6 +2062,7 @@ export async function agentBootstrap(options = {}) {
     integrations: [],
     aiArtifacts: [],
     ...options,
+    reownManagedFiles: options.reownManagedFiles ?? [],
   };
   const detectedPackageJSON = await readPackageJSONIfPresent();
   const packageManager = assertSupportedPackageManager(
@@ -2644,6 +2698,8 @@ Options:
   --json               Print JSON output
   --yes                Use defaults and skip prompts
   --no-install         Write files without installing dependencies during apply
+  --reown-managed-file <path>
+                      Treat a tracked managed file's current contents as approved
   -h, --help           Show this help
 
 Agent-first setup:

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 // @ts-check
 import { existsSync, realpathSync } from "node:fs";
 import { mkdir, readFile, rm, stat, unlink, writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs as parseNodeArgs } from "node:util";
 
@@ -1021,7 +1021,14 @@ function createStylelintConfig(integrations) {
   /** @type {{ extends: string[], ignoreFiles: string[], plugins: string[], rules: Record<string, unknown> }} */
   const config = {
     extends: [],
-    ignoreFiles: ["coverage/**", "dist/**", "dist-web/**", "node_modules/**"],
+    ignoreFiles: [
+      "coverage/**",
+      "dist/**",
+      "**/dist/**",
+      "**/dist-types/**",
+      "dist-web/**",
+      "node_modules/**",
+    ],
     plugins: [],
     rules: {},
   };
@@ -1076,6 +1083,37 @@ function createReactDoctorConfig() {
 
 /**
  * @param {string} path
+ * @returns {string}
+ */
+function realpathIfPresent(path) {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+/**
+ * @param {string} path
+ * @returns {string}
+ */
+function normalizeManagedFilePath(path) {
+  const pathWithPlatformSeparators = path.replace(/\\/g, "/");
+  const projectRoot = realpathIfPresent(resolve("."));
+  const absolutePath = realpathIfPresent(resolve(pathWithPlatformSeparators));
+  return relative(projectRoot, absolutePath).replace(/\\/g, "/");
+}
+
+/**
+ * @param {string[]} paths
+ * @returns {Set<string>}
+ */
+function normalizeManagedFilePathSet(paths) {
+  return new Set(paths.map(normalizeManagedFilePath));
+}
+
+/**
+ * @param {string} path
  * @param {string} contents
  * @param {CalaveraState} previousState
  * @param {Set<string>} reownManagedFiles
@@ -1103,7 +1141,7 @@ async function assertSafeManagedFileWrite(path, contents, previousState, reownMa
     return;
   }
 
-  if (stateFile && reownManagedFiles.has(path)) {
+  if (stateFile && reownManagedFiles.has(normalizeManagedFilePath(path))) {
     return;
   }
 
@@ -1322,7 +1360,7 @@ async function inspectManagedFilePlan(filePlan, previousState, reownManagedFiles
     return undefined;
   }
 
-  if (stateFile && reownManagedFiles.has(filePlan.path)) {
+  if (stateFile && reownManagedFiles.has(normalizeManagedFilePath(filePlan.path))) {
     return {
       severity: "warning",
       kind: "managed-file-reown",
@@ -1347,7 +1385,7 @@ async function inspectManagedFilePlan(filePlan, previousState, reownManagedFiles
 export async function inspectProject(recipe, options = {}) {
   const packageJSON = await readPackageJSONIfPresent();
   const previousState = await readStateIfPresent();
-  const reownManagedFiles = new Set(options.reownManagedFiles ?? []);
+  const reownManagedFiles = normalizeManagedFilePathSet(options.reownManagedFiles ?? []);
   const packageManager = detectPackageManager(packageJSON);
   const integrations = recipe ? resolveRecipeIntegrations(recipe) : [];
   const integrationIds = new Set(integrations.map((integration) => integration.id));
@@ -1490,7 +1528,7 @@ export async function applyRecipeObject(recipe, options = {}) {
     ...options,
   };
   const previousState = await readStateIfPresent();
-  const reownManagedFiles = new Set(applyOptions.reownManagedFiles ?? []);
+  const reownManagedFiles = normalizeManagedFilePathSet(applyOptions.reownManagedFiles ?? []);
   const integrations = resolveRecipeIntegrations(recipe);
   const dependencyList = unique(
     integrations.flatMap((integration) => integration.dependencies ?? []),

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -23,7 +23,7 @@ import {
   validateRecipe,
   validateRecipeResponse,
 } from "./recipe.js";
-import { assertPlainObject } from "./utils/assertions.js";
+import { assertPlainObject, assertStringArray } from "./utils/assertions.js";
 import { writeJSON } from "./utils/fs.js";
 
 /**
@@ -39,6 +39,10 @@ const SERVER_INSTRUCTIONS =
 const profileIds = profileIdsForRecipe();
 const packageManagerIds = packageManagerIdsForRecipe();
 const recipeSchema = z.record(z.string(), z.unknown()).describe("A Calavera recipe object.");
+const reownManagedFilesSchema = z
+  .array(z.string())
+  .optional()
+  .describe(recipeToolInputDescriptions.reownManagedFiles);
 const aiArtifactInputSchema = z.object({
   id: z.string().describe(recipeToolInputDescriptions.aiArtifactId),
   target: z.string().optional().describe(recipeToolInputDescriptions.aiArtifactTarget),
@@ -69,6 +73,7 @@ const toolConfigs = {
     description: recipeToolDescriptions.inspect_project,
     inputSchema: {
       recipe: recipeSchema.optional().describe(recipeToolInputDescriptions.recipe),
+      reownManagedFiles: reownManagedFilesSchema,
     },
     annotations: toolAnnotations.read,
   },
@@ -129,6 +134,7 @@ const toolConfigs = {
         .enum(packageManagerIds)
         .optional()
         .describe(recipeToolInputDescriptions.packageManagerOverride),
+      reownManagedFiles: reownManagedFilesSchema,
     },
     annotations: toolAnnotations.read,
   },
@@ -146,6 +152,7 @@ const toolConfigs = {
         .describe(recipeToolInputDescriptions.config),
       writeConfig: z.boolean().default(true).describe(recipeToolInputDescriptions.writeConfig),
       noInstall: z.boolean().default(false).describe(recipeToolInputDescriptions.noInstall),
+      reownManagedFiles: reownManagedFilesSchema,
     },
     annotations: toolAnnotations.apply,
   },
@@ -168,6 +175,19 @@ function assertToolInput(input, toolName) {
 function assertRecipeInput(value) {
   validateRecipe(value);
   return /** @type {Recipe} */ (value);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+function optionalReownManagedFiles(value) {
+  if (value === undefined) {
+    return [];
+  }
+
+  assertStringArray("reownManagedFiles", value);
+  return value;
 }
 
 /**
@@ -202,7 +222,9 @@ function listProfilesTool() {
  */
 async function inspectProjectTool(args) {
   const recipe = args.recipe === undefined ? undefined : assertRecipeInput(args.recipe);
-  return inspectProject(recipe);
+  return inspectProject(recipe, {
+    reownManagedFiles: optionalReownManagedFiles(args.reownManagedFiles),
+  });
 }
 
 /**
@@ -259,6 +281,7 @@ async function dryRunApplyTool(args) {
       noInstall: true,
       assumeYes: true,
       packageManager: /** @type {PackageManager | undefined} */ (args.packageManager),
+      reownManagedFiles: optionalReownManagedFiles(args.reownManagedFiles),
     }),
   };
 }
@@ -286,6 +309,7 @@ async function applyRecipeTool(args) {
       noInstall: Boolean(args.noInstall),
       assumeYes: true,
       packageManager: /** @type {PackageManager | undefined} */ (args.packageManager),
+      reownManagedFiles: optionalReownManagedFiles(args.reownManagedFiles),
     }),
   };
 }

--- a/src/recipe.js
+++ b/src/recipe.js
@@ -150,6 +150,8 @@ export const recipeToolInputDescriptions = Object.freeze({
   config: "Recipe file path to write before applying.",
   writeConfig: "Write the approved recipe to the config path before applying.",
   noInstall: "Skip package manager dependency installation.",
+  reownManagedFiles:
+    "Tracked Calavera-managed file paths whose current contents the user has approved as the baseline for this dry-run/apply.",
   optionalDownloadRecipe:
     "Optional Calavera recipe object. When omitted, the current visible composer recipe is downloaded.",
 });


### PR DESCRIPTION
## Summary
- Add `reownManagedFiles` support to CLI, MCP tools, and apply/inspect flows
- Allow approved managed file drift to be treated as intentional local state before dry-run or apply
- Cover the new behavior with parser and integration tests

## Testing
- Added unit and integration tests for CLI parsing and managed-file reown application flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for re-owning managed files during apply and dry-run workflows.
  * New CLI and tool input options let you mark specific managed files as the approved baseline for the next run.
* **Bug Fixes**
  * Improved handling of managed-file drift by resolving approved local changes without failing the run.
  * Updated managed-file tracking so accepted content changes are reflected in the saved state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->