### PR TITLE
Exclude installed skills from CodeRabbit reviews

### DIFF
--- a/.changeset/calm-rabbits-review.md
+++ b/.changeset/calm-rabbits-review.md
@@ -1,0 +1,5 @@
+---
+"create-project-calavera": minor
+---
+
+Add merge-safe CodeRabbit path exclusions whenever Calavera installs skill artifacts.

--- a/README.md
+++ b/README.md
@@ -470,6 +470,14 @@ choose their `.agents/hooks/<target>/` or `.agents/agents/<target>/` directory.
 The current bundled hooks and agents come from `claude-toolkit` and default to
 `claude-code`.
 
+When a recipe installs a skill, Calavera also creates or updates
+`.coderabbit.yaml` so CodeRabbit excludes `.claude/skills/**`,
+`.agents/skills/**`, and `pnpm-lock.yaml`. This avoids spending downstream
+review tokens on vendored skill documentation whose findings belong upstream.
+Existing CodeRabbit settings and path filters are preserved. The file remains
+project-owned rather than Calavera-managed, so `clean` does not remove these
+review preferences.
+
 Set an agent item's `target` to `codex` when you want Calavera to generate a
 Codex custom-agent TOML file under `.codex/agents/` instead of preserving the
 source Markdown under `.agents/agents/<target>/`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,6 +55,7 @@
     "@schalkneethling/calavera-baseline-core": "workspace:^",
     "execa": "^9.6.0",
     "prettier": "^3.5.3",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   }
 }

