### PR TITLE
Promote the verified prerelease cohort to stable

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next",
   "initialVersions": {
     "@calavera/menu-bar": "0.1.0",


### PR DESCRIPTION
## Summary

- exit Changesets prerelease mode after the verified `next.3` cohort
- prepare the 18 public packages for stable versions (`2.3.0` for the CLI and `0.2.0` for the companion packages)
- leave publication to the existing protected OIDC release workflow

## Validation

- `node scripts/check-release-contracts.mjs`
- `oxfmt --check .changeset/pre.json`
- isolated `changeset version` rehearsal confirmed the intended 18 public stable versions

## Release PR safeguard

Changesets currently proposes incidental Composer and menu-bar version/changelog changes while exiting prerelease mode, despite those applications being private and ignored. Those generated private-app changes must be removed from the automated stable version PR before it is merged.

fix #347