### PR TITLE
Automate gated package releases

### DIFF
--- a/.changeset/steady-bats-release.md
+++ b/.changeset/steady-bats-release.md
@@ -1,0 +1,5 @@
+---
+"@schalkneethling/calavera-skill-release-with-confidence": patch
+---
+
+Document and adopt the automated, restartable release workflow, including deterministic Changesets formatting, direct npm trust verification, and SemVer-aware release decisions.

--- a/knip.json
+++ b/knip.json
@@ -2,5 +2,6 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignore": ["packages/artifacts/*/payload/**/*.mts"],
   "ignoreBinaries": ["uv", "uvx"],
+  "ignoreDependencies": ["fledgling"],
   "ignoreExportsUsedInFile": true
 }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
     "typecheck": "tsc --noEmit",
     "publish:check": "pnpm --filter create-project-calavera publish:check && pnpm --filter @schalkneethling/calavera-baseline-core exec publint && pnpm --filter @schalkneethling/calavera-artifact-core exec publint && pnpm --filter './packages/artifacts/*' --recursive exec publint",
     "release:status": "changeset status",
-    "release:version": "changeset version",
-    "release:contracts": "node scripts/check-release-contracts.mjs",
+    "release:version": "node scripts/release-version.mjs",
+    "release:prepare": "node scripts/release-orchestrator.mjs prepare",
+    "release:publish": "node scripts/release-orchestrator.mjs publish",
+    "release:contracts": "node scripts/check-release-contracts.mjs && node --test scripts/release-orchestrator.test.mjs",
     "release:fixture": "pnpm --filter create-project-calavera exec node --test --test-name-pattern='artifact install locks exact versions and targeted update preserves other artifacts' scripts/check-config-schema.test.mjs",
     "release:rehearse": "pnpm quality && pnpm release:fixture && pnpm web:build && pnpm --filter @calavera/baseline-explorer build && pnpm --filter @calavera/menu-bar build:web && pnpm publish:check",
     "workflow:check": "uvx zizmor@1.25.2 --offline .github/workflows"
@@ -39,17 +41,25 @@
     "@types/semver": "^7.7.1",
     "ajv": "8.20.0",
     "eslint": "^10.4.0",
+    "fledgling": "1.2.0",
     "globals": "^17.6.0",
     "html-validate": "^11.5.6",
     "knip": "^6.27.0",
     "oxfmt": "^0.58.0",
     "oxlint": "^1.73.0",
     "publint": "^0.3.21",
+    "semver": "7.8.5",
     "stylelint": "^17.12.0",
     "stylelint-config-standard": "^40.0.0",
     "stylelint-order": "^8.1.1",
     "stylelint-plugin-use-baseline": "^1.4.2",
     "typescript": "^6.0.3"
   },
-  "packageManager": "pnpm@11.3.0"
+  "packageManager": "pnpm@11.3.0",
+  "fledgling": {
+    "provider": "github",
+    "workflow": "publish.yml",
+    "environment": "publish",
+    "permissions": "publish"
+  }
 }

--- a/packages/artifacts/skill-release-with-confidence/payload/release-with-confidence/SKILL.md
+++ b/packages/artifacts/skill-release-with-confidence/payload/release-with-confidence/SKILL.md
@@ -81,6 +81,12 @@ Use repository-native checks. Typical gates include a frozen install, quality su
 validation, workflow audit, version-plan inspection, builds, packing, fixture installation, migration
 tests, and clean-environment smoke tests.
 
+If the repository provides a reviewed release orchestrator, use it as the primary path. For example,
+Calavera uses `release:prepare` for the complete read-only evidence chain and `release:publish` for
+revalidation, the explicit publication checkpoint, monitoring, and post-release consumer checks.
+Use the individual commands in the reference as recovery and diagnostic tools, not as a routine
+copy-and-paste checklist.
+
 ## 4. Rehearse the exact candidate
 
 Run the full rehearsal on the exact commit intended for release:
@@ -118,6 +124,11 @@ publish, and verification workflow.
 
 Create the release as a draft first. Verify its tag, target commit, title, notes, and prerelease flag.
 Pause for approval, then publish. Monitor test, build, artifact upload, and publish separately.
