### PR TITLE
Fix prerelease artifact compatibility

### DIFF
--- a/.changeset/brisk-ravens-accept.md
+++ b/.changeset/brisk-ravens-accept.md
@@ -1,0 +1,7 @@
+---
+"create-project-calavera": patch
+"@schalkneethling/calavera-artifact-core": patch
+"@schalkneethling/calavera-skill-release-with-confidence": patch
+---
+
+Allow prerelease Calavera CLIs to install artifacts from compatible release lines and explicitly admit the Release with Confidence skill on the 2.4 prerelease line.

--- a/packages/artifact-core/src/registry.js
+++ b/packages/artifact-core/src/registry.js
@@ -90,7 +90,10 @@ function validateArtifactManifest(manifest, artifact, cliVersion) {
     throw new Error(`Invalid artifact manifest for ${artifact.packageName}.`);
   }
   const compatibility = /** @type {Record<string, unknown>} */ (manifest.compatibility).calavera;
-  if (typeof compatibility !== "string" || !semver.satisfies(cliVersion, compatibility)) {
+  if (
+    typeof compatibility !== "string" ||
+    !semver.satisfies(cliVersion, compatibility, { includePrerelease: true })
+  ) {
     throw new Error(
       `${artifact.packageName} is not compatible with create-project-calavera ${cliVersion}.`,
     );

--- a/packages/artifact-core/test/registry.test.mjs
+++ b/packages/artifact-core/test/registry.test.mjs
@@ -11,11 +11,16 @@ import { promisify } from "node:util";
 import { artifactForId } from "../src/catalog.js";
 import { extractArtifactPackage, hashArtifactPayload } from "../src/registry.js";
 
-const packageRoot = fileURLToPath(new URL("../../artifacts/skill-project-goal/", import.meta.url));
+const projectGoalPackageRoot = fileURLToPath(
+  new URL("../../artifacts/skill-project-goal/", import.meta.url),
+);
+const releasePackageRoot = fileURLToPath(
+  new URL("../../artifacts/skill-release-with-confidence/", import.meta.url),
+);
 const artifact = artifactForId("skill-project-goal");
 const execFileAsync = promisify(execFile);
 
-async function packFixture(directory) {
+async function packFixture(directory, packageRoot = projectGoalPackageRoot) {
   await execFileAsync("pnpm", ["pack", "--pack-destination", directory], { cwd: packageRoot });
   const name = (await readdir(directory)).find((entry) => entry.endsWith(".tgz"));
   if (!name) throw new Error("Fixture package did not produce a tarball.");
@@ -91,6 +96,58 @@ test("verified extraction rejects a tarball that fails npm integrity", async () 
         "2.2.0",
       ),
     /integrity|checksum/i,
+  );
+});
+
+test("prerelease CLIs accept compatible stable-line and prerelease artifacts", async () => {
+  for (const [id, packageRoot] of [
+    ["skill-project-goal", projectGoalPackageRoot],
+    ["skill-release-with-confidence", releasePackageRoot],
+  ]) {
+    const directory = await mkdtemp(join(tmpdir(), `calavera-registry-${id}-`));
+    const packed = await packFixture(directory, packageRoot);
+    const selectedArtifact = artifactForId(id);
+    const result = await extractArtifactPackage(
+      {
+        artifact: selectedArtifact,
+        packageName: selectedArtifact.packageName,
+        version: selectedArtifact.version,
+        resolved: packed.path,
+        integrity: packed.integrity,
+        tag: "next",
+        cache: join(directory, "cache"),
+        offline: false,
+      },
+      join(directory, "package"),
+      "2.4.0-next.0",
+    );
+
+    assert.equal(result.manifest.id, id);
+  }
+});
+
+test("prerelease CLIs below an artifact minimum remain incompatible", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "calavera-registry-prerelease-minimum-"));
+  const packed = await packFixture(directory, releasePackageRoot);
+  const selectedArtifact = artifactForId("skill-release-with-confidence");
+
+  await assert.rejects(
+    () =>
+      extractArtifactPackage(
+        {
+          artifact: selectedArtifact,
+          packageName: selectedArtifact.packageName,
+          version: selectedArtifact.version,
+          resolved: packed.path,
+          integrity: packed.integrity,
+          tag: "next",
+          cache: join(directory, "cache"),
+          offline: false,
+        },
+        join(directory, "package"),
+        "2.3.0-next.0",
+      ),
+    /not compatible/,
   );
 });
 

--- a/packages/artifacts/skill-release-with-confidence/calavera-artifact.json
+++ b/packages/artifacts/skill-release-with-confidence/calavera-artifact.json
@@ -6,6 +6,6 @@
   "displayName": "Release with confidence",
   "payload": "payload/release-with-confidence",
   "compatibility": {
-    "calavera": ">=2.4.0 <3"
+    "calavera": ">=2.4.0-next.0 <3"
   }
 }


### PR DESCRIPTION
## Summary

- evaluate artifact compatibility with node-semver's documented `includePrerelease` option
- explicitly admit the Release with Confidence artifact on the `2.4.0-next` line
- cover compatible earlier-line artifacts, explicit prerelease compatibility, and below-minimum rejection
- add patch release intent for the CLI, artifact core, and Release with Confidence package

## Root cause

node-semver excludes prerelease versions from ordinary range matching by default. That made `create-project-calavera@2.4.0-next.0` incompatible with both existing artifact ranges such as `>=2.2.0 <3` and the new skill's stable-only `>=2.4.0 <3` minimum. The published consumer smoke test therefore failed before installation.

## Validation

- `npm test` in `packages/artifact-core`: 5 passing
- `npm test` in `packages/cli`: 123 passing
- `vp check`: formatting and lint clean
- `git diff --check`

fix #362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prerelease Calavera CLI versions can now install artifacts from compatible stable and prerelease release lines.
  * Compatibility checks correctly reject artifacts below their configured minimum prerelease version.

* **Compatibility**
  * Updated the Release with Confidence skill to support Calavera 2.4 prerelease versions and later versions below 3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->