### PR TITLE
Gate Composer integrations by the published CLI

### DIFF
--- a/.changeset/safe-dingos-compose.md
+++ b/.changeset/safe-dingos-compose.md
@@ -1,0 +1,5 @@
+---
+"create-project-calavera": patch
+---
+
+Expose minimum CLI versions for integrations so the hosted Composer can avoid unreleased CLI capabilities.

--- a/README.md
+++ b/README.md
@@ -484,6 +484,12 @@ want Calavera to treat the existing files as local, unmanaged content.
 
 The recipe composer runs as a small Vite app:
 
+The hosted Composer reads the version currently published under the npm
+`latest` tag and only offers integrations supported by that CLI release. New
+integrations can therefore land and deploy without producing recipes that the
+published CLI cannot apply. If the npm registry is unavailable, the Composer
+falls back to the last known-safe v2.2 integration catalog.
+
 ```bash
 npm run web:dev
 ```

--- a/apps/composer/cli-compatibility.js
+++ b/apps/composer/cli-compatibility.js
@@ -1,5 +1,7 @@
 export const NPM_LATEST_CLI_URL = "https://registry.npmjs.org/create-project-calavera/latest";
 export const SAFE_CLI_FALLBACK_VERSION = "2.2.0";
+export const CLI_VERSION_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
 const fallbackIntegrationIds = new Set([
   "editorconfig",
@@ -47,13 +49,35 @@ const fallbackIntegrationIds = new Set([
 ]);
 
 function parseVersion(version) {
-  const match = /^(\d+)\.(\d+)\.(\d+)(-.+)?$/.exec(version);
+  const match = CLI_VERSION_PATTERN.exec(version);
   if (!match) throw new Error(`Invalid Calavera CLI version: ${version}.`);
 
   return {
     numbers: match.slice(1, 4).map(Number),
-    prerelease: Boolean(match[4]),
+    prerelease: match[4]?.split(".") ?? [],
   };
+}
+
+function comparePrereleaseIdentifiers(current, minimum) {
+  const length = Math.max(current.length, minimum.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const currentIdentifier = current[index];
+    const minimumIdentifier = minimum[index];
+    if (currentIdentifier === undefined) return -1;
+    if (minimumIdentifier === undefined) return 1;
+    if (currentIdentifier === minimumIdentifier) continue;
+
+    const currentIsNumeric = /^\d+$/.test(currentIdentifier);
+    const minimumIsNumeric = /^\d+$/.test(minimumIdentifier);
+    if (currentIsNumeric && minimumIsNumeric) {
+      return Number(currentIdentifier) > Number(minimumIdentifier) ? 1 : -1;
+    }
+    if (currentIsNumeric !== minimumIsNumeric) return currentIsNumeric ? -1 : 1;
+    return currentIdentifier > minimumIdentifier ? 1 : -1;
+  }
+
+  return 0;
 }
 
 export function versionMeetsMinimum(version, minimumVersion) {
@@ -66,12 +90,18 @@ export function versionMeetsMinimum(version, minimumVersion) {
     }
   }
 
-  return !current.prerelease || minimum.prerelease;
+  if (current.prerelease.length === 0) return true;
+  if (minimum.prerelease.length === 0) return false;
+  return comparePrereleaseIdentifiers(current.prerelease, minimum.prerelease) >= 0;
 }
 
-export function minimumCliVersionForIntegration(integration) {
+export function isFallbackCliIntegration(id) {
+  return fallbackIntegrationIds.has(id);
+}
+
+function minimumCliVersionForIntegration(integration) {
   if (integration.minimumCliVersion) return integration.minimumCliVersion;
-  if (fallbackIntegrationIds.has(integration.id)) return SAFE_CLI_FALLBACK_VERSION;
+  if (isFallbackCliIntegration(integration.id)) return SAFE_CLI_FALLBACK_VERSION;
 
   throw new Error(
     `Integration ${integration.id} must declare minimumCliVersion before the hosted Composer can offer it.`,

--- a/apps/composer/cli-compatibility.js
+++ b/apps/composer/cli-compatibility.js
@@ -1,0 +1,124 @@
+export const NPM_LATEST_CLI_URL = "https://registry.npmjs.org/create-project-calavera/latest";
+export const SAFE_CLI_FALLBACK_VERSION = "2.2.0";
+
+const fallbackIntegrationIds = new Set([
+  "editorconfig",
+  "typescript",
+  "oxlint",
+  "oxlint-eslint",
+  "oxlint-typescript",
+  "oxlint-unicorn",
+  "oxlint-oxc",
+  "oxlint-import",
+  "oxlint-react",
+  "react-doctor",
+  "oxlint-jsx-a11y",
+  "oxlint-node",
+  "oxlint-promise",
+  "oxlint-vitest",
+  "oxlint-jest",
+  "oxlint-nextjs",
+  "oxlint-vue",
+  "oxlint-jsdoc",
+  "oxfmt",
+  "eslint",
+  "typescript-eslint",
+  "eslint-config-prettier",
+  "eslint-react",
+  "eslint-jsx-a11y",
+  "eslint-import",
+  "eslint-n",
+  "eslint-promise",
+  "eslint-unicorn",
+  "eslint-sonarjs",
+  "eslint-vitest",
+  "eslint-jest",
+  "stylelint",
+  "stylelint-standard",
+  "stylelint-order",
+  "stylelint-baseline",
+  "stylelint-scss",
+  "stylelint-stylistic",
+  "css-property-type-validator",
+  "prettier",
+  "prettier-tailwind",
+  "prettier-svelte",
+  "prettier-astro",
+]);
+
+function parseVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(-.+)?$/.exec(version);
+  if (!match) throw new Error(`Invalid Calavera CLI version: ${version}.`);
+
+  return {
+    numbers: match.slice(1, 4).map(Number),
+    prerelease: Boolean(match[4]),
+  };
+}
+
+export function versionMeetsMinimum(version, minimumVersion) {
+  const current = parseVersion(version);
+  const minimum = parseVersion(minimumVersion);
+
+  for (let index = 0; index < current.numbers.length; index += 1) {
+    if (current.numbers[index] !== minimum.numbers[index]) {
+      return current.numbers[index] > minimum.numbers[index];
+    }
+  }
+
+  return !current.prerelease || minimum.prerelease;
+}
+
+export function minimumCliVersionForIntegration(integration) {
+  if (integration.minimumCliVersion) return integration.minimumCliVersion;
+  if (fallbackIntegrationIds.has(integration.id)) return SAFE_CLI_FALLBACK_VERSION;
+
+  throw new Error(
+    `Integration ${integration.id} must declare minimumCliVersion before the hosted Composer can offer it.`,
+  );
+}
+
+export function filterIntegrationsForCli(integrations, cliVersion) {
+  return integrations.filter((integration) =>
+    versionMeetsMinimum(cliVersion, minimumCliVersionForIntegration(integration)),
+  );
+}
+
+export function integrationResponseForCli(response, cliVersion) {
+  return {
+    ...response,
+    integrations: filterIntegrationsForCli(response.integrations, cliVersion),
+  };
+}
+
+export function assertRecipeIntegrationsSupported(recipe, integrations, cliVersion) {
+  const supportedIds = new Set(
+    filterIntegrationsForCli(integrations, cliVersion).map(({ id }) => id),
+  );
+  const unsupportedIds = recipe.integrations.filter((id) => !supportedIds.has(id));
+
+  if (unsupportedIds.length > 0) {
+    throw new Error(
+      `The published Calavera CLI v${cliVersion} does not support: ${unsupportedIds.join(
+        ", ",
+      )}. Wait for the required CLI release before downloading this recipe.`,
+    );
+  }
+
+  return recipe;
+}
+
+export async function loadPublishedCliCompatibility(fetchLatest = globalThis.fetch) {
+  try {
+    const response = await fetchLatest(NPM_LATEST_CLI_URL, {
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) throw new Error(`npm registry returned ${response.status}.`);
+
+    const metadata = await response.json();
+    parseVersion(metadata.version);
+    return { version: metadata.version, source: "npm" };
+  } catch {
+    return { version: SAFE_CLI_FALLBACK_VERSION, source: "fallback" };
+  }
+}

--- a/apps/composer/index.html
+++ b/apps/composer/index.html
@@ -86,6 +86,7 @@
 
           <fieldset>
             <legend>Integration packs</legend>
+            <p class="compatibility-note" id="cli-compatibility" role="status"></p>
             <div id="integrations" class="integrations"></div>
             <section id="baseline-options" class="integration-options" hidden>
               <h2>Stylelint Baseline target</h2>

--- a/apps/composer/package.json
+++ b/apps/composer/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "build": "vite build",
-    "preview": "vite preview --host 127.0.0.1"
+    "preview": "vite preview --host 127.0.0.1",
+    "test": "node --test test/*.test.mjs"
   },
   "devDependencies": {
     "vite": "^8.0.14"

--- a/apps/composer/script.js
+++ b/apps/composer/script.js
@@ -27,6 +27,13 @@ import {
   recommendBaselineTarget,
   searchBaselineFeatures,
 } from "../../packages/baseline-core/src/index.js";
+import {
+  assertRecipeIntegrationsSupported,
+  filterIntegrationsForCli,
+  integrationResponseForCli,
+  loadPublishedCliCompatibility,
+  SAFE_CLI_FALLBACK_VERSION,
+} from "./cli-compatibility.js";
 
 const form = document.querySelector("#composer");
 const integrations = document.querySelector("#integrations");
@@ -37,9 +44,14 @@ const nextCommandsNote = document.querySelector("#next-commands-note");
 const webMcpBanner = document.querySelector("#webmcp-banner");
 const baselineOptions = document.querySelector("#baseline-options");
 const baselineAvailable = document.querySelector("#baseline-available");
+const cliCompatibilityNote = document.querySelector("#cli-compatibility");
 const profiles = profileIdsForRecipe();
 const packageManagers = packageManagerIdsForRecipe();
 const aiArtifactOptions = listAiArtifactOptions();
+let cliCompatibility = {
+  version: SAFE_CLI_FALLBACK_VERSION,
+  source: "fallback",
+};
 
 for (
   let year = baselineMetadata.currentYear;
@@ -57,11 +69,38 @@ function selectedProfile() {
 }
 
 function visibleCatalog(profile = selectedProfile()) {
-  return listIntegrationOptions(profile);
+  return filterIntegrationsForCli(listIntegrationOptions(profile), cliCompatibility.version);
+}
+
+function supportedIntegrationIds() {
+  return new Set(visibleCatalog().map(({ id }) => id));
+}
+
+function assertPublishedCliCompatibility(recipeInput) {
+  const validatedRecipe = validateRecipe(recipeInput);
+  return assertRecipeIntegrationsSupported(
+    validatedRecipe,
+    listIntegrationOptions(),
+    cliCompatibility.version,
+  );
+}
+
+function renderCliCompatibility() {
+  const allIntegrations = listIntegrationOptions();
+  const availableIntegrations = filterIntegrationsForCli(allIntegrations, cliCompatibility.version);
+  const hiddenCount = allIntegrations.length - availableIntegrations.length;
+  const source = cliCompatibility.source === "npm" ? "npm latest" : "safe fallback";
+
+  cliCompatibilityNote.textContent = `Showing integrations supported by create-project-calavera v${cliCompatibility.version} (${source}).${
+    hiddenCount > 0
+      ? ` ${hiddenCount} integration${hiddenCount === 1 ? " is" : "s are"} waiting for a newer CLI release.`
+      : ""
+  }`;
 }
 
 function renderIntegrations() {
   integrations.replaceChildren();
+  renderCliCompatibility();
 
   const groups = visibleCatalog().reduce((grouped, item) => {
     grouped.set(item.group, [...(grouped.get(item.group) ?? []), item]);
@@ -271,7 +310,9 @@ function downloadFile(recipeContents = recipe()) {
 }
 
 function downloadRecipe({ recipe: recipeInput } = {}) {
-  const recipeContents = recipeInput === undefined ? recipe() : validateRecipe(recipeInput);
+  const recipeContents = assertPublishedCliCompatibility(
+    recipeInput === undefined ? recipe() : recipeInput,
+  );
   downloadFile(recipeContents);
 
   return {
@@ -306,7 +347,22 @@ function registerWebMcpTools() {
         readOnlyHint: true,
         untrustedContentHint: false,
       },
-      execute: async () => listProfilesResponse({ browser: true }),
+      execute: async () => {
+        const response = listProfilesResponse({ browser: true });
+        const supportedIds = new Set(
+          filterIntegrationsForCli(listIntegrationOptions(), cliCompatibility.version).map(
+            ({ id }) => id,
+          ),
+        );
+
+        return {
+          ...response,
+          profiles: response.profiles.map((profile) => ({
+            ...profile,
+            defaultIntegrations: profile.defaultIntegrations.filter((id) => supportedIds.has(id)),
+          })),
+        };
+      },
     });
 
     navigator.modelContext.registerTool({
@@ -327,7 +383,10 @@ function registerWebMcpTools() {
         readOnlyHint: true,
         untrustedContentHint: false,
       },
-      execute: async (input) => listIntegrationsResponse(input),
+      execute: async (input) => {
+        const response = listIntegrationsResponse(input);
+        return integrationResponseForCli(response, cliCompatibility.version);
+      },
     });
 
     navigator.modelContext.registerTool({
@@ -348,7 +407,19 @@ function registerWebMcpTools() {
         readOnlyHint: true,
         untrustedContentHint: false,
       },
-      execute: async (input) => describeIntegrationResponse(input.id),
+      execute: async (input) => {
+        const integration = describeIntegrationResponse(input.id);
+        const [supportedIntegration] = filterIntegrationsForCli(
+          [integration],
+          cliCompatibility.version,
+        );
+        if (!supportedIntegration) {
+          throw new Error(
+            `${integration.id} is not available in the published Calavera CLI v${cliCompatibility.version}.`,
+          );
+        }
+        return supportedIntegration;
+      },
     });
 
     navigator.modelContext.registerTool({
@@ -505,7 +576,11 @@ function registerWebMcpTools() {
         readOnlyHint: true,
         untrustedContentHint: false,
       },
-      execute: async (input) => composeRecipeResponse(input, { browser: true }),
+      execute: async (input) => {
+        const response = composeRecipeResponse(input, { browser: true });
+        assertPublishedCliCompatibility(response.recipe);
+        return response;
+      },
     });
 
     navigator.modelContext.registerTool({
@@ -526,7 +601,19 @@ function registerWebMcpTools() {
         readOnlyHint: true,
         untrustedContentHint: false,
       },
-      execute: async (input) => validateRecipeResponse(input.recipe),
+      execute: async (input) => {
+        const validation = validateRecipeResponse(input.recipe);
+        if (!validation.ok) return validation;
+
+        try {
+          return { ok: true, recipe: assertPublishedCliCompatibility(input.recipe) };
+        } catch (error) {
+          return {
+            ok: false,
+            errors: [error instanceof Error ? error.message : String(error)],
+          };
+        }
+      },
     });
 
     navigator.modelContext.registerTool({
@@ -547,7 +634,8 @@ function registerWebMcpTools() {
         readOnlyHint: true,
         untrustedContentHint: false,
       },
-      execute: async (input) => explainRecipeResponse(input.recipe),
+      execute: async (input) =>
+        explainRecipeResponse(assertPublishedCliCompatibility(input.recipe)),
     });
 
     navigator.modelContext.registerTool({
@@ -600,3 +688,13 @@ document.querySelector("#download").addEventListener("click", () => {
 renderAiArtifacts();
 setDefaults();
 registerWebMcpTools();
+
+loadPublishedCliCompatibility().then((compatibility) => {
+  const selectedIds = new FormData(form).getAll("integration").map(String);
+  cliCompatibility = compatibility;
+  renderIntegrations();
+  const supportedIds = supportedIntegrationIds();
+  selectIntegrations(selectedIds.filter((id) => supportedIds.has(id)));
+  syncIntegrationOptions();
+  render();
+});

--- a/apps/composer/styles.css
+++ b/apps/composer/styles.css
@@ -191,6 +191,14 @@ fieldset {
   padding-inline: 0;
 }
 
+.compatibility-note {
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin-block: -0.25rem 0.75rem;
+  margin-inline: 0;
+}
+
 legend,
 .field {
   color: var(--teal-deep);

--- a/apps/composer/test/cli-compatibility.test.mjs
+++ b/apps/composer/test/cli-compatibility.test.mjs
@@ -4,24 +4,31 @@ import test from "node:test";
 import { integrationCatalog } from "../../../packages/cli/src/catalog.js";
 import {
   assertRecipeIntegrationsSupported,
+  CLI_VERSION_PATTERN,
   filterIntegrationsForCli,
   integrationResponseForCli,
+  isFallbackCliIntegration,
   loadPublishedCliCompatibility,
-  minimumCliVersionForIntegration,
   SAFE_CLI_FALLBACK_VERSION,
   versionMeetsMinimum,
 } from "../cli-compatibility.js";
 
 test("version comparison keeps unreleased integrations behind their CLI release", () => {
   assert.equal(versionMeetsMinimum("2.2.0", "2.3.0"), false);
+  assert.equal(versionMeetsMinimum("2.3.0-alpha", "2.3.0-beta"), false);
+  assert.equal(versionMeetsMinimum("2.3.0-beta", "2.3.0-alpha"), true);
+  assert.equal(versionMeetsMinimum("2.3.0-beta.2", "2.3.0-beta.11"), false);
   assert.equal(versionMeetsMinimum("2.3.0-next.1", "2.3.0"), false);
+  assert.equal(versionMeetsMinimum("2.3.0", "2.3.0-next.1"), true);
   assert.equal(versionMeetsMinimum("2.3.0", "2.3.0"), true);
   assert.equal(versionMeetsMinimum("3.0.0", "2.3.0"), true);
 });
 
 test("every post-v2.2 integration declares its minimum CLI version", () => {
   for (const integration of integrationCatalog) {
-    assert.doesNotThrow(() => minimumCliVersionForIntegration(integration));
+    if (isFallbackCliIntegration(integration.id)) continue;
+    assert.equal(typeof integration.minimumCliVersion, "string", integration.id);
+    assert.match(integration.minimumCliVersion, CLI_VERSION_PATTERN, integration.id);
   }
 });
 

--- a/apps/composer/test/cli-compatibility.test.mjs
+++ b/apps/composer/test/cli-compatibility.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { integrationCatalog } from "../../../packages/cli/src/catalog.js";
+import {
+  assertRecipeIntegrationsSupported,
+  filterIntegrationsForCli,
+  integrationResponseForCli,
+  loadPublishedCliCompatibility,
+  minimumCliVersionForIntegration,
+  SAFE_CLI_FALLBACK_VERSION,
+  versionMeetsMinimum,
+} from "../cli-compatibility.js";
+
+test("version comparison keeps unreleased integrations behind their CLI release", () => {
+  assert.equal(versionMeetsMinimum("2.2.0", "2.3.0"), false);
+  assert.equal(versionMeetsMinimum("2.3.0-next.1", "2.3.0"), false);
+  assert.equal(versionMeetsMinimum("2.3.0", "2.3.0"), true);
+  assert.equal(versionMeetsMinimum("3.0.0", "2.3.0"), true);
+});
+
+test("every post-v2.2 integration declares its minimum CLI version", () => {
+  for (const integration of integrationCatalog) {
+    assert.doesNotThrow(() => minimumCliVersionForIntegration(integration));
+  }
+});
+
+test("v2.2 compatibility excludes Knip and logical CSS until v2.3 is published", () => {
+  const v220Ids = filterIntegrationsForCli(integrationCatalog, "2.2.0").map(({ id }) => id);
+  const v230Ids = filterIntegrationsForCli(integrationCatalog, "2.3.0").map(({ id }) => id);
+
+  assert.equal(v220Ids.includes("stylelint-logical-css"), false);
+  assert.equal(v220Ids.includes("knip"), false);
+  assert.equal(v220Ids.includes("stylelint-baseline"), true);
+  assert.equal(v230Ids.includes("stylelint-logical-css"), true);
+  assert.equal(v230Ids.includes("knip"), true);
+});
+
+test("WebMCP catalog responses and recipes use the same published CLI boundary", () => {
+  const response = integrationResponseForCli(
+    { profile: "minimal", integrations: integrationCatalog },
+    "2.2.0",
+  );
+
+  assert.equal(
+    response.integrations.some(({ id }) => id === "knip"),
+    false,
+  );
+  assert.throws(
+    () =>
+      assertRecipeIntegrationsSupported(
+        { integrations: ["stylelint-logical-css"] },
+        integrationCatalog,
+        "2.2.0",
+      ),
+    /does not support: stylelint-logical-css/,
+  );
+  assert.deepEqual(
+    assertRecipeIntegrationsSupported(
+      { integrations: ["stylelint-logical-css"] },
+      integrationCatalog,
+      "2.3.0",
+    ),
+    { integrations: ["stylelint-logical-css"] },
+  );
+});
+
+test("published CLI lookup fails closed to the known v2.2 catalog", async () => {
+  const compatibility = await loadPublishedCliCompatibility(async () => {
+    throw new Error("registry unavailable");
+  });
+
+  assert.deepEqual(compatibility, {
+    version: SAFE_CLI_FALLBACK_VERSION,
+    source: "fallback",
+  });
+});
+
+test("published CLI lookup accepts valid npm latest metadata", async () => {
+  const compatibility = await loadPublishedCliCompatibility(async () => ({
+    ok: true,
+    json: async () => ({ version: "2.3.0" }),
+  }));
+
+  assert.deepEqual(compatibility, { version: "2.3.0", source: "npm" });
+});

--- a/packages/cli/src/catalog.js
+++ b/packages/cli/src/catalog.js
@@ -21,6 +21,7 @@ export const integrationCatalog = [
     group: "Unused code",
     platform: "knip",
     status: "optional",
+    minimumCliVersion: "2.3.0",
     dependencies: ["knip"],
   },
   {
@@ -361,6 +362,7 @@ export const integrationCatalog = [
     group: "CSS logical properties",
     platform: "stylelint-plugin",
     status: "optional",
+    minimumCliVersion: "2.3.0",
     dependencies: ["stylelint-plugin-logical-css"],
     includes: ["stylelint"],
     stylelint: {


### PR DESCRIPTION
## Summary

- record the minimum CLI version for integrations introduced after v2.2.0
- make the hosted Composer read the version currently published under npm `latest`
- hide Logical CSS and Knip until their supporting CLI release is actually available
- apply the same compatibility boundary to visual composition, downloads, validation, explanation, and WebMCP tools
- fail closed to the known-safe v2.2 integration catalog when the npm registry is unavailable
- preserve the existing exact schema/catalog source-parity contract

## Root cause

The Composer deploys independently from npm. `stylelint-logical-css` landed after the v2.2.0 CLI release, so the hosted UI advertised source capabilities that npm `latest` could not apply. Source parity tests remained green because the source schema and source catalog matched; the mismatch existed between the deployed Composer and the released package.

## Validation

- `pnpm quality`
- `pnpm --filter @calavera/composer test`
- `pnpm --filter @calavera/composer build`
- live npm lookup confirmed v2.2.0 hides `stylelint-logical-css` and `knip`
- `pnpm changeset status --since=next`

fix #309


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web Composer now shows only integrations supported by the currently published CLI version.
  * Recipes and Composer tools prevent unsupported integrations from being selected or generated.
  * Added compatibility messaging when integrations require newer CLI support.
  * Composer safely falls back to a known compatible CLI version if registry information is unavailable.

* **Documentation**
  * Clarified Web Composer integration catalog and fallback behavior.

* **Tests**
  * Added coverage for version compatibility, filtering, validation, and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->