--- a/packages/cli/scripts/check-config-schema.test.mjs
+++ b/packages/cli/scripts/check-config-schema.test.mjs
@@ -893,6 +893,7 @@ test("artifact install locks exact versions and targeted update preserves other 
     assert.equal(lock.artifacts.find(({ id }) => id === "skill-code-review").version, "0.1.0");
     assert.equal((await stat(".agents/skills/project-goal/SKILL.md")).isFile(), true);
     assert.equal((await stat(".agents/skills/code-review/SKILL.md")).isFile(), true);
+    assert.match(await readFile(".coderabbit.yaml", "utf8"), /!\.agents\/skills\/\*\*/);
 
     await writeFile(".agents/skills/project-goal/SKILL.md", "local edit\n");
     releases.set("skill-project-goal", "0.3.0");
@@ -1438,6 +1439,7 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     const fallbackGuidance = await readFile("AGENTS.calavera.md", "utf8");
     const mcpGuidance = await readFile(".agents/calavera/mcp.md", "utf8");
     const skill = await readFile(".agents/skills/calavera/SKILL.md", "utf8");
+    const codeRabbitConfig = await readFile(".coderabbit.yaml", "utf8");
     const state = JSON.parse(await readFile(".calavera/state.json", "utf8"));
 
     assert.equal(existingGuidance, "Existing project guidance.\n");
@@ -1531,6 +1533,8 @@ test("agent bootstrap preserves existing AGENTS.md and writes fallback guidance"
     assert.match(skill, /reports `-32000`/);
     assert.match(skill, /outcome as unknown instead of failed/);
     assert.match(skill, /Fallbacks/);
+    assert.match(codeRabbitConfig, /!\.claude\/skills\/\*\*/);
+    assert.match(codeRabbitConfig, /!\.agents\/skills\/\*\*/);
     assert.match(skill, /npm create project-calavera@<version> apply -- --dry-run/);
     assert.match(skill, /pnpm dlx create-project-calavera@<version> apply --dry-run/);
     assert.match(skill, /yarn dlx create-project-calavera@<version> apply --dry-run/);
@@ -2958,6 +2962,153 @@ test("MCP AI-only apply preserves existing managed tooling state", async () => {
     );
   } finally {
     process.chdir(originalDirectory);
+  }
+});
+
+test("skill apply adds CodeRabbit exclusions across dry-run, MCP, and apply", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-coderabbit-skills-"));
+  const recipe = buildRecipe("minimal", [], "npm", [
+    { type: "skill", src: "skills/frontend-engineering" },
+  ]);
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile("package.json", `${JSON.stringify({ scripts: {} }, null, 2)}\n`);
+
+    const dryRun = await applyRecipeObject(recipe, {
+      dryRun: true,
+      json: true,
+      noInstall: true,
+      assumeYes: true,
+    });
+    assert.equal(
+      dryRun.changes.some(({ type, path }) => type === "write" && path === ".coderabbit.yaml"),
+      true,
+    );
+    await assertPathMissing(".coderabbit.yaml");
+
+    const mcpDryRun = await callMcpTool("dry_run_apply", { recipe });
+    assert.equal(
+      mcpDryRun.result.changes.some(
+        ({ type, path }) => type === "write" && path === ".coderabbit.yaml",
+      ),
+      true,
+    );
+
+    await applyRecipeObject(recipe, {
+      json: true,
+      noInstall: true,
+      assumeYes: true,
+    });
+    const config = await readFile(".coderabbit.yaml", "utf8");
+    assert.match(config, /CodeRabbit configuration/);
+    assert.match(config, /vendored AI-agent/);
+    assert.match(config, /- "!\.claude\/skills\/\*\*"/);
+    assert.match(config, /- "!\.agents\/skills\/\*\*"/);
+    assert.match(config, /- "!pnpm-lock\.yaml"/);
+
+    const repeatedApply = await applyRecipeObject(recipe, {
+      json: true,
+      noInstall: true,
+      assumeYes: true,
+    });
+    assert.equal(
+      repeatedApply.changes.some(({ path }) => path === ".coderabbit.yaml"),
+      false,
+    );
+  } finally {
+    process.chdir(originalDirectory);
+    await rm(projectDirectory, { force: true, recursive: true });
+  }
+});
+
+test("skill apply preserves existing CodeRabbit settings and path filters", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-coderabbit-merge-"));
+  const recipe = buildRecipe("minimal", [], "npm", [
+    { type: "skill", src: "skills/frontend-engineering" },
+  ]);
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile("package.json", `${JSON.stringify({ scripts: {} }, null, 2)}\n`);
+    await writeFile(
+      ".coderabbit.yaml",
+      'language: en-US\nreviews:\n  profile: chill\n  path_filters:\n    - "src/**"\n',
+    );
+
+    const result = await applyRecipeObject(recipe, {
+      json: true,
+      noInstall: true,
+      assumeYes: true,
+    });
+    assert.equal(
+      result.changes.some(({ type, path }) => type === "update" && path === ".coderabbit.yaml"),
+      true,
+    );
+    const config = await readFile(".coderabbit.yaml", "utf8");
+    assert.match(config, /language: en-US/);
+    assert.match(config, /profile: chill/);
+    assert.match(config, /src\/\*\*/);
+    assert.match(config, /!\.claude\/skills\/\*\*/);
+    assert.match(config, /!\.agents\/skills\/\*\*/);
+    assert.match(config, /!pnpm-lock\.yaml/);
+  } finally {
+    process.chdir(originalDirectory);
+    await rm(projectDirectory, { force: true, recursive: true });
+  }
+});
+
+test("skill apply rejects incompatible CodeRabbit configuration before writing skills", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-coderabbit-invalid-"));
+  const recipe = buildRecipe("minimal", [], "npm", [
+    { type: "skill", src: "skills/frontend-engineering" },
+  ]);
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile("package.json", `${JSON.stringify({ scripts: {} }, null, 2)}\n`);
+    await writeFile(".coderabbit.yaml", "reviews: []\n");
+
+    await assert.rejects(
+      () =>
+        applyRecipeObject(recipe, {
+          json: true,
+          noInstall: true,
+          assumeYes: true,
+        }),
+      /\.coderabbit\.yaml: reviews must be a mapping/,
+    );
+    await assertPathMissing(".agents/skills/frontend-engineering");
+    assert.equal(await readFile(".coderabbit.yaml", "utf8"), "reviews: []\n");
+  } finally {
+    process.chdir(originalDirectory);
+    await rm(projectDirectory, { force: true, recursive: true });
+  }
+});
+
+test("non-skill AI artifacts do not add CodeRabbit configuration", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-coderabbit-hook-"));
+
+  try {
+    process.chdir(projectDirectory);
+    await writeFile("package.json", `${JSON.stringify({ scripts: {} }, null, 2)}\n`);
+    const result = await applyRecipeObject(
+      buildRecipe("minimal", [], "npm", [
+        { type: "hook", src: "hooks/auto-approve-safe-commands" },
+      ]),
+      { dryRun: true, json: true, noInstall: true, assumeYes: true },
+    );
+    assert.equal(
+      result.changes.some(({ path }) => path === ".coderabbit.yaml"),
+      false,
+    );
+  } finally {
+    process.chdir(originalDirectory);
+    await rm(projectDirectory, { force: true, recursive: true });
   }
 });
 

