### PR TITLE
Exit next prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next",
   "initialVersions": {
     "@calavera/menu-bar": "0.1.0",


### PR DESCRIPTION
## Summary

- exit Changesets `next` prerelease mode after the verified `v2.4.0-next.1` release
- preserve the complete prerelease cohort for stable version generation
- keep the transition limited to the Changesets mode flag

## Validation

- `vp check`
- `git diff --check`
- reviewed `.changeset/pre.json` diff contains only `mode: pre` to `mode: exit`

fix #368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Completed the active pre-release cycle and returned the project to its standard release mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->