### PR TITLE
style: refine the Baseline Explorer hero

### DIFF
--- a/apps/baseline-explorer/index.html
+++ b/apps/baseline-explorer/index.html
@@ -52,8 +52,7 @@
 
         <div class="workbench">
           <section class="controls" aria-labelledby="controls-title">
-            <p class="section-label" id="controls-title">Set the compatibility line</p>
-
+            <h2 class="visually-hidden" id="controls-title">Set the compatibility line</h2>
             <div id="target-controls">
               <label for="target">Baseline target</label>
               <select id="target"></select>
@@ -76,7 +75,6 @@
           <section class="result" aria-live="polite" aria-labelledby="result-title">
             <div class="result-heading">
               <div>
-                <p class="section-label">Compatibility result</p>
                 <h2 id="result-title">Widely available</h2>
               </div>
               <span class="status-chip" id="result-status">Moving target</span>
@@ -94,7 +92,6 @@
 
       <section class="output-section" id="output-section" aria-labelledby="output-title">
         <div>
-          <p class="section-label">Carry the decision into your project</p>
           <h2 id="output-title">Generated configuration</h2>
         </div>
         <div class="output-tabs" role="tablist" aria-label="Generated configuration formats">

--- a/apps/baseline-explorer/src/styles.css
+++ b/apps/baseline-explorer/src/styles.css
@@ -51,18 +51,26 @@ select {
 
 .masthead {
   align-items: center;
-  border-bottom: 1px solid #9bb6c4;
+  background: var(--ink);
+  border-bottom: 0.25rem solid var(--cyan);
+  color: var(--paper);
   display: grid;
   font-family: SFMono-Regular, Consolas, monospace;
   font-size: 0.78rem;
   gap: 1rem;
   grid-template-columns: 1fr auto 1fr;
   letter-spacing: 0.04em;
-  padding: 1rem clamp(1rem, 4vw, 4rem);
+  padding-block: 0.9rem;
+  padding-inline: max(1rem, calc((100vw - 76rem) / 2));
 }
 
 .masthead a {
   color: inherit;
+  text-underline-offset: 0.2em;
+}
+
+.masthead p {
+  margin: 0;
 }
 
 .masthead > :last-child {
@@ -83,9 +91,13 @@ footer {
 
 .intro {
   display: grid;
-  gap: 1rem 4rem;
-  grid-template-columns: minmax(0, 1.6fr) minmax(18rem, 0.7fr);
-  padding: clamp(4rem, 10vw, 8rem) 0 3rem;
+  gap: 1.5rem clamp(3rem, 7vw, 7rem);
+  grid-template-areas:
+    "eyebrow eyebrow"
+    "title stamp"
+    "lede stamp";
+  grid-template-columns: minmax(0, 1.65fr) minmax(17rem, 0.65fr);
+  padding: clamp(3.5rem, 8vw, 6.5rem) 0 clamp(3rem, 6vw, 5rem);
 }
 
 .eyebrow,
@@ -99,26 +111,44 @@ footer {
   text-transform: uppercase;
 }
 
+.intro .eyebrow {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  grid-area: eyebrow;
+}
+
+.intro .eyebrow::after {
+  background: var(--cyan);
+  content: "";
+  height: 0.2rem;
+  max-width: 11rem;
+  width: 14vw;
+}
+
 h1 {
-  font-size: clamp(3.5rem, 9vw, 7.5rem);
+  font-size: clamp(3.75rem, 7.5vw, 6.75rem);
   font-weight: 650;
-  letter-spacing: -0.075em;
-  line-height: 0.83;
+  grid-area: title;
+  letter-spacing: -0.07em;
+  line-height: 0.88;
   margin: 0;
-  max-width: 13ch;
+  max-width: 12ch;
 }
 
 .lede {
   font-size: clamp(1.1rem, 2vw, 1.45rem);
+  grid-area: lede;
   line-height: 1.45;
-  margin: 1.75rem 0 0;
-  max-width: 42rem;
+  margin: 0.5rem 0 0;
+  max-width: 39rem;
 }
 
 .source-stamp {
-  align-self: end;
+  align-self: center;
   background: rgb(248 252 254 / 78%);
   border-top: 4px solid var(--cyan);
+  grid-area: stamp;
   margin: 0;
 }
 
@@ -410,8 +440,23 @@ footer {
     grid-template-columns: 1fr;
   }
 
+  .intro {
+    gap: 1.25rem;
+    grid-template-areas:
+      "eyebrow"
+      "title"
+      "lede"
+      "stamp";
+    padding-block: 3.5rem;
+  }
+
+  h1 {
+    font-size: clamp(3.25rem, 15vw, 5.5rem);
+    max-width: 11ch;
+  }
+
   .source-stamp {
-    margin-top: 2rem;
+    margin-top: 1.25rem;
   }
 
   .controls {

--- a/apps/baseline-explorer/src/styles.css
+++ b/apps/baseline-explorer/src/styles.css
@@ -402,6 +402,8 @@ h2 {
 
 .output-tabs {
   align-self: end;
+  border: 1px solid #809fac;
+  border-bottom: 0;
   display: flex;
   grid-column: 2;
 }

--- a/apps/baseline-explorer/src/styles.css
+++ b/apps/baseline-explorer/src/styles.css
@@ -100,12 +100,13 @@ footer {
 
 .intro {
   display: grid;
-  gap: 1.5rem clamp(3rem, 7vw, 7rem);
+  gap: 1.5rem;
   grid-template-areas:
-    "eyebrow eyebrow"
-    "title stamp"
-    "lede stamp";
-  grid-template-columns: minmax(0, 1.65fr) minmax(17rem, 0.65fr);
+    "eyebrow"
+    "title"
+    "lede"
+    "stamp";
+  grid-template-columns: minmax(0, 1fr);
   padding: clamp(3.5rem, 8vw, 6.5rem) 0 clamp(3rem, 6vw, 5rem);
 }
 
@@ -153,19 +154,27 @@ h1 {
 }
 
 .source-stamp {
-  align-self: center;
-  background: rgb(248 252 254 / 78%);
+  align-self: start;
+  border-bottom: 1px solid #9bb6c4;
   border-top: 4px solid var(--cyan);
+  display: grid;
   grid-area: stamp;
-  margin: 0;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 1.25rem 0 0;
+  max-width: 54rem;
+  width: 100%;
 }
 
 .source-stamp div {
-  border-bottom: 1px solid #9bb6c4;
+  border-right: 1px solid #9bb6c4;
   display: grid;
-  gap: 1rem;
-  grid-template-columns: 1fr 1.4fr;
-  padding: 0.85rem 0;
+  gap: 0.35rem;
+  grid-template-columns: 1fr;
+  padding: 1rem 1.2rem;
+}
+
+.source-stamp div:last-child {
+  border-right: 0;
 }
 
 .source-stamp dt {
@@ -459,11 +468,6 @@ footer {
 
   .intro {
     gap: 1.25rem;
-    grid-template-areas:
-      "eyebrow"
-      "title"
-      "lede"
-      "stamp";
     padding-block: 3.5rem;
   }
 
@@ -473,7 +477,17 @@ footer {
   }
 
   .source-stamp {
+    grid-template-columns: 1fr;
     margin-top: 1.25rem;
+  }
+
+  .source-stamp div {
+    border-bottom: 1px solid #9bb6c4;
+    border-right: 0;
+  }
+
+  .source-stamp div:last-child {
+    border-bottom: 0;
   }
 
   .controls {

--- a/apps/baseline-explorer/src/styles.css
+++ b/apps/baseline-explorer/src/styles.css
@@ -393,6 +393,11 @@ h2 {
   padding-top: 1rem;
 }
 
+.browser-runway:empty,
+.result-details:empty {
+  display: none;
+}
+
 .output-section {
   display: grid;
   gap: 2rem;

--- a/apps/baseline-explorer/src/styles.css
+++ b/apps/baseline-explorer/src/styles.css
@@ -18,6 +18,15 @@
   box-sizing: border-box;
 }
 
+.visually-hidden {
+  block-size: 1px;
+  clip-path: inset(50%);
+  inline-size: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+}
+
 body {
   background:
     linear-gradient(90deg, transparent 49.9%, rgb(16 24 43 / 6%) 50%, transparent 50.1%) 0 0 / 3rem
@@ -100,8 +109,7 @@ footer {
   padding: clamp(3.5rem, 8vw, 6.5rem) 0 clamp(3rem, 6vw, 5rem);
 }
 
-.eyebrow,
-.section-label {
+.eyebrow {
   font:
     700 0.72rem/1.2 SFMono-Regular,
     Consolas,
@@ -175,7 +183,6 @@ h1 {
 .explorer-shell {
   background: var(--paper);
   border: 1px solid #809fac;
-  border-radius: 0.7rem;
   box-shadow: 0.75rem 0.75rem 0 var(--navy);
   overflow: clip;
 }
@@ -190,10 +197,17 @@ h1 {
 .output-tabs button {
   background: transparent;
   border: 0;
-  border-right: 1px solid #809fac;
+  border-radius: 0;
   color: var(--ink);
   cursor: pointer;
+}
+
+.mode-switcher button {
   padding: 0.9rem 1.2rem;
+}
+
+.output-tabs button {
+  padding: 0.7rem 1rem;
 }
 
 .mode-switcher button[aria-pressed="true"],
@@ -231,6 +245,10 @@ input[type="search"] {
   color: var(--ink);
   padding: 0.9rem;
   width: 100%;
+}
+
+select {
+  padding-inline: 1.15rem 2.75rem;
 }
 
 button:focus-visible,
@@ -374,8 +392,7 @@ h2 {
 }
 
 .output-tabs {
-  border: 1px solid #809fac;
-  border-bottom: 0;
+  align-self: end;
   display: flex;
   grid-column: 2;
 }

--- a/apps/baseline-explorer/test/output-controls.spec.mjs
+++ b/apps/baseline-explorer/test/output-controls.spec.mjs
@@ -19,6 +19,20 @@ async function expectSelected(page, selectedId) {
   }
 }
 
+test("empty recommendations hide data dividers until a feature is selected", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Recommend from features" }).click();
+
+  const browserRunway = page.locator("#browser-runway");
+  const resultDetails = page.locator("#result-details");
+  await expect(browserRunway).toBeHidden();
+  await expect(resultDetails).toBeHidden();
+
+  await page.locator('.feature-option input[value="nesting"]').check();
+  await expect(browserRunway).toBeVisible();
+  await expect(resultDetails).toBeVisible();
+});
+
 test("generated-output tabs implement the APG interaction and copy each format", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- replace the Baseline Explorer hero's implicit grid flow with explicit responsive areas
- give the headline a readable desktop measure and preserve the semantic mobile reading order
- move dataset provenance into a supporting column connected by the cyan compatibility line
- strengthen and align the masthead without changing Explorer behavior

## Root cause

The four hero children flowed implicitly across a two-column grid. This placed the eyebrow in the wide column and the headline in the narrow column, forcing nearly every headline word onto its own line and creating a large empty region before the Explorer.

## Validation

- Baseline Explorer production build
- Stylelint, including the Baseline compatibility rule
- Oxfmt
- desktop visual review at 1464px
- mobile visual review at 390px
- Playwright APG output-tab and copy interaction test
- `git diff --check`

fix #327


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved page heading and label semantics for clearer navigation with assistive technologies.
  * Added screen-reader-only supporting content where appropriate.

* **Style**
  * Refreshed the explorer’s layout, typography, spacing, colors, controls, and responsive mobile presentation.
  * Improved select controls, tabs, buttons, and source information styling.

* **Bug Fixes**
  * Empty recommendation and result details sections now remain hidden until relevant results are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->