+
+Use a SemVer implementation such as
+[`node-semver`](https://github.com/npm/node-semver) for version validity, prerelease detection, and
+compatibility ranges. Do not infer release channels or prerelease compatibility with ad hoc string
+comparison.
 
 After publishing, verify every expected package or artifact, its candidate channel, and the unchanged
 stable channel. Define integrity evidence per surface—for example npm provenance, a signed and

--- a/packages/artifacts/skill-release-with-confidence/payload/release-with-confidence/references/fledgling.md
+++ b/packages/artifacts/skill-release-with-confidence/payload/release-with-confidence/references/fledgling.md
@@ -48,6 +48,11 @@ Adapt the provider and workflow to the project. Tie the publisher to a protected
 CI provider supports it. Request only `publish` unless the project deliberately uses npm staged
 publishing.
 
+Install the reviewed version as a local development dependency and invoke that pinned binary. If its
+package includes an unrelated install hook, explicitly disable that build script only after verifying
+the published CLI is already built and functional; do not enable arbitrary dependency lifecycle
+scripts merely to install release tooling.
+
 Fledgling skips packages marked `private: true`. Add explicit ignore patterns for public workspace
 packages that must never be claimed or managed.
 
@@ -69,7 +74,9 @@ with the release inventory and verify that private or ignored packages are absen
 
 Fledgling can publish a minimal placeholder for an unclaimed name. That is an irreversible public
 registry mutation even though it contains no project code. Its default placeholder version is
-`0.0.0`, and its default tag is `latest`.
+`0.0.0`. npm may create `latest` for the first version even when a non-stable placeholder tag was
+requested. Follow the claim promptly with the real reviewed initial stable package through the
+project's OIDC workflow, verify that `latest` points to it, and remove the temporary placeholder tag.
 
 ### Package-name safety and npm policy
 
@@ -123,7 +130,7 @@ Never use Fledgling's force-replacement option without reviewing the exact trust
 obtaining explicit approval. Replacing trust revokes the existing publisher before creating the new
 one.
 
-## Use `sync` as the feedback loop
+## Verify npm state directly
 
 Run the pinned `fledgling sync` command:
 
@@ -133,8 +140,14 @@ Run the pinned `fledgling sync` command:
 - during periodic release-security reviews.
 
 Use interactive mode so Fledgling reads npm state, reports exact differences, and pauses before
-applying them. Record the plan without credentials. Apply only reviewed differences, then run `sync`
-again and require a no-drift result.
+applying them. Record the plan without credentials. Apply only reviewed differences.
+
+Treat npm itself as the authority after mutation. Verify each publisher with `npm trust list`, and
+verify exact versions and dist-tags with `npm view`. A tool's reconciliation command is useful
+advisory feedback, but registry propagation or a tool defect can produce a false mismatch; do not
+replace a publisher merely because the wrapper reports drift. Compare the exact npm trust record
+first. A duplicate trust creation conflict is evidence to inspect, not permission to force-replace
+the existing publisher.
 
 Keep independent evidence that:
 

--- a/packages/artifacts/skill-release-with-confidence/payload/release-with-confidence/references/release-gates.md
+++ b/packages/artifacts/skill-release-with-confidence/payload/release-with-confidence/references/release-gates.md
@@ -291,6 +291,37 @@ Apply the gate restart rule to every command block below. If any command fails o
 from the stated expectation, stop. After recovery, return to repository synchronization and repeat
 the full applicable sequence.
 
+### Prefer the automated gate
+
+Current Calavera releases normally require two commands:
+
+```bash
+pnpm release:prepare
+pnpm release:publish
+```
+
+`release:prepare` synchronizes and identifies the exact candidate, runs the frozen install and all
+local gates, calculates the complete public workspace inventory, and distinguishes exact npm 404s
+from registry failures. It is read-only unless a newly introduced npm package requires the explicit
+`--bootstrap` transition:
+
+```bash
+pnpm release:prepare -- --bootstrap
+```
+
+That transition uses the pinned Fledgling dependency to claim only the reviewed package names and
+configure trusted publishing, publishes the real initial stable packages through the existing OIDC
+workflow, removes the temporary bootstrap tag, and restarts the gates.
+
+`release:publish` reruns preparation, creates or verifies a draft release for the exact commit,
+pauses once for publication approval, watches the matching workflow run, verifies provenance and
+dist-tags, and exercises the published CLI and a changed artifact in a disposable consumer.
+Successful reruns rediscover and verify an already published release instead of repeating it.
+
+Use `--yes` only when the operator has already reviewed the exact transition and deliberately wants
+to answer the script's publication checkpoint non-interactively. The detailed commands below remain
+valuable for diagnosis and recovery. They are not the normal release interface.
+
 ### Synchronize and record the exact state
 
 ```bash
@@ -330,7 +361,9 @@ Its rehearsal composed existing scripts rather than duplicating their behavior:
     "quality": "pnpm lint && pnpm format:all:check && pnpm typecheck && pnpm knip && pnpm test && pnpm release:contracts",
     "publish:check": "pnpm --filter create-project-calavera publish:check && pnpm --filter @schalkneethling/calavera-baseline-core exec publint && pnpm --filter @schalkneethling/calavera-artifact-core exec publint && pnpm --filter './packages/artifacts/*' --recursive exec publint",
     "release:status": "changeset status",
-    "release:version": "changeset version",
+    "release:version": "node scripts/release-version.mjs",
+    "release:prepare": "node scripts/release-orchestrator.mjs prepare",
+    "release:publish": "node scripts/release-orchestrator.mjs publish",
     "release:rehearse": "pnpm quality && pnpm release:fixture && pnpm web:build && pnpm --filter @calavera/baseline-explorer build && pnpm --filter @calavera/menu-bar build:web && pnpm publish:check",
     "workflow:check": "uvx zizmor@1.25.2 --offline .github/workflows"
   }
@@ -373,7 +406,8 @@ pnpm release:version
 
 `release:version` mutates manifests, changelogs and Changesets state. Simulate it first in a true
 disposable copy, then inspect every generated file. Do not run it merely to see what might happen in
-the working repository.
+the working repository. Calavera's wrapper also formats only the generated JSON, Markdown, and YAML
+files so Changesets prerelease state is deterministic.
 
 When Changesets could not find where `HEAD` diverged from `main`, Calavera synchronized the genuine
 local `main` reference and restarted the gates. It did not force or fabricate branch history.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       eslint:
         specifier: ^10.4.0
         version: 10.6.0(jiti@2.7.0)
+      fledgling:
+        specifier: 1.2.0
+        version: 1.2.0(@gunshi/plugin-i18n@0.36.0)
       globals:
         specifier: ^17.6.0
         version: 17.7.0
@@ -50,6 +53,9 @@ importers:
       publint:
         specifier: ^0.3.21
         version: 0.3.21
+      semver:
+        specifier: 7.8.5
+        version: 7.8.5
       stylelint:
         specifier: ^17.12.0
         version: 17.14.0(typescript@6.0.3)
@@ -244,6 +250,21 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
+  '@bomb.sh/tab@0.0.17':
+    resolution: {integrity: sha512-rGhqfWwaSF6qN5Gm5P9EH9eybrwLEowHTkV+wsRgFewT6aQCQWVWXLclVk0McgVIlWCGX+W9mYYC1Egsg+Znsw==}
+    hasBin: true
+    peerDependencies:
+      cac: ^6.7.14
+      citty: ^0.1.6 || ^0.2.0
+      commander: ^13.1.0
+    peerDependenciesMeta:
+      cac:
+        optional: true
+      citty:
+        optional: true
+      commander:
+        optional: true
+
   '@cacheable/memory@2.2.0':
     resolution: {integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==}
 
@@ -414,6 +435,25 @@ packages:
   '@gar/promise-retry@1.0.3':
     resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@gunshi/plugin-completion@0.36.0':
+    resolution: {integrity: sha512-79EIxM3KIksBNHEzl1dW3ZQcjLuKxz2LYMK/gF/wRri+z/SlkqcpS3gqv/p3HiIK+2pegpTd5o5AKznko5kDXw==}
+    engines: {node: '>= 22'}
+    peerDependencies:
+      '@gunshi/plugin-i18n': 0.36.0
+
+  '@gunshi/plugin-i18n@0.36.0':
+    resolution: {integrity: sha512-T4IZh6lWApMiQ6UnBku5oGUgFgcv07GoZNF8v8aRoqcbmW9FQ6UVW8Em6s/oSFLMuIthR5B6OgcgI3ptZlgrZw==}
+    engines: {node: '>= 22'}
+    peerDependencies:
+      '@gunshi/plugin-global': 0.36.0
+    peerDependenciesMeta:
+      '@gunshi/plugin-global':
+        optional: true
+
+  '@gunshi/plugin@0.36.0':
+    resolution: {integrity: sha512-y0/lUz7k1kSF9pbINqmz1VoG7lkvMDzw/onbHtf0Ot2cteLQkncplJFLo1qQWterwtduYfRjYeYZRlj4kZc5pg==}
+    engines: {node: '>= 22'}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -1727,6 +1767,11 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fledgling@1.2.0:
+    resolution: {integrity: sha512-9CQjNV6PmqZ1vHwv8kaIYoie3jQd+H8vIGGSHR+5GlwZjKf/8vHShuZK5M2O7/kb7GyOvHqjJ/u2i9lSvKuKLQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
@@ -1829,6 +1874,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gunshi@0.36.0:
+    resolution: {integrity: sha512-LJhM/2YiC4GfsaT2fnvccNkGXzbtMCBkgXpyLSM+1QVal2n7k8VJZol8qm1qgm2wmaQ6NBVmcGZIOkB/ms+6uQ==}
+    engines: {node: '>= 22'}
 
   has-flag@5.0.1:
     resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
@@ -3030,6 +3079,8 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
+  '@bomb.sh/tab@0.0.17': {}
+
   '@cacheable/memory@2.2.0':
     dependencies:
       '@cacheable/utils': 2.5.0
@@ -3287,6 +3338,22 @@ snapshots:
       levn: 0.4.1
 
   '@gar/promise-retry@1.0.3': {}
+
+  '@gunshi/plugin-completion@0.36.0(@gunshi/plugin-i18n@0.36.0)':
+    dependencies:
+      '@bomb.sh/tab': 0.0.17
+      '@gunshi/plugin': 0.36.0
+      '@gunshi/plugin-i18n': 0.36.0
+    transitivePeerDependencies:
+      - cac
+      - citty
+      - commander
+
+  '@gunshi/plugin-i18n@0.36.0':
+    dependencies:
+      '@gunshi/plugin': 0.36.0
+
+  '@gunshi/plugin@0.36.0': {}
 
   '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:
@@ -4367,6 +4434,19 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fledgling@1.2.0(@gunshi/plugin-i18n@0.36.0):
+    dependencies:
+      '@clack/prompts': 1.7.0
+      '@gunshi/plugin-completion': 0.36.0(@gunshi/plugin-i18n@0.36.0)
+      gunshi: 0.36.0
+      picocolors: 1.1.1
+      tinyglobby: 0.2.17
+    transitivePeerDependencies:
+      - '@gunshi/plugin-i18n'
+      - cac
+      - citty
+      - commander
+
   form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
@@ -4485,6 +4565,8 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gunshi@0.36.0: {}
 
   has-flag@5.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,9 @@ packages:
   - "packages/*"
   - "packages/artifacts/*"
 
+allowBuilds:
+  fledgling: false
+
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - "@schalkneethling/css-property-type-validator-core"

--- a/scripts/check-release-contracts.mjs
+++ b/scripts/check-release-contracts.mjs
@@ -5,9 +5,11 @@ import { join } from "node:path";
 const readJson = async (path) => JSON.parse(await readFile(path, "utf8"));
 const changesets = await readJson(".changeset/config.json");
 const publishWorkflow = await readFile(".github/workflows/publish.yml", "utf8");
+const releasePrWorkflow = await readFile(".github/workflows/release-pr.yml", "utf8");
 const menuWorkflow = await readFile(".github/workflows/menu-bar-release.yml", "utf8");
 const workspace = await readFile("pnpm-workspace.yaml", "utf8");
 const rootPackage = await readJson("package.json");
+const knip = await readJson("knip.json");
 
 const workflowJob = (workflow, jobName) => {
   const lines = workflow.split("\n");
@@ -74,6 +76,28 @@ for (const application of [
 assert.match(rootPackage.scripts["release:fixture"], /targeted update preserves other artifacts/);
 assert.match(rootPackage.scripts["release:rehearse"], /@calavera\/baseline-explorer build/);
 assert.match(rootPackage.scripts["release:rehearse"], /@calavera\/menu-bar build:web/);
+assert.equal(rootPackage.scripts["release:version"], "node scripts/release-version.mjs");
+assert.equal(
+  rootPackage.scripts["release:prepare"],
+  "node scripts/release-orchestrator.mjs prepare",
+);
+assert.equal(
+  rootPackage.scripts["release:publish"],
+  "node scripts/release-orchestrator.mjs publish",
+);
+assert.match(rootPackage.scripts["release:contracts"], /release-orchestrator\.test\.mjs/);
+assert.equal(rootPackage.devDependencies.fledgling, "1.2.0");
+assert(
+  knip.ignoreDependencies.includes("fledgling"),
+  "Knip must account for Fledgling's subprocess-only CLI invocation",
+);
+assert.deepEqual(rootPackage.fledgling, {
+  provider: "github",
+  workflow: "publish.yml",
+  environment: "publish",
+  permissions: "publish",
+});
+assert.match(releasePrWorkflow, /version: pnpm release:version/);
 assert.match(workspace, /packages:\n\s+- "apps\/\*"/);
 assert.match(workspace, /- "packages\/artifacts\/\*"/);
 const packDestinations = [...publishWorkflow.matchAll(/--pack-destination\s+([^\s]+)/g)].map(

--- a/scripts/release-orchestrator.mjs
+++ b/scripts/release-orchestrator.mjs
@@ -1,0 +1,690 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { fileURLToPath } from "node:url";
+import semver from "semver";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const repository = "schalkneethling/create-project-calavera";
+const baseBranch = "main";
+const workflow = "publish.yml";
+const publishEnvironment = "publish";
+
+export class ReleaseError extends Error {}
+
+function commandText(command, args) {
+  return [command, ...args].join(" ");
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? root,
+    encoding: "utf8",
+    env: process.env,
+    stdio: options.capture ? "pipe" : "inherit",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0 && !options.allowFailure) {
+    throw new ReleaseError(`${commandText(command, args)} failed with exit code ${result.status}.`);
+  }
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function capture(command, args, options = {}) {
+  return run(command, args, { ...options, capture: true }).stdout.trim();
+}
+
+function captureJson(command, args, options = {}) {
+  const output = capture(command, args, options);
+  try {
+    return JSON.parse(output);
+  } catch {
+    throw new ReleaseError(`${commandText(command, args)} did not return valid JSON.`);
+  }
+}
+
+export function isExplicitRegistryNotFound(result) {
+  return (
+    result.status !== 0 && /(^|\s)(E404|404)(\s|$)/m.test(`${result.stdout}\n${result.stderr}`)
+  );
+}
+
+export function releaseChannel(version) {
+  if (!semver.valid(version)) throw new ReleaseError(`Invalid package version: ${version}.`);
+  return semver.prerelease(version) ? "next" : "latest";
+}
+
+export function releaseTag(packages, sha) {
+  const cli = packages.find(({ name }) => name === "create-project-calavera");
+  return cli ? `v${cli.version}` : `packages-${sha.slice(0, 12)}`;
+}
+
+export function hasPendingVersionBumps(output) {
+  return output
+    .split("\n")
+    .some(
+      (line) =>
+        /Packages to be bumped at (patch|minor|major):/i.test(line) &&
+        !/NO packages to be bumped/i.test(line),
+    );
+}
+
+export function validateReleaseMetadata(metadata, expected) {
+  if (metadata.tagName !== expected.tag) {
+    throw new ReleaseError(`Release tag ${metadata.tagName} does not match ${expected.tag}.`);
+  }
+  if (metadata.targetCommitish !== expected.sha) {
+    throw new ReleaseError(
+      `Release target ${metadata.targetCommitish} does not match ${expected.sha}.`,
+    );
+  }
+  if (metadata.isPrerelease !== expected.prerelease) {
+    throw new ReleaseError("Release prerelease state does not match the package versions.");
+  }
+  if (expected.draft !== undefined && metadata.isDraft !== expected.draft) {
+    throw new ReleaseError("Release draft state is not what the current transition requires.");
+  }
+}
+
+function parseWorkspacePatterns(source) {
+  return [...source.matchAll(/^\s*-\s+["']?([^"'\s]+)["']?\s*$/gm)].map(([, pattern]) => pattern);
+}
+
+async function expandWorkspacePattern(pattern) {
+  if (!pattern.endsWith("/*")) return [pattern];
+  const parent = pattern.slice(0, -2);
+  return (await readdir(join(root, parent), { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(parent, entry.name));
+}
+
+export async function discoverPublicPackages() {
+  const workspace = await readFile(join(root, "pnpm-workspace.yaml"), "utf8");
+  const paths = [];
+  for (const pattern of parseWorkspacePatterns(workspace)) {
+    paths.push(...(await expandWorkspacePattern(pattern)));
+  }
+
+  const packages = [];
+  for (const path of new Set(paths)) {
+    const manifestPath = join(root, path, "package.json");
+    try {
+      if (!(await stat(manifestPath)).isFile()) continue;
+    } catch {
+      continue;
+    }
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    if (manifest.private === true || !manifest.name || !manifest.version) continue;
+    packages.push({
+      name: manifest.name,
+      version: manifest.version,
+      path,
+      channel: releaseChannel(manifest.version),
+    });
+  }
+  return packages.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function registryQuery(args) {
+  return run("npm", ["view", ...args], { capture: true, allowFailure: true });
+}
+
+function requireRegistryJson(result, description) {
+  if (result.status !== 0) {
+    throw new ReleaseError(
+      `${description} failed for a reason other than an explicit missing-version response:\n${result.stderr || result.stdout}`,
+    );
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    throw new ReleaseError(`${description} returned malformed JSON.`);
+  }
+}
+
+export async function registryPlan(packages) {
+  const planned = [];
+  for (const pkg of packages) {
+    const exact = registryQuery([`${pkg.name}@${pkg.version}`, "version", "--json"]);
+    if (exact.status === 0) {
+      planned.push({ ...pkg, published: true, packageExists: true });
+      continue;
+    }
+    if (!isExplicitRegistryNotFound(exact)) {
+      requireRegistryJson(exact, `Exact registry lookup for ${pkg.name}@${pkg.version}`);
+    }
+
+    const versionsResult = registryQuery([pkg.name, "versions", "--json"]);
+    if (isExplicitRegistryNotFound(versionsResult)) {
+      planned.push({
+        ...pkg,
+        published: false,
+        packageExists: false,
+        tagsBefore: {},
+      });
+      continue;
+    }
+    requireRegistryJson(versionsResult, `Package registry lookup for ${pkg.name}`);
+    const tagsBefore = requireRegistryJson(
+      registryQuery([pkg.name, "dist-tags", "--json"]),
+      `Dist-tag lookup for ${pkg.name}`,
+    );
+    planned.push({
+      ...pkg,
+      published: false,
+      packageExists: true,
+      tagsBefore,
+    });
+  }
+  return planned;
+}
+
+function assertCleanCandidate() {
+  const branch = capture("git", ["branch", "--show-current"]);
+  if (branch !== baseBranch) {
+    throw new ReleaseError(`Release preparation must run from ${baseBranch}; found ${branch}.`);
+  }
+  if (capture("git", ["status", "--porcelain"])) {
+    throw new ReleaseError("Release preparation requires a clean working tree.");
+  }
+
+  run("git", ["fetch", "origin", baseBranch]);
+  const sha = capture("git", ["rev-parse", "HEAD"]);
+  const remoteSha = capture("git", ["rev-parse", `origin/${baseBranch}`]);
+  if (sha !== remoteSha) {
+    throw new ReleaseError(
+      `Local ${baseBranch} ${sha} does not match origin/${baseBranch} ${remoteSha}.`,
+    );
+  }
+  return sha;
+}
+
+function assertCandidateUnchanged(sha) {
+  if (capture("git", ["rev-parse", "HEAD"]) !== sha || capture("git", ["status", "--porcelain"])) {
+    throw new ReleaseError(
+      "A release gate changed the candidate. Restart from the first gate after reviewing the change.",
+    );
+  }
+}
+
+function runGates(sha) {
+  for (const [command, args] of [
+    ["pnpm", ["install", "--frozen-lockfile"]],
+    ["pnpm", ["release:rehearse"]],
+    ["pnpm", ["workflow:check"]],
+  ]) {
+    run(command, args);
+    assertCandidateUnchanged(sha);
+  }
+
+  const status = run("pnpm", ["release:status"], { capture: true });
+  process.stdout.write(status.stdout);
+  if (hasPendingVersionBumps(status.stdout)) {
+    throw new ReleaseError(
+      "Changesets still has packages to version; merge the generated version PR first.",
+    );
+  }
+  assertCandidateUnchanged(sha);
+}
+
+function printPlan(plan) {
+  console.info(`\nRelease candidate: ${plan.sha}`);
+  console.info("Packages absent from npm:");
+  for (const pkg of plan.packages.filter(({ published }) => !published)) {
+    console.info(`- ${pkg.name}@${pkg.version} -> ${pkg.channel}`);
+  }
+  console.info("Packages already published:");
+  for (const pkg of plan.packages.filter(({ published }) => published)) {
+    console.info(`- ${pkg.name}@${pkg.version}`);
+  }
+}
+
+async function confirm(expected, assumeYes) {
+  if (assumeYes) return;
+  if (!process.stdin.isTTY) {
+    throw new ReleaseError(
+      `Interactive confirmation required. Re-run with --yes to confirm ${expected}.`,
+    );
+  }
+  const prompt = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await prompt.question(`Type "${expected}" to continue: `);
+  prompt.close();
+  if (answer !== expected) throw new ReleaseError("Release transition cancelled.");
+}
+
+function fledglingArgs(packageNames, dryRun) {
+  return [
+    "exec",
+    "fledgling",
+    "add",
+    ...packageNames,
+    dryRun ? "--dry-run" : "--yes",
+    "--repo",
+    repository,
+    "--workflow",
+    workflow,
+    "--env",
+    publishEnvironment,
+    "--permissions",
+    "publish",
+    "--placeholder-version",
+    "0.0.0",
+    "--tag",
+    "bootstrap",
+  ];
+}
+
+function verifyTrust(packageName) {
+  const trust = capture("npm", ["trust", "list", packageName]);
+  for (const expected of [
+    "type: github",
+    `file: ${workflow}`,
+    `repository: ${repository}`,
+    `environment: ${publishEnvironment}`,
+    "permissions: publish",
+  ]) {
+    if (!trust.includes(expected)) {
+      throw new ReleaseError(`Trusted publisher for ${packageName} is missing ${expected}.`);
+    }
+  }
+}
+
+async function bootstrapNewPackages(plan, options) {
+  const newPackages = plan.packages.filter(({ packageExists }) => !packageExists);
+  if (newPackages.length === 0) return { plan, bootstrapped: false };
+
+  const npmVersion = capture("npm", ["--version"]).split(".").map(Number);
+  if (npmVersion[0] < 11 || (npmVersion[0] === 11 && npmVersion[1] < 15)) {
+    throw new ReleaseError("Fledgling requires npm 11.15.0 or newer.");
+  }
+  const names = newPackages.map(({ name }) => name);
+  run("pnpm", fledglingArgs(names, true));
+  if (!options.bootstrap) {
+    throw new ReleaseError(
+      `New package names require a reviewed bootstrap. Re-run pnpm release:prepare -- --bootstrap after reviewing the Fledgling plan.`,
+    );
+  }
+  if (newPackages.some(({ version }) => version.includes("-"))) {
+    throw new ReleaseError(
+      "Bootstrap new package names before prerelease versioning so a real stable initial version can replace npm's mandatory latest placeholder.",
+    );
+  }
+  const otherMissing = plan.packages.filter(
+    ({ published, packageExists }) => !published && packageExists,
+  );
+  if (otherMissing.length > 0) {
+    throw new ReleaseError(
+      "Refusing package bootstrap while existing packages also have unpublished versions.",
+    );
+  }
+
+  await confirm(`bootstrap ${names.join(",")}`, options.yes);
+  run("pnpm", fledglingArgs(names, false));
+  for (const name of names) verifyTrust(name);
+
+  const tag = `packages-bootstrap-${plan.sha.slice(0, 12)}`;
+  let metadata = releaseMetadata(tag);
+  if (!metadata) {
+    ({ metadata } = createDraft(plan, tag, true));
+  } else {
+    validateReleaseMetadata(metadata, {
+      tag,
+      sha: plan.sha,
+      prerelease: true,
+    });
+  }
+  if (!metadata.isDraft) {
+    throw new ReleaseError(
+      `Bootstrap release ${tag} already exists, but the package names still appear absent.`,
+    );
+  }
+
+  run("gh", ["release", "edit", tag, "--repo", repository, "--draft=false", "--prerelease=true"]);
+  const workflowRun = waitForRun(tag, plan.sha);
+  console.info(`Watching bootstrap publication ${workflowRun.url}`);
+  run("gh", [
+    "run",
+    "watch",
+    String(workflowRun.databaseId),
+    "--repo",
+    repository,
+    "--exit-status",
+    "--interval",
+    "10",
+  ]);
+  verifyPublishedPackages(plan, workflowRun.databaseId);
+
+  for (const pkg of newPackages) {
+    run("npm", ["dist-tag", "rm", pkg.name, "bootstrap"]);
+    const tags = captureJson("npm", ["view", pkg.name, "dist-tags", "--json"]);
+    if (tags.latest !== pkg.version || tags.bootstrap) {
+      throw new ReleaseError(`Bootstrap tags for ${pkg.name} were not finalized safely.`);
+    }
+  }
+
+  assertCandidateUnchanged(plan.sha);
+  runGates(plan.sha);
+  const refreshed = {
+    sha: plan.sha,
+    packages: await registryPlan(await discoverPublicPackages()),
+  };
+  printPlan(refreshed);
+  return { plan: refreshed, bootstrapped: true };
+}
+
+export async function prepareRelease(options = {}) {
+  const sha = assertCleanCandidate();
+  runGates(sha);
+  const packages = await registryPlan(await discoverPublicPackages());
+  let plan = { sha, packages };
+  printPlan(plan);
+  const bootstrap = await bootstrapNewPackages(plan, options);
+  plan = bootstrap.plan;
+  if (
+    !options.allowPublished &&
+    !bootstrap.bootstrapped &&
+    plan.packages.every(({ published }) => published)
+  ) {
+    throw new ReleaseError("Every local public package version is already published.");
+  }
+  return plan;
+}
+
+function releaseMetadata(tag) {
+  const result = run(
+    "gh",
+    [
+      "release",
+      "view",
+      tag,
+      "--repo",
+      repository,
+      "--json",
+      "url,tagName,targetCommitish,name,body,isDraft,isPrerelease,publishedAt",
+    ],
+    { capture: true, allowFailure: true },
+  );
+  if (result.status !== 0) {
+    if (/release not found|HTTP 404/i.test(`${result.stdout}\n${result.stderr}`)) return undefined;
+    throw new ReleaseError(
+      `GitHub release lookup for ${tag} failed:\n${result.stderr || result.stdout}`,
+    );
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    throw new ReleaseError(`GitHub release lookup for ${tag} returned malformed JSON.`);
+  }
+}
+
+function createDraft(plan, tag, prereleaseOverride) {
+  const candidates = plan.packages.filter(({ published }) => !published);
+  const prerelease = prereleaseOverride ?? candidates.some(({ channel }) => channel === "next");
+  const notes = [
+    "Packages:",
+    ...candidates.map(({ name, version }) => `- ${name}@${version}`),
+  ].join("\n");
+  run("gh", [
+    "release",
+    "create",
+    tag,
+    "--repo",
+    repository,
+    "--target",
+    plan.sha,
+    "--title",
+    `Calavera ${tag}`,
+    "--notes",
+    notes,
+    "--draft",
+    ...(prerelease ? ["--prerelease"] : []),
+  ]);
+  const metadata = releaseMetadata(tag);
+  if (!metadata) throw new ReleaseError(`Draft release ${tag} was not created.`);
+  validateReleaseMetadata(metadata, {
+    tag,
+    sha: plan.sha,
+    draft: true,
+    prerelease,
+  });
+  return { metadata, prerelease };
+}
+
+export function packagesFromReleaseNotes(plan, body) {
+  const identities = new Set(
+    [...body.matchAll(/^- (.+)@([^@\s]+)$/gm)].map(([, name, version]) => `${name}@${version}`),
+  );
+  return plan.packages
+    .filter(({ name, version }) => identities.has(`${name}@${version}`))
+    .map((pkg) => ({ ...pkg, published: false }));
+}
+
+function waitForRun(tag, sha) {
+  for (let attempt = 0; attempt < 24; attempt += 1) {
+    const runs = captureJson("gh", [
+      "run",
+      "list",
+      "--repo",
+      repository,
+      "--workflow",
+      workflow,
+      "--event",
+      "release",
+      "--limit",
+      "20",
+      "--json",
+      "databaseId,headSha,headBranch,status,conclusion,url",
+    ]);
+    const selected = runs.find((run) => run.headSha === sha && run.headBranch === tag);
+    if (selected) return selected;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5000);
+  }
+  throw new ReleaseError(`No ${workflow} run appeared for ${tag} at ${sha}.`);
+}
+
+function verifyPublishedPackages(plan, runId) {
+  const candidates = plan.packages.filter(({ published }) => !published);
+  const log = capture("gh", ["run", "view", String(runId), "--repo", repository, "--log"]);
+  const provenanceCount = log.match(/Signed provenance statement/g)?.length ?? 0;
+  if (provenanceCount < candidates.length) {
+    throw new ReleaseError(
+      `Publish log contains ${provenanceCount} provenance statements for ${candidates.length} packages.`,
+    );
+  }
+  for (const pkg of candidates) {
+    if (!log.includes(`+ ${pkg.name}@${pkg.version}`)) {
+      throw new ReleaseError(`Publish log does not confirm ${pkg.name}@${pkg.version}.`);
+    }
+    const version = capture("npm", ["view", `${pkg.name}@${pkg.version}`, "version", "--json"]);
+    if (JSON.parse(version) !== pkg.version) {
+      throw new ReleaseError(`Registry did not return ${pkg.name}@${pkg.version}.`);
+    }
+    const tags = captureJson("npm", ["view", pkg.name, "dist-tags", "--json"]);
+    if (tags[pkg.channel] !== pkg.version) {
+      throw new ReleaseError(`${pkg.name} ${pkg.channel} does not point to ${pkg.version}.`);
+    }
+    if (pkg.channel === "next" && pkg.tagsBefore?.latest && tags.latest !== pkg.tagsBefore.latest) {
+      throw new ReleaseError(`${pkg.name} latest changed during a prerelease.`);
+    }
+  }
+}
+
+async function smokePublishedArtifacts(plan) {
+  const cli = plan.packages.find(({ name }) => name === "create-project-calavera");
+  if (!cli) throw new ReleaseError("The workspace does not expose create-project-calavera.");
+  run("npx", [
+    "--yes",
+    "--package",
+    `${cli.name}@${cli.version}`,
+    "create-project-calavera",
+    "--help",
+  ]);
+
+  const candidateArtifact = plan.packages.find(
+    ({ published, path }) => !published && path.startsWith("packages/artifacts/"),
+  );
+  if (!candidateArtifact) return;
+  const manifest = JSON.parse(
+    await readFile(join(root, candidateArtifact.path, "calavera-artifact.json"), "utf8"),
+  );
+  const directory = await mkdtemp(join(tmpdir(), "calavera-release-smoke-"));
+  try {
+    await writeFile(
+      join(directory, "package.json"),
+      `${JSON.stringify({ name: basename(directory), private: true }, null, 2)}\n`,
+    );
+    await writeFile(
+      join(directory, "calavera.config.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          profile: "minimal",
+          packageManager: "npm",
+          integrations: [],
+          ai: [{ id: manifest.id }],
+          scripts: {},
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    run(
+      "npx",
+      [
+        "--yes",
+        "--package",
+        `${cli.name}@${cli.version}`,
+        "create-project-calavera",
+        "artifacts",
+        "install",
+        "--tag",
+        candidateArtifact.channel,
+        "--yes",
+      ],
+      { cwd: directory },
+    );
+    const lock = JSON.parse(
+      await readFile(join(directory, ".calavera", "artifacts.lock.json"), "utf8"),
+    );
+    const installed = lock.artifacts.find(({ id }) => id === manifest.id);
+    if (installed?.version !== candidateArtifact.version) {
+      throw new ReleaseError(
+        `Consumer smoke installed ${installed?.version ?? "nothing"} instead of ${candidateArtifact.version}.`,
+      );
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+export async function publishRelease(options = {}) {
+  const plan = await prepareRelease({ ...options, allowPublished: true });
+  const candidates = plan.packages.filter(({ published }) => !published);
+  const tag =
+    options.tag ?? releaseTag(candidates.length > 0 ? candidates : plan.packages, plan.sha);
+  let metadata = releaseMetadata(tag);
+  const prerelease =
+    candidates.length === 0 && metadata
+      ? metadata.isPrerelease
+      : candidates.some(({ channel }) => channel === "next");
+  if (!metadata) {
+    ({ metadata } = createDraft(plan, tag));
+  } else {
+    validateReleaseMetadata(metadata, {
+      tag,
+      sha: plan.sha,
+      prerelease,
+    });
+  }
+  if (!metadata.isDraft) {
+    if (candidates.length > 0) {
+      throw new ReleaseError(
+        `Release ${tag} is already published, but expected versions remain absent from npm.`,
+      );
+    }
+    const releasedPackages = packagesFromReleaseNotes(plan, metadata.body ?? "");
+    if (releasedPackages.length === 0) {
+      throw new ReleaseError(
+        `Release ${tag} is published, but its notes do not contain a verifiable package inventory.`,
+      );
+    }
+    const releasedIdentities = new Set(
+      releasedPackages.map(({ name, version }) => `${name}@${version}`),
+    );
+    const verificationPlan = {
+      ...plan,
+      packages: plan.packages.map((pkg) =>
+        releasedIdentities.has(`${pkg.name}@${pkg.version}`) ? { ...pkg, published: false } : pkg,
+      ),
+    };
+    const workflowRun = waitForRun(tag, plan.sha);
+    verifyPublishedPackages(verificationPlan, workflowRun.databaseId);
+    await smokePublishedArtifacts(verificationPlan);
+    console.info(`Release ${tag} and its package inventory are already published and verified.`);
+    return plan;
+  }
+
+  console.info(`Verified draft: ${metadata.url}`);
+  await confirm(`publish ${tag}`, options.yes);
+  run("gh", [
+    "release",
+    "edit",
+    tag,
+    "--repo",
+    repository,
+    "--draft=false",
+    ...(prerelease ? ["--prerelease=true"] : ["--latest"]),
+  ]);
+
+  const workflowRun = waitForRun(tag, plan.sha);
+  console.info(`Watching ${workflowRun.url}`);
+  run("gh", [
+    "run",
+    "watch",
+    String(workflowRun.databaseId),
+    "--repo",
+    repository,
+    "--exit-status",
+    "--interval",
+    "10",
+  ]);
+  verifyPublishedPackages(plan, workflowRun.databaseId);
+  await smokePublishedArtifacts(plan);
+  assertCandidateUnchanged(plan.sha);
+  console.info(`Release ${tag} is published and verified.`);
+}
+
+function parseOptions(args) {
+  const options = {
+    yes: args.includes("--yes"),
+    bootstrap: args.includes("--bootstrap"),
+  };
+  const tagIndex = args.indexOf("--tag");
+  if (tagIndex !== -1) options.tag = args[tagIndex + 1];
+  return options;
+}
+
+export async function main(args = process.argv.slice(2)) {
+  const [command, ...rest] = args;
+  const options = parseOptions(rest);
+  if (command === "prepare") return prepareRelease(options);
+  if (command === "publish") return publishRelease(options);
+  throw new ReleaseError(
+    "Usage: release-orchestrator.mjs <prepare|publish> [--bootstrap] [--tag <tag>] [--yes]",
+  );
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release-orchestrator.mjs
+++ b/scripts/release-orchestrator.mjs
@@ -282,18 +282,25 @@ function fledglingArgs(packageNames, dryRun) {
   ];
 }
 
+export function hasExpectedTrust(response) {
+  const entries = Array.isArray(response) ? response : [response];
+  return entries.some(
+    (entry) =>
+      entry?.type === "github" &&
+      entry.file === workflow &&
+      entry.repository === repository &&
+      entry.environment === publishEnvironment &&
+      Array.isArray(entry.permissions) &&
+      entry.permissions.includes("createPackage"),
+  );
+}
+
 function verifyTrust(packageName) {
-  const trust = capture("npm", ["trust", "list", packageName]);
-  for (const expected of [
-    "type: github",
-    `file: ${workflow}`,
-    `repository: ${repository}`,
-    `environment: ${publishEnvironment}`,
-    "permissions: publish",
-  ]) {
-    if (!trust.includes(expected)) {
-      throw new ReleaseError(`Trusted publisher for ${packageName} is missing ${expected}.`);
-    }
+  const response = captureJson("npm", ["trust", "list", packageName, "--json"]);
+  if (!hasExpectedTrust(response)) {
+    throw new ReleaseError(
+      `Trusted publisher for ${packageName} does not match the required GitHub workflow, repository, environment, and publish permission.`,
+    );
   }
 }
 
@@ -312,7 +319,7 @@ async function bootstrapNewPackages(plan, options) {
       `New package names require a reviewed bootstrap. Re-run pnpm release:prepare -- --bootstrap after reviewing the Fledgling plan.`,
     );
   }
-  if (newPackages.some(({ version }) => version.includes("-"))) {
+  if (newPackages.some(({ version }) => semver.prerelease(version) !== null)) {
     throw new ReleaseError(
       "Bootstrap new package names before prerelease versioning so a real stable initial version can replace npm's mandatory latest placeholder.",
     );
@@ -348,7 +355,7 @@ async function bootstrapNewPackages(plan, options) {
   }
 
   run("gh", ["release", "edit", tag, "--repo", repository, "--draft=false", "--prerelease=true"]);
-  const workflowRun = waitForRun(tag, plan.sha);
+  const workflowRun = await waitForRun(tag, plan.sha);
   console.info(`Watching bootstrap publication ${workflowRun.url}`);
   run("gh", [
     "run",
@@ -467,25 +474,41 @@ export function packagesFromReleaseNotes(plan, body) {
     .map((pkg) => ({ ...pkg, published: false }));
 }
 
-function waitForRun(tag, sha) {
-  for (let attempt = 0; attempt < 24; attempt += 1) {
-    const runs = captureJson("gh", [
-      "run",
-      "list",
-      "--repo",
-      repository,
-      "--workflow",
-      workflow,
-      "--event",
-      "release",
-      "--limit",
-      "20",
-      "--json",
-      "databaseId,headSha,headBranch,status,conclusion,url",
-    ]);
+function listWorkflowRuns() {
+  return captureJson("gh", [
+    "run",
+    "list",
+    "--repo",
+    repository,
+    "--workflow",
+    workflow,
+    "--event",
+    "release",
+    "--limit",
+    "20",
+    "--json",
+    "databaseId,headSha,headBranch,status,conclusion,url",
+  ]);
+}
+
+function delay(milliseconds) {
+  return new Promise((resolveDelay) => {
+    setTimeout(resolveDelay, milliseconds);
+  });
+}
+
+export async function waitForRun(tag, sha, options = {}) {
+  const pollIntervalMs = options.pollIntervalMs ?? 5000;
+  const timeoutMs = options.timeoutMs ?? 300000;
+  const attempts = Math.max(1, Math.ceil(timeoutMs / pollIntervalMs));
+  const getRuns = options.getRuns ?? listWorkflowRuns;
+  const wait = options.delay ?? delay;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const runs = getRuns();
     const selected = runs.find((run) => run.headSha === sha && run.headBranch === tag);
     if (selected) return selected;
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5000);
+    if (attempt < attempts - 1) await wait(pollIntervalMs);
   }
   throw new ReleaseError(`No ${workflow} run appeared for ${tag} at ${sha}.`);
 }
@@ -625,7 +648,7 @@ export async function publishRelease(options = {}) {
         releasedIdentities.has(`${pkg.name}@${pkg.version}`) ? { ...pkg, published: false } : pkg,
       ),
     };
-    const workflowRun = waitForRun(tag, plan.sha);
+    const workflowRun = await waitForRun(tag, plan.sha);
     verifyPublishedPackages(verificationPlan, workflowRun.databaseId);
     await smokePublishedArtifacts(verificationPlan);
     console.info(`Release ${tag} and its package inventory are already published and verified.`);
@@ -644,7 +667,7 @@ export async function publishRelease(options = {}) {
     ...(prerelease ? ["--prerelease=true"] : ["--latest"]),
   ]);
 
-  const workflowRun = waitForRun(tag, plan.sha);
+  const workflowRun = await waitForRun(tag, plan.sha);
   console.info(`Watching ${workflowRun.url}`);
   run("gh", [
     "run",
@@ -662,13 +685,19 @@ export async function publishRelease(options = {}) {
   console.info(`Release ${tag} is published and verified.`);
 }
 
-function parseOptions(args) {
+export function parseOptions(args) {
   const options = {
     yes: args.includes("--yes"),
     bootstrap: args.includes("--bootstrap"),
   };
   const tagIndex = args.indexOf("--tag");
-  if (tagIndex !== -1) options.tag = args[tagIndex + 1];
+  if (tagIndex !== -1) {
+    const tag = args[tagIndex + 1];
+    if (!tag || tag.startsWith("--")) {
+      throw new ReleaseError("--tag requires a following value.");
+    }
+    options.tag = tag;
+  }
   return options;
 }
 
@@ -684,7 +713,7 @@ export async function main(args = process.argv.slice(2)) {
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   main().catch((error) => {
-    console.error(error instanceof Error ? error.message : error);
+    process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
     process.exitCode = 1;
   });
 }

--- a/scripts/release-orchestrator.test.mjs
+++ b/scripts/release-orchestrator.test.mjs
@@ -8,12 +8,15 @@ import { fileURLToPath } from "node:url";
 
 import {
   discoverPublicPackages,
+  hasExpectedTrust,
   hasPendingVersionBumps,
   isExplicitRegistryNotFound,
   packagesFromReleaseNotes,
+  parseOptions,
   releaseChannel,
   releaseTag,
   validateReleaseMetadata,
+  waitForRun,
 } from "./release-orchestrator.mjs";
 import { generatedFormatPaths, versionPackages } from "./release-version.mjs";
 
@@ -34,11 +37,76 @@ test("registry absence accepts only explicit 404 responses", () => {
 test("release channels and tags are derived from exact versions", () => {
   assert.equal(releaseChannel("2.4.0-next.1"), "next");
   assert.equal(releaseChannel("2.4.0"), "latest");
+  assert.equal(releaseChannel("1.0.0+build-1"), "latest");
   assert.equal(
     releaseTag([{ name: "create-project-calavera", version: "2.4.0-next.1" }], "a".repeat(40)),
     "v2.4.0-next.1",
   );
   assert.equal(releaseTag([], "abcdef1234567890"), "packages-abcdef123456");
+});
+
+test("release options require an explicit tag value", () => {
+  assert.deepEqual(parseOptions(["--tag", "v2.4.0-next.1", "--yes"]), {
+    yes: true,
+    bootstrap: false,
+    tag: "v2.4.0-next.1",
+  });
+  assert.throws(() => parseOptions(["--tag"]), /requires a following value/);
+  assert.throws(() => parseOptions(["--tag", "--yes"]), /requires a following value/);
+});
+
+test("trusted publisher verification uses npm's structured response", () => {
+  assert.equal(
+    hasExpectedTrust({
+      id: "publisher-id",
+      type: "github",
+      file: "publish.yml",
+      repository: "schalkneethling/create-project-calavera",
+      environment: "publish",
+      permissions: ["createPackage"],
+    }),
+    true,
+  );
+  assert.equal(
+    hasExpectedTrust({
+      type: "github",
+      file: "publish.yml",
+      repository: "schalkneethling/create-project-calavera",
+      environment: "publish",
+      permissions: ["createStagedPackage"],
+    }),
+    false,
+  );
+});
+
+test("release workflow polling waits asynchronously within a configurable budget", async () => {
+  let polls = 0;
+  const delays = [];
+  const run = await waitForRun("v2.4.0-next.1", "abc123", {
+    pollIntervalMs: 20,
+    timeoutMs: 60,
+    getRuns() {
+      polls += 1;
+      return polls === 2
+        ? [{ headSha: "abc123", headBranch: "v2.4.0-next.1", databaseId: 42 }]
+        : [];
+    },
+    async delay(milliseconds) {
+      delays.push(milliseconds);
+    },
+  });
+  assert.equal(run.databaseId, 42);
+  assert.deepEqual(delays, [20]);
+
+  await assert.rejects(
+    waitForRun("missing", "abc123", {
+      pollIntervalMs: 20,
+      timeoutMs: 40,
+      getRuns: () => [],
+      delay: async () => {},
+    }),
+    /No publish\.yml run appeared/,
+  );
 });
 
 test("Changesets status distinguishes pending bumps from NO-package summaries", () => {
@@ -205,6 +273,7 @@ test("version generation formats one-item prerelease state deterministically", a
     2,
   )}\n`;
   await writeFile(join(directory, "apps", "private", "package.json"), privateManifest);
+  await writeFile(join(directory, "tracked-notes.json"), '{ "before": true }\n');
 
   execFileSync("git", ["init", "-b", "main"], { cwd: directory });
   execFileSync("git", ["add", "."], { cwd: directory });
@@ -224,6 +293,11 @@ test("version generation formats one-item prerelease state deterministically", a
     { cwd: directory },
   );
 
+  const preexistingTrackedChange = '{"tracked" : "leave unchanged"}\n';
+  const preexistingUntrackedChange = '{"untracked" : "leave unchanged"}\n';
+  await writeFile(join(directory, "tracked-notes.json"), preexistingTrackedChange);
+  await writeFile(join(directory, "untracked-notes.json"), preexistingUntrackedChange);
+
   const options = {
     rootDir: directory,
     changesetBin: join(root, "node_modules", ".bin", "changeset"),
@@ -240,6 +314,14 @@ test("version generation formats one-item prerelease state deterministically", a
   assert.equal(
     await readFile(join(directory, "apps", "private", "package.json"), "utf8"),
     privateManifest,
+  );
+  assert.equal(
+    await readFile(join(directory, "tracked-notes.json"), "utf8"),
+    preexistingTrackedChange,
+  );
+  assert.equal(
+    await readFile(join(directory, "untracked-notes.json"), "utf8"),
+    preexistingUntrackedChange,
   );
 
   versionPackages(options);

--- a/scripts/release-orchestrator.test.mjs
+++ b/scripts/release-orchestrator.test.mjs
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  discoverPublicPackages,
+  hasPendingVersionBumps,
+  isExplicitRegistryNotFound,
+  packagesFromReleaseNotes,
+  releaseChannel,
+  releaseTag,
+  validateReleaseMetadata,
+} from "./release-orchestrator.mjs";
+import { generatedFormatPaths, versionPackages } from "./release-version.mjs";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+test("registry absence accepts only explicit 404 responses", () => {
+  assert.equal(
+    isExplicitRegistryNotFound({ status: 1, stdout: "", stderr: "npm error code E404" }),
+    true,
+  );
+  assert.equal(
+    isExplicitRegistryNotFound({ status: 1, stdout: "", stderr: "npm error code ENOTFOUND" }),
+    false,
+  );
+  assert.equal(isExplicitRegistryNotFound({ status: 0, stdout: '"1.0.0"', stderr: "" }), false);
+});
+
+test("release channels and tags are derived from exact versions", () => {
+  assert.equal(releaseChannel("2.4.0-next.1"), "next");
+  assert.equal(releaseChannel("2.4.0"), "latest");
+  assert.equal(
+    releaseTag([{ name: "create-project-calavera", version: "2.4.0-next.1" }], "a".repeat(40)),
+    "v2.4.0-next.1",
+  );
+  assert.equal(releaseTag([], "abcdef1234567890"), "packages-abcdef123456");
+});
+
+test("Changesets status distinguishes pending bumps from NO-package summaries", () => {
+  assert.equal(
+    hasPendingVersionBumps(
+      "🦋  info NO packages to be bumped at patch\n🦋  info NO packages to be bumped at minor",
+    ),
+    false,
+  );
+  assert.equal(
+    hasPendingVersionBumps(
+      "🦋  info NO packages to be bumped at patch\n🦋  info Packages to be bumped at minor:",
+    ),
+    true,
+  );
+});
+
+test("release metadata must identify the exact candidate transition", () => {
+  const metadata = {
+    tagName: "v2.4.0-next.1",
+    targetCommitish: "abc123",
+    isDraft: true,
+    isPrerelease: true,
+  };
+  assert.doesNotThrow(() =>
+    validateReleaseMetadata(metadata, {
+      tag: "v2.4.0-next.1",
+      sha: "abc123",
+      draft: true,
+      prerelease: true,
+    }),
+  );
+  assert.throws(
+    () =>
+      validateReleaseMetadata(metadata, {
+        tag: "v2.4.0-next.1",
+        sha: "different",
+        draft: true,
+        prerelease: true,
+      }),
+    /does not match/,
+  );
+});
+
+test("published release notes recover the exact package inventory for reruns", () => {
+  const plan = {
+    packages: [
+      {
+        name: "create-project-calavera",
+        version: "2.4.0-next.0",
+        published: true,
+      },
+      {
+        name: "@schalkneethling/calavera-artifact-core",
+        version: "0.3.0-next.0",
+        published: true,
+      },
+      {
+        name: "@schalkneethling/unrelated",
+        version: "1.0.0",
+        published: true,
+      },
+    ],
+  };
+  assert.deepEqual(
+    packagesFromReleaseNotes(
+      plan,
+      "Packages:\n- create-project-calavera@2.4.0-next.0\n- @schalkneethling/calavera-artifact-core@0.3.0-next.0",
+    ).map(({ name, published }) => ({ name, published })),
+    [
+      { name: "create-project-calavera", published: false },
+      { name: "@schalkneethling/calavera-artifact-core", published: false },
+    ],
+  );
+});
+
+test("public release packages are discovered from workspace metadata", async () => {
+  const packages = await discoverPublicPackages();
+  assert.ok(packages.some(({ name }) => name === "create-project-calavera"));
+  assert.ok(
+    packages.some(({ name }) => name === "@schalkneethling/calavera-skill-release-with-confidence"),
+  );
+  assert.equal(
+    packages.some(({ name }) => name === "@calavera/menu-bar"),
+    false,
+  );
+});
+
+test("version formatting is limited to changed generated documents", () => {
+  assert.deepEqual(
+    generatedFormatPaths([
+      ".changeset/pre.json",
+      "packages/cli/package.json",
+      "packages/cli/CHANGELOG.md",
+      "packages/cli/src/index.js",
+      ".changeset/pre.json",
+    ]),
+    [".changeset/pre.json", "packages/cli/CHANGELOG.md", "packages/cli/package.json"],
+  );
+});
+
+test("version generation formats one-item prerelease state deterministically", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "calavera-version-fixture-"));
+  await mkdir(join(directory, ".changeset"));
+  await mkdir(join(directory, "packages", "fixture"), { recursive: true });
+  await mkdir(join(directory, "apps", "private"), { recursive: true });
+  await writeFile(
+    join(directory, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "release-fixture",
+        private: true,
+        workspaces: ["packages/*", "apps/*"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(join(directory, ".oxfmtrc.json"), "{}\n");
+  await writeFile(
+    join(directory, ".changeset", "config.json"),
+    `${JSON.stringify(
+      {
+        $schema: "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+        changelog: false,
+        commit: false,
+        fixed: [],
+        linked: [],
+        access: "restricted",
+        baseBranch: "main",
+        updateInternalDependencies: "patch",
+        ignore: ["private-app"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(
+    join(directory, ".changeset", "pre.json"),
+    `${JSON.stringify(
+      {
+        mode: "pre",
+        tag: "next",
+        initialVersions: {
+          "fixture-package": "1.0.0",
+        },
+        changesets: [],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(
+    join(directory, ".changeset", "one-change.md"),
+    `---\n"fixture-package": minor\n---\n\nAdd a fixture feature.\n`,
+  );
+  await writeFile(
+    join(directory, "packages", "fixture", "package.json"),
+    `${JSON.stringify({ name: "fixture-package", version: "1.0.0" }, null, 2)}\n`,
+  );
+  const privateManifest = `${JSON.stringify(
+    { name: "private-app", version: "0.1.0", private: true },
+    null,
+    2,
+  )}\n`;
+  await writeFile(join(directory, "apps", "private", "package.json"), privateManifest);
+
+  execFileSync("git", ["init", "-b", "main"], { cwd: directory });
+  execFileSync("git", ["add", "."], { cwd: directory });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=Calavera Test",
+      "-c",
+      "user.email=calavera@example.invalid",
+      "-c",
+      "commit.gpgsign=false",
+      "commit",
+      "-m",
+      "fixture",
+    ],
+    { cwd: directory },
+  );
+
+  const options = {
+    rootDir: directory,
+    changesetBin: join(root, "node_modules", ".bin", "changeset"),
+    formatterBin: join(root, "node_modules", ".bin", "oxfmt"),
+  };
+  versionPackages(options);
+
+  const preState = await readFile(join(directory, ".changeset", "pre.json"), "utf8");
+  const packageManifest = JSON.parse(
+    await readFile(join(directory, "packages", "fixture", "package.json"), "utf8"),
+  );
+  assert.match(preState, /"changesets": \["one-change"\]/);
+  assert.equal(packageManifest.version, "1.1.0-next.0");
+  assert.equal(
+    await readFile(join(directory, "apps", "private", "package.json"), "utf8"),
+    privateManifest,
+  );
+
+  versionPackages(options);
+  assert.equal(await readFile(join(directory, ".changeset", "pre.json"), "utf8"), preState);
+});

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -21,18 +21,30 @@ function captureGitPaths(rootDir, args) {
   return output.split("\n").filter(Boolean);
 }
 
+function capturePendingPaths(rootDir) {
+  return [
+    ...captureGitPaths(rootDir, ["diff", "--name-only", "--diff-filter=ACMR"]),
+    ...captureGitPaths(rootDir, ["ls-files", "--others", "--exclude-standard"]),
+  ];
+}
+
 export function versionPackages(options = {}) {
   const rootDir = options.rootDir ?? root;
   const changesetBin = options.changesetBin ?? join(root, "node_modules", ".bin", "changeset");
   const formatterBin = options.formatterBin ?? join(root, "node_modules", ".bin", "oxfmt");
 
+  const pathsBeforeVersioning = new Map(
+    capturePendingPaths(rootDir).map((path) => [path, readFileSync(join(rootDir, path))]),
+  );
   execFileSync(changesetBin, ["version"], { cwd: rootDir, stdio: "inherit" });
 
-  const changedPaths = [
-    ...captureGitPaths(rootDir, ["diff", "--name-only", "--diff-filter=ACMR"]),
-    ...captureGitPaths(rootDir, ["ls-files", "--others", "--exclude-standard"]),
-  ];
-  const formatPaths = generatedFormatPaths(changedPaths).filter((path) =>
+  const generatedPaths = capturePendingPaths(rootDir).filter((path) => {
+    const previousContents = pathsBeforeVersioning.get(path);
+    return (
+      previousContents === undefined || !previousContents.equals(readFileSync(join(rootDir, path)))
+    );
+  });
+  const formatPaths = generatedFormatPaths(generatedPaths).filter((path) =>
     existsSync(join(rootDir, path)),
   );
 

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -1,0 +1,49 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+export function generatedFormatPaths(changedPaths) {
+  return [
+    ...new Set(
+      changedPaths.filter((path) => [".json", ".md", ".yaml", ".yml"].includes(extname(path))),
+    ),
+  ].sort();
+}
+
+function captureGitPaths(rootDir, args) {
+  const output = execFileSync("git", args, {
+    cwd: rootDir,
+    encoding: "utf8",
+  });
+  return output.split("\n").filter(Boolean);
+}
+
+export function versionPackages(options = {}) {
+  const rootDir = options.rootDir ?? root;
+  const changesetBin = options.changesetBin ?? join(root, "node_modules", ".bin", "changeset");
+  const formatterBin = options.formatterBin ?? join(root, "node_modules", ".bin", "oxfmt");
+
+  execFileSync(changesetBin, ["version"], { cwd: rootDir, stdio: "inherit" });
+
+  const changedPaths = [
+    ...captureGitPaths(rootDir, ["diff", "--name-only", "--diff-filter=ACMR"]),
+    ...captureGitPaths(rootDir, ["ls-files", "--others", "--exclude-standard"]),
+  ];
+  const formatPaths = generatedFormatPaths(changedPaths).filter((path) =>
+    existsSync(join(rootDir, path)),
+  );
+
+  if (formatPaths.length > 0) {
+    execFileSync(formatterBin, ["--write", ...formatPaths], {
+      cwd: rootDir,
+      stdio: "inherit",
+    });
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  versionPackages();
+}


### PR DESCRIPTION
## Summary

- add rerunnable prepare and publish release commands with exact candidate, registry, GitHub Release, provenance, and consumer verification
- make Changesets version output deterministic by formatting generated release state automatically
- use pinned Fledgling only for explicit new-package claiming and trusted-publisher bootstrap, with npm as the authoritative verification source
- use node-semver for version validation and prerelease-channel decisions
- update the release-with-confidence skill and add contract coverage for the automated path

## Sequencing

This PR is intentionally stacked on #364 because published prerelease artifact smoke tests require that compatibility fix. After #364 merges, retarget this PR to main.

## Validation

- vp check
- npm test
- npm run typecheck
- npm run knip
- npm run lint:skills
- npm run release:contracts
- pnpm install --frozen-lockfile

fix #363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated, restartable release workflow with preparation and publishing checkpoints.
  * Added support for safely bootstrapping packages, verifying registry metadata, provenance, dist-tags, and published versions.
  * Added a post-release consumer smoke test to confirm published artifacts install correctly.

* **Bug Fixes**
  * Improved deterministic versioning and formatting of generated release documents.
  * Strengthened release validation and safeguards against inconsistent or incomplete release state.

* **Documentation**
  * Updated release guidance for reviewed workflows, semantic versioning, npm verification, and recovery procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->