### PR TITLE
fix: keep Composer recipe validation browser-safe

### DIFF
--- a/apps/composer/test/cli-compatibility.test.mjs
+++ b/apps/composer/test/cli-compatibility.test.mjs
@@ -12,6 +12,7 @@ import {
   SAFE_CLI_FALLBACK_VERSION,
   versionMeetsMinimum,
 } from "../cli-compatibility.js";
+import viteConfig from "../vite.config.js";
 
 test("version comparison keeps unreleased integrations behind their CLI release", () => {
   assert.equal(versionMeetsMinimum("2.2.0", "2.3.0"), false);
@@ -92,4 +93,24 @@ test("published CLI lookup accepts valid npm latest metadata", async () => {
   }));
 
   assert.deepEqual(compatibility, { version: "2.3.0", source: "npm" });
+});
+
+test("Composer build rejects Node-only modules in its browser graph", () => {
+  const browserOnlyPlugin = viteConfig.plugins.find(
+    ({ name }) => name === "browser-only-module-graph",
+  );
+
+  assert.throws(
+    () =>
+      browserOnlyPlugin.resolveId.call(
+        {
+          error(message) {
+            throw new Error(message);
+          },
+        },
+        "node:path",
+        "packages/cli/src/recipe.js",
+      ),
+    /Node-only module node:path reached the Composer/,
+  );
 });

