### PR TITLE
Bootstrap first npm publication for new packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,6 +98,10 @@ jobs:
           name: package
           path: package
       - name: Publish package
+        # Temporary first-publication bridge for #336. Remove through #337 after
+        # every new package has a trusted publisher configured.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           mapfile -t tarballs < <(find package -maxdepth 1 -name "*.tgz" -print)
           if [ "${#tarballs[@]}" -eq 0 ]; then


### PR DESCRIPTION
## Summary

- expose the protected `publish` environment’s short-lived `NPM_TOKEN` only as `NODE_AUTH_TOKEN` for the npm publish step
- preserve OIDC permissions, provenance, package packing, registry failure handling, and `next` dist-tag selection
- mark the bridge for mandatory removal through #337 after package-level trusted publishers can be configured

## Why

npm requires a package to exist before it can have a trusted-publisher relationship. The existing CLI can publish through OIDC, but the newly introduced shared and artifact packages need a one-time authenticated publication before they can be switched to OIDC-only releases.

The credential is stored only in the protected `publish` environment, is not present in repository files, and remains subject to environment approval. Stable promotion is blocked on #337, which removes this fallback, deletes and revokes the token, and configures every new package for trusted publishing.

## Validation

- Oxfmt workflow check
- release boundary and channel contracts
- Zizmor 1.25.2 offline audit: no findings
- `git diff --check`

fix #336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing workflow to authenticate securely during publication.
  * Added temporary documentation for the publication authentication setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->