### PR TITLE
Stage package releases through the npm next channel

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,26 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "@calavera/menu-bar": "0.1.0",
+    "@schalkneethling/calavera-artifact-core": "0.1.0",
+    "@schalkneethling/calavera-agent-technical-devils-advocate": "0.1.0",
+    "@schalkneethling/calavera-hook-auto-approve-safe-commands": "0.1.0",
+    "@schalkneethling/calavera-hook-block-dangerous-commands": "0.1.0",
+    "@schalkneethling/calavera-skill-calavera": "0.1.0",
+    "@schalkneethling/calavera-skill-code-review": "0.1.0",
+    "@schalkneethling/calavera-skill-css-tokens": "0.1.0",
+    "@schalkneethling/calavera-skill-frontend-engineering": "0.1.0",
+    "@schalkneethling/calavera-skill-frontend-security": "0.1.0",
+    "@schalkneethling/calavera-skill-frontend-testing": "0.1.0",
+    "@schalkneethling/calavera-skill-github-goal-issue-triage": "0.1.0",
+    "@schalkneethling/calavera-skill-more-secure-dependabot-config": "0.1.0",
+    "@schalkneethling/calavera-skill-npm-publishing-best-practices": "0.1.0",
+    "@schalkneethling/calavera-skill-npm-trusted-publishing-github-workflow": "0.1.0",
+    "@schalkneethling/calavera-skill-project-goal": "0.1.0",
+    "@schalkneethling/calavera-skill-refined-plan-mode": "0.1.0",
+    "@schalkneethling/calavera-baseline-core": "0.1.0",
+    "create-project-calavera": "2.2.0"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
## Summary

- enter Changesets prerelease mode with the `next` tag
- preserve the pending package Changesets and their independent release boundaries
- prepare the automated version PR to generate SemVer prerelease versions before stable promotion

## Why

The current version PR proposes stable CLI `2.3.0` and workspace package `0.2.0` releases. Most shared and artifact packages have never been published, so sending this large release directly to npm `latest` would bypass the documented prerelease artifact-channel rehearsal.

After this control change lands, the Changesets workflow should update the version PR to versions such as `2.3.0-next.0` and `0.2.0-next.0`. The publish workflow derives npm’s `next` dist-tag from those prerelease suffixes. Exiting prerelease mode and generating stable versions remains a separate reviewed step.

## Validation

- `changeset pre enter next`
- `pnpm release:status` confirms the expected 18 public minor releases
- private applications remain absent from the bump list
- Oxfmt check passes for `.changeset/pre.json`
- no package version or application file changes in this PR

fix #334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured the project for next-version prereleases.
  * Recorded initial package versions for prerelease tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->