### PR TITLE
Fix publish workflow package artifact upload path

### DIFF
--- a/.changeset/bright-wolves-retry.md
+++ b/.changeset/bright-wolves-retry.md
@@ -1,0 +1,22 @@
+---
+"create-project-calavera": patch
+"@schalkneethling/calavera-baseline-core": patch
+"@schalkneethling/calavera-artifact-core": patch
+"@schalkneethling/calavera-skill-calavera": patch
+"@schalkneethling/calavera-skill-code-review": patch
+"@schalkneethling/calavera-skill-css-tokens": patch
+"@schalkneethling/calavera-skill-frontend-engineering": patch
+"@schalkneethling/calavera-skill-frontend-security": patch
+"@schalkneethling/calavera-skill-frontend-testing": patch
+"@schalkneethling/calavera-skill-github-goal-issue-triage": patch
+"@schalkneethling/calavera-skill-more-secure-dependabot-config": patch
+"@schalkneethling/calavera-skill-npm-publishing-best-practices": patch
+"@schalkneethling/calavera-skill-npm-trusted-publishing-github-workflow": patch
+"@schalkneethling/calavera-skill-project-goal": patch
+"@schalkneethling/calavera-skill-refined-plan-mode": patch
+"@schalkneethling/calavera-hook-auto-approve-safe-commands": patch
+"@schalkneethling/calavera-hook-block-dangerous-commands": patch
+"@schalkneethling/calavera-agent-technical-devils-advocate": patch
+---
+
+Retry the prerelease cohort after correcting the package artifact upload destination.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,10 +66,10 @@ jobs:
         run: pnpm --filter @calavera/baseline-explorer build
       - name: Pack package
         run: |
-          pnpm --filter create-project-calavera pack --pack-destination ../../package
-          pnpm --filter @schalkneethling/calavera-baseline-core pack --pack-destination ../../package
-          pnpm --filter @schalkneethling/calavera-artifact-core pack --pack-destination ../../package
-          pnpm --filter "./packages/artifacts/*" --recursive pack --pack-destination ../../../package
+          pnpm --filter create-project-calavera pack --pack-destination package
+          pnpm --filter @schalkneethling/calavera-baseline-core pack --pack-destination package
+          pnpm --filter @schalkneethling/calavera-artifact-core pack --pack-destination package
+          pnpm --filter "./packages/artifacts/*" --recursive pack --pack-destination package
       - name: Upload package artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/scripts/check-release-contracts.mjs
+++ b/scripts/check-release-contracts.mjs
@@ -54,6 +54,16 @@ assert.match(rootPackage.scripts["release:rehearse"], /@calavera\/baseline-explo
 assert.match(rootPackage.scripts["release:rehearse"], /@calavera\/menu-bar build:web/);
 assert.match(workspace, /packages:\n\s+- "apps\/\*"/);
 assert.match(workspace, /- "packages\/artifacts\/\*"/);
+const packDestinations = [...publishWorkflow.matchAll(/--pack-destination\s+([^\s]+)/g)].map(
+  ([, destination]) => destination,
+);
+assert.equal(packDestinations.length, 4, "publish workflow must pack every public package group");
+assert.deepEqual(
+  [...new Set(packDestinations)],
+  ["package"],
+  "publish workflow must pack tarballs into the upload directory",
+);
+assert.match(publishWorkflow, /path: package\/\*\.tgz/);
 assert.match(publishWorkflow, /npm view .*version >"\$view_output" 2>&1/);
 assert.match(publishWorkflow, /grep -Eq .*E404\|404/);
 assert.match(publishWorkflow, /exit "\$view_status"/);


### PR DESCRIPTION
## Summary

- write every packed npm tarball to the repository-local `package` directory consumed by the upload step
- enforce the pack-command count, canonical destination, and upload glob in the release contract check
- add a Changeset for the complete 18-package prerelease cohort so the corrected retry advances to `next.1`

## Root cause

Filtered pnpm workspace commands execute from the workspace root. The previous `../../package` and `../../../package` destinations therefore wrote tarballs outside the checkout, while `actions/upload-artifact` searched `package/*.tgz` inside it.

The failed `next.0` prerelease remains unchanged as audit evidence; this PR prepares a clean versioned retry.

## Validation

- `pnpm release:contracts`
- `pnpm workflow:check`
- `pnpm exec oxfmt --check .github/workflows/publish.yml scripts/check-release-contracts.mjs .changeset/bright-wolves-retry.md`
- `pnpm release:status`
- `git diff --check`

fix #339