### PR TITLE
fix: validate CSS specification hosts

### DIFF
--- a/.changeset/clean-css-hosts.md
+++ b/.changeset/clean-css-hosts.md
@@ -1,0 +1,5 @@
+---
+"@schalkneethling/calavera-baseline-core": patch
+---
+
+Parse CSS specification URLs and require the exact approved hostname during Baseline data generation.

--- a/packages/baseline-core/scripts/build-data.mjs
+++ b/packages/baseline-core/scripts/build-data.mjs
@@ -4,6 +4,7 @@ import { getAllVersions, getCompatibleVersions } from "baseline-browser-mapping"
 import { features } from "web-features";
 
 import packageJson from "../package.json" with { type: "json" };
+import { isCssSpecificationUrl } from "../src/specification-url.js";
 
 const CURRENT_YEAR = new Date().getUTCFullYear();
 const FIRST_BASELINE_YEAR = 2015;
@@ -21,7 +22,7 @@ function isCssFeature(feature) {
   return (
     feature.compat_features?.some((key) => key.startsWith("css.")) ||
     feature.group?.includes("css") ||
-    feature.spec?.some((url) => url.includes("csswg.org"))
+    feature.spec?.some(isCssSpecificationUrl)
   );
 }
 

--- a/packages/baseline-core/src/specification-url.js
+++ b/packages/baseline-core/src/specification-url.js
@@ -1,0 +1,13 @@
+const CSS_SPECIFICATION_HOSTS = new Set(["drafts.csswg.org"]);
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+export function isCssSpecificationUrl(value) {
+  try {
+    return CSS_SPECIFICATION_HOSTS.has(new URL(value).hostname);
+  } catch {
+    return false;
+  }
+}

--- a/packages/baseline-core/test/baseline.test.mjs
+++ b/packages/baseline-core/test/baseline.test.mjs
@@ -10,12 +10,23 @@ import {
   recommendBaselineTarget,
   searchBaselineFeatures,
 } from "../src/index.js";
+import { isCssSpecificationUrl } from "../src/specification-url.js";
 
 test("generated Baseline data records pinned sources and CSS features", () => {
   assert.equal(baselineMetadata.sources.webFeatures, "3.34.0");
   assert.equal(baselineMetadata.sources.baselineBrowserMapping, "2.10.43");
   assert.ok(baselineMetadata.featureCount > 100);
   assert.ok(searchBaselineFeatures("nesting").some(({ id }) => id === "nesting"));
+});
+
+test("CSS specification URLs require the exact approved host", () => {
+  assert.equal(isCssSpecificationUrl("https://drafts.csswg.org/css-grid/"), true);
+  assert.equal(isCssSpecificationUrl("https://drafts.csswg.org.evil.example/css-grid/"), false);
+  assert.equal(
+    isCssSpecificationUrl("https://evil.example/?url=https://drafts.csswg.org/css-grid/"),
+    false,
+  );
+  assert.equal(isCssSpecificationUrl("not a URL containing drafts.csswg.org"), false);
 });
 
 test("target descriptions distinguish moving and fixed targets", () => {


### PR DESCRIPTION
## Summary

- parse specification URLs before classifying them as CSS specifications
- require the exact currently approved `drafts.csswg.org` hostname
- fail closed for deceptive hosts, path/query substring matches, and malformed URLs
- add a Baseline-core Changeset

## Root cause

The Baseline data builder used `url.includes("csswg.org")`. That substring could occur outside the parsed hostname or inside a deceptive hostname, causing CodeQL alert #1 (`js/incomplete-url-substring-sanitization`).

The pinned WebDX data currently uses only `drafts.csswg.org`, so an exact host allowlist preserves the generated dataset while removing the ambiguous substring check.

## Validation

- `pnpm --filter @schalkneethling/calavera-baseline-core test`
- `pnpm quality`
- `pnpm format:all:check`
- `pnpm release:status`
- generated Baseline data remains unchanged for the pinned inputs

fix #318
