### PR TITLE
Fix Baseline package provenance metadata

### DIFF
--- a/.changeset/gentle-bats-recover.md
+++ b/.changeset/gentle-bats-recover.md
@@ -1,0 +1,22 @@
+---
+"create-project-calavera": patch
+"@schalkneethling/calavera-baseline-core": patch
+"@schalkneethling/calavera-artifact-core": patch
+"@schalkneethling/calavera-skill-calavera": patch
+"@schalkneethling/calavera-skill-code-review": patch
+"@schalkneethling/calavera-skill-css-tokens": patch
+"@schalkneethling/calavera-skill-frontend-engineering": patch
+"@schalkneethling/calavera-skill-frontend-security": patch
+"@schalkneethling/calavera-skill-frontend-testing": patch
+"@schalkneethling/calavera-skill-github-goal-issue-triage": patch
+"@schalkneethling/calavera-skill-more-secure-dependabot-config": patch
+"@schalkneethling/calavera-skill-npm-publishing-best-practices": patch
+"@schalkneethling/calavera-skill-npm-trusted-publishing-github-workflow": patch
+"@schalkneethling/calavera-skill-project-goal": patch
+"@schalkneethling/calavera-skill-refined-plan-mode": patch
+"@schalkneethling/calavera-hook-auto-approve-safe-commands": patch
+"@schalkneethling/calavera-hook-block-dangerous-commands": patch
+"@schalkneethling/calavera-agent-technical-devils-advocate": patch
+---
+
+Retry the complete prerelease cohort with npm-compatible provenance metadata.

--- a/packages/baseline-core/package.json
+++ b/packages/baseline-core/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@schalkneethling/calavera-baseline-core",
   "version": "0.2.0-next.1",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/schalkneethling/create-project-calavera.git",
+    "directory": "packages/baseline-core"
+  },
   "files": [
     "data",
     "src"

--- a/scripts/check-release-contracts.mjs
+++ b/scripts/check-release-contracts.mjs
@@ -31,6 +31,17 @@ assert.equal(
   true,
   "releaseable workspaces must remain public",
 );
+for (const [index, packageJson] of publicPackages.entries()) {
+  assert.deepEqual(
+    packageJson.repository,
+    {
+      type: "git",
+      url: "git+ssh://git@github.com/schalkneethling/create-project-calavera.git",
+      directory: publicPackagePaths[index],
+    },
+    `${packageJson.name} must identify its monorepo source for npm provenance`,
+  );
+}
 assert.equal(
   applications.every(({ private: isPrivate }) => isPrivate === true),
   true,


### PR DESCRIPTION
## Summary

- add the missing monorepo repository metadata to `@schalkneethling/calavera-baseline-core`
- require every public workspace package to identify the expected repository URL and package directory
- add a full-cohort Changeset so the recovery advances all 18 packages to `next.2`

## Root cause

The `v2.3.0-next.1` workflow packed and uploaded all packages, then npm rejected Baseline Core with `E422`. Its tarball had no repository metadata, so npm could not reconcile the package with the GitHub repository recorded in the Sigstore provenance bundle. Eight packages had already published successfully, making `next.1` a partial release that must not be reused.

## Validation

- `pnpm release:contracts`
- `pnpm --filter @schalkneethling/calavera-baseline-core test`
- `pnpm publish:check`
- `pnpm exec oxfmt --check packages/baseline-core/package.json scripts/check-release-contracts.mjs .changeset/gentle-bats-recover.md`
- `pnpm release:status`
- `git diff --check`

fix #342