### PR TITLE
Report planned clean changes in human-readable output

### DIFF
--- a/.changeset/clear-wolves-clean.md
+++ b/.changeset/clear-wolves-clean.md
@@ -1,0 +1,5 @@
+---
+"create-project-calavera": patch
+---
+
+Report planned deletions and locally edited skips in human-readable clean output.

--- a/packages/cli/scripts/check-config-schema.test.mjs
+++ b/packages/cli/scripts/check-config-schema.test.mjs
@@ -2821,6 +2821,74 @@ test("clean treats a matching managed run-if-files helper as stale", async () =>
   }
 });
 
+test("clean human output reports planned and completed deletes and locally edited skips", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-clean-output-"));
+  const safePath = ".editorconfig";
+  const safeContents = "root = true\n";
+  const editedPath = "knip.json";
+  const originalEditedContents = "{}\n";
+  const localEditedContents = '{\n  "entry": ["src/index.js"]\n}\n';
+  const cliPath = fileURLToPath(new URL("../src/index.js", import.meta.url));
+  const environment = { ...process.env, NO_COLOR: "1" };
+
+  try {
+    process.chdir(projectDirectory);
+    await mkdir(".calavera");
+    await writeFile(
+      "calavera.config.json",
+      `${JSON.stringify(buildRecipe("minimal", [], "npm"), null, 2)}\n`,
+    );
+    await writeFile(safePath, safeContents);
+    await writeFile(editedPath, localEditedContents);
+    await writeFile(
+      ".calavera/state.json",
+      `${JSON.stringify(
+        {
+          version: 1,
+          profile: "minimal",
+          integrations: [],
+          files: [safePath, editedPath],
+          managedFiles: [
+            { path: safePath, hash: textHash(safeContents) },
+            { path: editedPath, hash: textHash(originalEditedContents) },
+          ],
+          aiArtifacts: [],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const { stdout: dryRunStdout } = await execFileAsync(
+      process.execPath,
+      [cliPath, "clean", "--dry-run", "--yes"],
+      { env: environment },
+    );
+
+    assert.match(dryRunStdout, /Dry run complete\. No files were removed\./);
+    assert.match(dryRunStdout, /Would remove \.editorconfig/);
+    assert.match(dryRunStdout, /Would skip knip\.json: Managed file has local edits/);
+    assert.equal(await readFile(safePath, "utf8"), safeContents);
+    assert.equal(await readFile(editedPath, "utf8"), localEditedContents);
+
+    const { stdout: cleanStdout } = await execFileAsync(
+      process.execPath,
+      [cliPath, "clean", "--yes"],
+      { env: environment },
+    );
+
+    assert.match(cleanStdout, /Removed stale managed files\./);
+    assert.match(cleanStdout, /Removed \.editorconfig/);
+    assert.match(cleanStdout, /Skipped knip\.json: Managed file has local edits/);
+    await assertPathMissing(safePath);
+    assert.equal(await readFile(editedPath, "utf8"), localEditedContents);
+  } finally {
+    process.chdir(originalDirectory);
+    await rm(projectDirectory, { force: true, recursive: true });
+  }
+});
+
 test("apply dry-run human output distinguishes owned writes and omitted scripts", async () => {
   const originalDirectory = process.cwd();
   const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-cli-dry-run-output-"));

--- a/packages/cli/scripts/check-config-schema.test.mjs
+++ b/packages/cli/scripts/check-config-schema.test.mjs
@@ -2837,7 +2837,7 @@ test("clean human output reports planned and completed deletes and locally edite
     await mkdir(".calavera");
     await writeFile(
       "calavera.config.json",
-      `${JSON.stringify(buildRecipe("minimal", [], "npm"), null, 2)}\n`,
+      `${JSON.stringify(buildRecipe("minimal", ["editorconfig"], "npm"), null, 2)}\n`,
     );
     await writeFile(safePath, safeContents);
     await writeFile(editedPath, localEditedContents);
@@ -2858,6 +2858,35 @@ test("clean human output reports planned and completed deletes and locally edite
         null,
         2,
       )}\n`,
+    );
+
+    const { stdout: skipOnlyJsonStdout } = await execFileAsync(
+      process.execPath,
+      [cliPath, "clean", "--dry-run", "--yes", "--json"],
+      { env: environment },
+    );
+    const skipOnlyJsonResult = JSON.parse(skipOnlyJsonStdout);
+
+    assert.equal(Object.hasOwn(skipOnlyJsonResult, "dryRun"), false);
+
+    const { stdout: skipOnlyDryRunStdout } = await execFileAsync(
+      process.execPath,
+      [cliPath, "clean", "--dry-run", "--yes"],
+      { env: environment },
+    );
+
+    assert.match(
+      skipOnlyDryRunStdout,
+      /No stale managed items were safe to remove\. Some stale items have local edits\./,
+    );
+    assert.match(skipOnlyDryRunStdout, /Would skip knip\.json: Managed file has local edits/);
+    assert.doesNotMatch(skipOnlyDryRunStdout, /^Skipped knip\.json:/m);
+    assert.equal(await readFile(safePath, "utf8"), safeContents);
+    assert.equal(await readFile(editedPath, "utf8"), localEditedContents);
+
+    await writeFile(
+      "calavera.config.json",
+      `${JSON.stringify(buildRecipe("minimal", [], "npm"), null, 2)}\n`,
     );
 
     const { stdout: dryRunStdout } = await execFileAsync(

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -3054,8 +3054,9 @@ function printHelp() {
 /**
  * @param {CommandResult} result
  * @param {boolean} [asJSON]
+ * @param {boolean} [commandDryRun]
  */
-function printResult(result, asJSON = false) {
+function printResult(result, asJSON = false, commandDryRun = false) {
   if (asJSON) {
     console.info(JSON.stringify(result, null, 2));
     return;
@@ -3074,16 +3075,17 @@ function printResult(result, asJSON = false) {
   }
 
   if (result.command === "clean") {
+    const dryRun = result.dryRun ?? commandDryRun;
     logger.info(result.message);
 
     for (const change of result.changes) {
       if (change.type === "delete") {
-        logger.info(result.dryRun ? `Would remove ${change.path}` : `Removed ${change.path}`);
+        logger.info(dryRun ? `Would remove ${change.path}` : `Removed ${change.path}`);
       }
 
       if (change.type === "skip") {
         logger.info(
-          result.dryRun
+          dryRun
             ? `Would skip ${change.path}: ${change.reason}`
             : `Skipped ${change.path}: ${change.reason}`,
         );
@@ -3265,7 +3267,7 @@ async function main() {
   }
 
   if (options.command === "clean") {
-    printResult(await clean(options), options.json);
+    printResult(await clean(options), options.json, options.dryRun);
     return;
   }
 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -3075,6 +3075,21 @@ function printResult(result, asJSON = false) {
 
   if (result.command === "clean") {
     logger.info(result.message);
+
+    for (const change of result.changes) {
+      if (change.type === "delete") {
+        logger.info(result.dryRun ? `Would remove ${change.path}` : `Removed ${change.path}`);
+      }
+
+      if (change.type === "skip") {
+        logger.info(
+          result.dryRun
+            ? `Would skip ${change.path}: ${change.reason}`
+            : `Skipped ${change.path}: ${change.reason}`,
+        );
+      }
+    }
+
     return;
   }
 


### PR DESCRIPTION
## Summary

- report every planned deletion in human-readable `clean --dry-run` output
- report locally edited files that cleanup will preserve, including the reason
- report completed deletions and preserved files during real cleanup
- retain the existing cleanup planner, safety behavior, summary messages, and JSON contract

## Why

The release rehearsal showed that structured JSON correctly planned removal of `.editorconfig`, while the ordinary CLI output only said that no files were removed. A safety-sensitive dry run must make its intended changes inspectable without requiring JSON mode.

## Validation

- focused end-to-end clean output regression
- complete CLI suite: 123 tests passed
- Oxfmt check on changed JavaScript files
- Oxlint on changed JavaScript files
- `git diff --check`
- Changeset release status

fix #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `clean` command output with clear details for files that will be removed or skipped.
  * Dry-run mode now indicates planned removals and skips, including reasons for skipped files.
  * Clean operations report completed removals while preserving locally edited files.

* **Tests**
  * Added coverage confirming file contents remain intact when locally edited files are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->