--- a/apps/composer/test/cli-compatibility.test.mjs
+++ b/apps/composer/test/cli-compatibility.test.mjs
@@ -100,6 +100,8 @@ test("Composer build rejects Node-only modules in its browser graph", () => {
     ({ name }) => name === "browser-only-module-graph",
   );
 
+  assert.ok(browserOnlyPlugin);
+  assert.equal(browserOnlyPlugin.enforce, "pre");
   assert.throws(
     () =>
       browserOnlyPlugin.resolveId.call(
@@ -111,6 +113,8 @@ test("Composer build rejects Node-only modules in its browser graph", () => {
         "node:path",
         "packages/cli/src/recipe.js",
       ),
-    /Node-only module node:path reached the Composer/,
+    {
+      message: "Node-only module node:path reached the Composer from packages/cli/src/recipe.js.",
+    },
   );
 });

--- a/apps/composer/vite.config.js
+++ b/apps/composer/vite.config.js
@@ -1,6 +1,17 @@
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  plugins: [
+    {
+      name: "browser-only-module-graph",
+      enforce: "pre",
+      resolveId(source, importer) {
+        if (source.startsWith("node:")) {
+          this.error(`Node-only module ${source} reached the Composer from ${importer}.`);
+        }
+      },
+    },
+  ],
   build: {
     emptyOutDir: true,
     outDir: "../../dist-web",

--- a/packages/cli/scripts/check-config-schema.test.mjs
+++ b/packages/cli/scripts/check-config-schema.test.mjs
@@ -555,6 +555,35 @@ test("shared recipe validation rejects malformed AI items and unknown properties
   assert.throws(() => validateRecipe({ ...recipe, unexpected: true }), /Unknown recipe properties/);
 });
 
+test("shared recipe validation rejects unsafe AI types, sources, and targets", () => {
+  const recipe = buildRecipe("minimal", [], "npm");
+
+  assert.throws(
+    () =>
+      validateRecipe({
+        ...recipe,
+        ai: [{ type: "plugin", src: "skills/project-goal" }],
+      }),
+    /unsupported type "plugin"/,
+  );
+  assert.throws(
+    () =>
+      validateRecipe({
+        ...recipe,
+        ai: [{ type: "skill", src: "hooks/block-dangerous-commands" }],
+      }),
+    /skill source must be under skills\//,
+  );
+  assert.throws(
+    () =>
+      validateRecipe({
+        ...recipe,
+        ai: [{ id: "hook-block-dangerous-commands", target: "../codex" }],
+      }),
+    /target is not supported/,
+  );
+});
+
 test("shared catalog helpers expose WebMCP-ready profile scoped options", () => {
   const modernToolIds = listIntegrationOptions("modern").map(({ id }) => id);
   const classicToolIds = listIntegrationOptions("classic").map(({ id }) => id);

--- a/packages/cli/scripts/check-config-schema.test.mjs
+++ b/packages/cli/scripts/check-config-schema.test.mjs
@@ -578,7 +578,21 @@ test("shared recipe validation rejects unsafe AI types, sources, and targets", (
     () =>
       validateRecipe({
         ...recipe,
-        ai: [{ id: "hook-block-dangerous-commands", target: "../codex" }],
+        ai: [{ id: "hook-block-dangerous-commands", target: "windsurf" }],
+      }),
+    /target is not supported/,
+  );
+  assert.throws(
+    () =>
+      validateRecipe({
+        ...recipe,
+        ai: [
+          {
+            type: "hook",
+            src: "hooks/block-dangerous-commands",
+            target: "windsurf",
+          },
+        ],
       }),
     /target is not supported/,
   );

--- a/packages/cli/src/ai/artifacts.js
+++ b/packages/cli/src/ai/artifacts.js
@@ -5,26 +5,14 @@ import { basename, dirname, join, resolve } from "node:path";
 import { artifactPayloadPath } from "@schalkneethling/calavera-artifact-core/node";
 
 import { fileExists } from "../utils/fs.js";
-import { isNotEmptyString, isPlainObject } from "../utils/guards.js";
+import { isNotEmptyString } from "../utils/guards.js";
 import { hashDirectory, hashFile, textHash } from "../utils/hash.js";
-import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "./catalog.js";
+import { normalizeAiItems } from "./recipe-items.js";
 
 /**
  * @typedef {import("../state.js").CalaveraState} CalaveraState
  *
  * @typedef {"skill" | "hook" | "agent"} AiArtifactType
- *
- * @typedef {object} AiItemConfig
- * @property {string} [id]
- * @property {string} [type]
- * @property {string} [src]
- * @property {string} [target]
- *
- * @typedef {object} NormalizedAiItem
- * @property {string} [id]
- * @property {string} type
- * @property {string} src
- * @property {string} [target]
  *
  * @typedef {object} ResolvedAiArtifact
  * @property {number} index
@@ -45,12 +33,6 @@ import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "./catalog.js";
  *
  * @typedef {{ type: string, path: string, category?: "ai", aiType?: AiArtifactType, name?: string, reason?: string, action?: "write" | "update", ownership?: "project" }} AiChange
  */
-
-const AI_SOURCE_DIRECTORIES = Object.freeze({
-  skill: "skills",
-  hook: "hooks",
-  agent: "agents",
-});
 
 const AI_HOOK_FILES = Object.freeze(["hook.mjs", "settings-fragment.json"]);
 const CODEX_AGENT_TARGET = "codex";
@@ -209,120 +191,8 @@ export function createCodexAgentToml(markdown) {
   return `${lines.join("\n")}\n`;
 }
 
-/**
- * @param {string} type
- * @param {number} index
- * @returns {AiArtifactType}
- */
-function normalizeAiItemType(type, index) {
-  if (Object.hasOwn(AI_SOURCE_DIRECTORIES, type)) {
-    return /** @type {AiArtifactType} */ (type);
-  }
-
-  throw new Error(
-    `AI item at index ${index} has unsupported type "${type}". Supported types: skill, hook, agent.`,
-  );
-}
-
-/**
- * @param {unknown} value
- * @returns {value is AiItemConfig}
- */
-function isAiItemConfig(value) {
-  return (
-    isPlainObject(value) &&
-    ((isNotEmptyString(value.id) && value.type === undefined && value.src === undefined) ||
-      (isNotEmptyString(value.type) && isNotEmptyString(value.src) && value.id === undefined)) &&
-    (value.target === undefined || isNotEmptyString(value.target))
-  );
-}
-
-/**
- * @param {AiArtifactType} type
- * @param {AiItemConfig} item
- * @param {number} index
- * @returns {string | undefined}
- */
-function normalizeAiTarget(type, item, index) {
-  if (type === "skill") {
-    if (item.target !== undefined) {
-      throw new Error(`AI item at index ${index} target only applies to hook and agent items.`);
-    }
-
-    return undefined;
-  }
-
-  const target = item.target?.trim() || DEFAULT_AI_TARGET;
-
-  if (target.includes("/") || target.includes("\\") || target === "." || target === "..") {
-    throw new Error(
-      `AI item at index ${index} target must be a single directory name without path separators or traversal.`,
-    );
-  }
-
-  return target;
-}
-
-/**
- * @param {unknown} aiConfig
- * @returns {NormalizedAiItem[]}
- */
-function normalizeAiItems(aiConfig) {
-  if (aiConfig === undefined) {
-    return [];
-  }
-
-  if (!Array.isArray(aiConfig)) {
-    throw new Error("The optional ai config key must be an array.");
-  }
-
-  return aiConfig.map((entry, index) => {
-    if (!isAiItemConfig(entry)) {
-      throw new Error(`AI item at index ${index} must contain id, or legacy type and src fields.`);
-    }
-
-    if (entry.id) {
-      const artifact = aiArtifactCatalog.find(({ id }) => id === entry.id);
-      if (!artifact) throw new Error(`AI item at index ${index} has unknown id "${entry.id}".`);
-      const target = entry.target?.trim();
-      if (target && artifact.targets && !artifact.targets.includes(target)) {
-        throw new Error(`AI item at index ${index} target is not supported by ${entry.id}.`);
-      }
-      return {
-        id: artifact.id,
-        type: artifact.type,
-        src: artifact.src,
-        target,
-      };
-    }
-
-    return {
-      type: /** @type {string} */ (entry.type).trim(),
-      src: /** @type {string} */ (entry.src).trim(),
-      target: entry.target?.trim(),
-    };
-  });
-}
-
-/**
- * @param {string} src
- * @param {number} index
- * @param {AiArtifactType} type
- * @returns {string}
- */
-function resolveAiSourcePath(src, index, type) {
-  const artifact = aiArtifactCatalog.find((candidate) => candidate.src === src);
-
-  if (!artifact) {
-    throw new Error(`AI item at index ${index} source must stay within src/ai/: ${src}.`);
-  }
-
-  if (artifact.type !== type) {
-    throw new Error(
-      `AI item at index ${index} ${type} source must be under ${AI_SOURCE_DIRECTORIES[type]}/: ${src}.`,
-    );
-  }
-
+/** @param {string} src */
+function resolveAiSourcePath(src) {
   return artifactPayloadPath(src);
 }
 
@@ -492,10 +362,8 @@ export function resolveAiArtifacts(recipe, sourcePaths = new Map()) {
   const deduped = new Map();
 
   for (const [index, item] of normalizeAiItems(recipe.ai).entries()) {
-    const type = normalizeAiItemType(item.type, index);
-    const target = normalizeAiTarget(type, item, index);
-    const sourcePath =
-      sourcePaths.get(item.id ?? item.src) ?? resolveAiSourcePath(item.src, index, type);
+    const { type, target } = item;
+    const sourcePath = sourcePaths.get(item.id ?? item.src) ?? resolveAiSourcePath(item.src);
     const name = inferAiSourceName(type, item.src, index);
     const key = [type, target, name].filter(Boolean).join(":");
 

--- a/packages/cli/src/ai/recipe-items.js
+++ b/packages/cli/src/ai/recipe-items.js
@@ -1,0 +1,152 @@
+// @ts-check
+import { isNotEmptyString, isPlainObject } from "../utils/guards.js";
+import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "./catalog.js";
+
+const AI_SOURCE_DIRECTORIES = Object.freeze({
+  skill: "skills",
+  hook: "hooks",
+  agent: "agents",
+});
+
+/**
+ * @typedef {"skill" | "hook" | "agent"} AiArtifactType
+ *
+ * @typedef {object} AiItemConfig
+ * @property {string} [id]
+ * @property {string} [type]
+ * @property {string} [src]
+ * @property {string} [target]
+ *
+ * @typedef {object} NormalizedAiItem
+ * @property {string} [id]
+ * @property {AiArtifactType} type
+ * @property {string} src
+ * @property {string} [target]
+ */
+
+/**
+ * @param {string} type
+ * @param {number} index
+ * @returns {AiArtifactType}
+ */
+function normalizeAiItemType(type, index) {
+  if (Object.hasOwn(AI_SOURCE_DIRECTORIES, type)) {
+    return /** @type {AiArtifactType} */ (type);
+  }
+
+  throw new Error(
+    `AI item at index ${index} has unsupported type "${type}". Supported types: skill, hook, agent.`,
+  );
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is AiItemConfig}
+ */
+function isAiItemConfig(value) {
+  return (
+    isPlainObject(value) &&
+    ((isNotEmptyString(value.id) && value.type === undefined && value.src === undefined) ||
+      (isNotEmptyString(value.type) && isNotEmptyString(value.src) && value.id === undefined)) &&
+    (value.target === undefined || isNotEmptyString(value.target))
+  );
+}
+
+/**
+ * @param {AiArtifactType} type
+ * @param {AiItemConfig} item
+ * @param {number} index
+ * @returns {string | undefined}
+ */
+function normalizeAiTarget(type, item, index) {
+  if (type === "skill") {
+    if (item.target !== undefined) {
+      throw new Error(`AI item at index ${index} target only applies to hook and agent items.`);
+    }
+
+    return undefined;
+  }
+
+  const target = item.target?.trim() || DEFAULT_AI_TARGET;
+
+  if (target.includes("/") || target.includes("\\") || target === "." || target === "..") {
+    throw new Error(
+      `AI item at index ${index} target must be a single directory name without path separators or traversal.`,
+    );
+  }
+
+  return target;
+}
+
+/**
+ * @param {string} src
+ * @param {number} index
+ * @param {AiArtifactType} type
+ */
+function validateAiSource(src, index, type) {
+  const artifact = aiArtifactCatalog.find((candidate) => candidate.src === src);
+
+  if (!artifact) {
+    throw new Error(`AI item at index ${index} source must stay within src/ai/: ${src}.`);
+  }
+
+  if (artifact.type !== type) {
+    throw new Error(
+      `AI item at index ${index} ${type} source must be under ${AI_SOURCE_DIRECTORIES[type]}/: ${src}.`,
+    );
+  }
+}
+
+/**
+ * @param {unknown} aiConfig
+ * @returns {NormalizedAiItem[]}
+ */
+export function normalizeAiItems(aiConfig) {
+  if (aiConfig === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(aiConfig)) {
+    throw new Error("The optional ai config key must be an array.");
+  }
+
+  return aiConfig.map((entry, index) => {
+    if (!isAiItemConfig(entry)) {
+      throw new Error(`AI item at index ${index} must contain id, or legacy type and src fields.`);
+    }
+
+    let item;
+
+    if (entry.id) {
+      const artifact = aiArtifactCatalog.find(({ id }) => id === entry.id);
+      if (!artifact) throw new Error(`AI item at index ${index} has unknown id "${entry.id}".`);
+      const target = entry.target?.trim();
+      if (target && artifact.targets && !artifact.targets.includes(target)) {
+        throw new Error(`AI item at index ${index} target is not supported by ${entry.id}.`);
+      }
+      item = {
+        id: artifact.id,
+        type: artifact.type,
+        src: artifact.src,
+        target,
+      };
+    } else {
+      item = {
+        type: /** @type {string} */ (entry.type).trim(),
+        src: /** @type {string} */ (entry.src).trim(),
+        target: entry.target?.trim(),
+      };
+    }
+
+    const type = normalizeAiItemType(item.type, index);
+    const target = normalizeAiTarget(type, item, index);
+    validateAiSource(item.src, index, type);
+
+    return {
+      id: item.id,
+      type,
+      src: item.src,
+      target,
+    };
+  });
+}

--- a/packages/cli/src/ai/recipe-items.js
+++ b/packages/cli/src/ai/recipe-items.js
@@ -82,6 +82,7 @@ function normalizeAiTarget(type, item, index) {
  * @param {string} src
  * @param {number} index
  * @param {AiArtifactType} type
+ * @returns {(typeof aiArtifactCatalog)[number]}
  */
 function validateAiSource(src, index, type) {
   const artifact = aiArtifactCatalog.find((candidate) => candidate.src === src);
@@ -95,6 +96,8 @@ function validateAiSource(src, index, type) {
       `AI item at index ${index} ${type} source must be under ${AI_SOURCE_DIRECTORIES[type]}/: ${src}.`,
     );
   }
+
+  return artifact;
 }
 
 /**
@@ -120,15 +123,11 @@ export function normalizeAiItems(aiConfig) {
     if (entry.id) {
       const artifact = aiArtifactCatalog.find(({ id }) => id === entry.id);
       if (!artifact) throw new Error(`AI item at index ${index} has unknown id "${entry.id}".`);
-      const target = entry.target?.trim();
-      if (target && artifact.targets && !artifact.targets.includes(target)) {
-        throw new Error(`AI item at index ${index} target is not supported by ${entry.id}.`);
-      }
       item = {
         id: artifact.id,
         type: artifact.type,
         src: artifact.src,
-        target,
+        target: entry.target?.trim(),
       };
     } else {
       item = {
@@ -140,7 +139,13 @@ export function normalizeAiItems(aiConfig) {
 
     const type = normalizeAiItemType(item.type, index);
     const target = normalizeAiTarget(type, item, index);
-    validateAiSource(item.src, index, type);
+    const artifact = validateAiSource(item.src, index, type);
+
+    if (item.target !== undefined && artifact.targets && !artifact.targets.includes(target)) {
+      throw new Error(
+        `AI item at index ${index} target is not supported by ${item.id ?? item.src}.`,
+      );
+    }
 
     return {
       id: item.id,

--- a/packages/cli/src/recipe.js
+++ b/packages/cli/src/recipe.js
@@ -1,5 +1,5 @@
 import { aiArtifactCatalog, DEFAULT_AI_TARGET } from "./ai/catalog.js";
-import { resolveAiArtifacts } from "./ai/artifacts.js";
+import { normalizeAiItems } from "./ai/recipe-items.js";
 import { integrationCatalog } from "./catalog.js";
 import { normalizeBaselineTarget } from "@schalkneethling/calavera-baseline-core";
 import {
@@ -650,7 +650,7 @@ export function validateRecipe(recipe) {
 
   if (Object.hasOwn(recipe, "ai")) {
     assertObjectArray("ai", recipe.ai);
-    resolveAiArtifacts(recipe);
+    normalizeAiItems(recipe.ai);
   }
 
   return recipe;


### PR DESCRIPTION
## Summary

- extract AI recipe-entry normalization into a browser-safe module shared by recipe validation and Node-side artifact installation
- keep filesystem, path, hashing, and payload resolution imports out of the Composer dependency graph
- make the Composer build fail if a future `node:` import reaches its browser graph
- add contract coverage for unsafe AI types, legacy sources, and targets

## Root cause

The Composer imports the shared CLI recipe module. That module imported the Node-only artifact installer at module load time solely to validate `recipe.ai`, causing Vite to traverse filesystem, path, crypto, and artifact Node modules and replace them with browser stubs.

Recipe validation now depends only on catalog data and pure guards. The Node installer consumes the same normalized entries before resolving payload and installation paths.

## Validation

- `pnpm release:rehearse`
- Composer production build completes without Node externalization warnings
- 7 Composer tests
- 122 CLI tests
- TypeScript, Oxfmt, Oxlint, Knip, Stylelint, and Skillspector
- release contracts, targeted artifact fixture, all application builds, and every `publint` package check

No Changeset is included because published CLI behavior and versions are unchanged; this repairs the private Composer build boundary.

fix #329


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation and normalization for AI recipe configurations, including supported artifact types, source locations, and target paths.
  * Composer now detects Node-only modules in browser code and reports the affected module and source.

* **Bug Fixes**
  * Prevented unsafe or invalid AI recipe entries, including unsupported types, misplaced sources, and path-traversal targets.
  * Improved error reporting when incompatible modules are included in Composer’s browser graph.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->