--- a/packages/cli/src/ai/artifacts.js
+++ b/packages/cli/src/ai/artifacts.js
@@ -43,7 +43,7 @@ import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "./catalog.js";
  * @property {string} hash
  * @property {string} [target]
  *
- * @typedef {{ type: string, path: string, category?: "ai", aiType?: AiArtifactType, name?: string, reason?: string }} AiChange
+ * @typedef {{ type: string, path: string, category?: "ai", aiType?: AiArtifactType, name?: string, reason?: string, action?: "write" | "update", ownership?: "project" }} AiChange
  */
 
 const AI_SOURCE_DIRECTORIES = Object.freeze({
@@ -54,6 +54,69 @@ const AI_SOURCE_DIRECTORIES = Object.freeze({
 
 const AI_HOOK_FILES = Object.freeze(["hook.mjs", "settings-fragment.json"]);
 const CODEX_AGENT_TARGET = "codex";
+export const CODE_RABBIT_CONFIG_PATH = ".coderabbit.yaml";
+const CODE_RABBIT_SKILL_FILTERS = Object.freeze([
+  "!.claude/skills/**",
+  "!.agents/skills/**",
+  "!pnpm-lock.yaml",
+]);
+const CODE_RABBIT_SKILL_CONFIG = `# CodeRabbit configuration — https://docs.coderabbit.ai/reference/yaml-template
+#
+# The .claude/skills and .agents/skills directories contain vendored AI-agent
+# skill documentation copied from upstream packages. Findings in those files
+# belong upstream, so excluding them keeps reviews focused on project code.
+
+reviews:
+  path_filters:
+    - "!.claude/skills/**"
+    - "!.agents/skills/**"
+    - "!pnpm-lock.yaml"
+`;
+
+/**
+ * @returns {Promise<{ contents: string, type: "write" | "update" } | undefined>}
+ */
+async function planCodeRabbitSkillConfig() {
+  if (!(await fileExists(CODE_RABBIT_CONFIG_PATH))) {
+    return { contents: CODE_RABBIT_SKILL_CONFIG, type: "write" };
+  }
+
+  const { isMap, isSeq, parseDocument } = await import("yaml");
+  const current = await readFile(CODE_RABBIT_CONFIG_PATH, "utf8");
+  const document = parseDocument(current);
+
+  if (document.errors.length > 0) {
+    throw new Error(
+      `Cannot update ${CODE_RABBIT_CONFIG_PATH}: ${document.errors.map(({ message }) => message).join("; ")}`,
+    );
+  }
+
+  const reviews = document.get("reviews", true);
+  if (reviews === undefined) {
+    document.set("reviews", {});
+  } else if (!isMap(reviews)) {
+    throw new Error(`Cannot update ${CODE_RABBIT_CONFIG_PATH}: reviews must be a mapping.`);
+  }
+
+  let pathFilters = document.getIn(["reviews", "path_filters"], true);
+  if (pathFilters === undefined) {
+    document.setIn(["reviews", "path_filters"], []);
+    pathFilters = document.getIn(["reviews", "path_filters"], true);
+  }
+  if (!isSeq(pathFilters)) {
+    throw new Error(
+      `Cannot update ${CODE_RABBIT_CONFIG_PATH}: reviews.path_filters must be an array.`,
+    );
+  }
+
+  const existingFilters = new Set(pathFilters.toJSON().map(String));
+  for (const filter of CODE_RABBIT_SKILL_FILTERS) {
+    if (!existingFilters.has(filter)) pathFilters.add(filter);
+  }
+
+  const contents = document.toString({ lineWidth: 0 });
+  return contents === current ? undefined : { contents, type: "update" };
+}
 
 /**
  * @param {ResolvedAiArtifact} artifact
@@ -541,6 +604,9 @@ async function assertSafeAiWrite(artifact, path, sourceHash, previousState) {
  */
 export async function buildAiApplyResult(recipe, options, previousState, sourcePaths = new Map()) {
   const artifacts = resolveAiArtifacts(recipe, sourcePaths);
+  const codeRabbitPlan = artifacts.some(({ type }) => type === "skill")
+    ? await planCodeRabbitSkillConfig()
+    : undefined;
   /** @type {AiChange[]} */
   const changes = [];
   /** @type {AiArtifactState[]} */
@@ -609,6 +675,22 @@ export async function buildAiApplyResult(recipe, options, previousState, sourceP
           ? "Codex custom agent files are installed under .codex/agents/."
           : `Agent files for ${artifact.target} are installed under .agents/agents/${artifact.target}/ in their original Markdown/frontmatter format.`,
       );
+    }
+  }
+
+  if (codeRabbitPlan) {
+    changes.push({
+      type: codeRabbitPlan.type,
+      path: CODE_RABBIT_CONFIG_PATH,
+      action: codeRabbitPlan.type,
+      ownership: "project",
+    });
+    if (!options.dryRun) {
+      const configPath = options.outputRoot
+        ? resolve(options.outputRoot, CODE_RABBIT_CONFIG_PATH)
+        : resolve(CODE_RABBIT_CONFIG_PATH);
+      await mkdir(dirname(configPath), { recursive: true });
+      await writeFile(configPath, codeRabbitPlan.contents);
     }
   }
 

--- a/packages/cli/src/artifact-lifecycle.js
+++ b/packages/cli/src/artifact-lifecycle.js
@@ -14,6 +14,7 @@ import packageJson from "../package.json" with { type: "json" };
 import {
   aiArtifactOutputPaths,
   buildAiApplyResult,
+  CODE_RABBIT_CONFIG_PATH,
   hashAiInstall,
   resolveAiArtifacts,
 } from "./ai/artifacts.js";
@@ -329,6 +330,12 @@ async function installArtifacts(options, updating, registry) {
         for (const path of outputPaths) {
           operations.push({ staged: resolve(outputRoot, path), target: resolve(path) });
         }
+      }
+      if (changedPaths.has(CODE_RABBIT_CONFIG_PATH)) {
+        operations.push({
+          staged: resolve(outputRoot, CODE_RABBIT_CONFIG_PATH),
+          target: resolve(CODE_RABBIT_CONFIG_PATH),
+        });
       }
       operations.push(
         { staged: stagedState, target: resolve(STATE_PATH) },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       prettier:
         specifier: ^3.5.3
         version: 3.9.5
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
## Summary

- create or merge `.coderabbit.yaml` whenever Calavera installs a skill
- exclude `.claude/skills/**`, `.agents/skills/**`, and `pnpm-lock.yaml` from CodeRabbit reviews
- preserve existing CodeRabbit settings and filters, reject incompatible YAML shapes before writing skills, and keep the configuration project-owned
- cover CLI and MCP dry-runs, ordinary apply, agent bootstrap, package-backed lifecycle transactions, idempotency, existing configuration, and non-skill artifacts

## Why

Installed skills are vendored upstream documentation. Excluding them keeps downstream reviews focused and avoids spending a consumer's review tokens on findings that should be fixed upstream.

## Validation

- `pnpm quality`
- `pnpm --filter create-project-calavera test`
- `pnpm web:build`
- `pnpm publish:check`
- `pnpm release:status`

fix #313
