### PR TITLE
chore: enter next prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,27 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "@calavera/menu-bar": "0.1.0",
+    "@schalkneethling/calavera-artifact-core": "0.2.0",
+    "@schalkneethling/calavera-agent-technical-devils-advocate": "0.2.0",
+    "@schalkneethling/calavera-hook-auto-approve-safe-commands": "0.2.0",
+    "@schalkneethling/calavera-hook-block-dangerous-commands": "0.2.0",
+    "@schalkneethling/calavera-skill-calavera": "0.2.0",
+    "@schalkneethling/calavera-skill-code-review": "0.2.0",
+    "@schalkneethling/calavera-skill-css-tokens": "0.2.0",
+    "@schalkneethling/calavera-skill-frontend-engineering": "0.2.0",
+    "@schalkneethling/calavera-skill-frontend-security": "0.2.0",
+    "@schalkneethling/calavera-skill-frontend-testing": "0.2.0",
+    "@schalkneethling/calavera-skill-github-goal-issue-triage": "0.2.0",
+    "@schalkneethling/calavera-skill-more-secure-dependabot-config": "0.2.0",
+    "@schalkneethling/calavera-skill-npm-publishing-best-practices": "0.2.0",
+    "@schalkneethling/calavera-skill-npm-trusted-publishing-github-workflow": "0.2.0",
+    "@schalkneethling/calavera-skill-project-goal": "0.2.0",
+    "@schalkneethling/calavera-skill-refined-plan-mode": "0.2.0",
+    "@schalkneethling/calavera-skill-release-with-confidence": "0.1.0",
+    "@schalkneethling/calavera-baseline-core": "0.2.0",
+    "create-project-calavera": "2.3.0"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
## Summary

- enter Changesets prerelease mode using the `next` tag
- allow the generated version PR to produce prerelease versions for the Calavera 2.4.0 candidate

## Validation

- `pnpm exec oxfmt --check .changeset/pre.json`

fix #350