### PR TITLE
Preserve ignored apps during release versioning

### DIFF
--- a/scripts/release-orchestrator.test.mjs
+++ b/scripts/release-orchestrator.test.mjs
@@ -425,6 +425,10 @@ test("stable version generation preserves ignored private applications", async (
     ],
     { cwd: directory },
   );
+  const fixtureCommit = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
+    cwd: directory,
+    encoding: "utf8",
+  }).trim();
 
   versionPackages({
     rootDir: directory,
@@ -436,6 +440,10 @@ test("stable version generation preserves ignored private applications", async (
     await readFile(join(directory, "packages", "fixture", "package.json"), "utf8"),
   );
   assert.equal(publicManifest.version, "1.1.0");
+  assert.equal(
+    await readFile(join(directory, "packages", "fixture", "CHANGELOG.md"), "utf8"),
+    `# fixture-package\n\n## 1.1.0\n\n### Minor Changes\n\n- ${fixtureCommit}: Add a fixture feature.\n`,
+  );
   assert.equal(
     await readFile(join(directory, "apps", "unversioned", "package.json"), "utf8"),
     unversionedManifest,

--- a/scripts/release-orchestrator.test.mjs
+++ b/scripts/release-orchestrator.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -326,4 +326,127 @@ test("version generation formats one-item prerelease state deterministically", a
 
   versionPackages(options);
   assert.equal(await readFile(join(directory, ".changeset", "pre.json"), "utf8"), preState);
+});
+
+test("stable version generation preserves ignored private applications", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "calavera-version-exit-fixture-"));
+  await mkdir(join(directory, ".changeset"));
+  await mkdir(join(directory, "packages", "fixture"), { recursive: true });
+  await mkdir(join(directory, "apps", "unversioned"), { recursive: true });
+  await mkdir(join(directory, "apps", "versioned"), { recursive: true });
+  await writeFile(
+    join(directory, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "release-exit-fixture",
+        private: true,
+        workspaces: ["packages/*", "apps/*"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(join(directory, ".oxfmtrc.json"), "{}\n");
+  await writeFile(
+    join(directory, ".changeset", "config.json"),
+    `${JSON.stringify(
+      {
+        $schema: "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+        changelog: "@changesets/cli/changelog",
+        commit: false,
+        fixed: [],
+        linked: [],
+        access: "public",
+        baseBranch: "main",
+        updateInternalDependencies: "patch",
+        ignore: ["unversioned-app", "versioned-app"],
+        privatePackages: {
+          version: false,
+          tag: false,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(
+    join(directory, ".changeset", "pre.json"),
+    `${JSON.stringify(
+      {
+        mode: "exit",
+        tag: "next",
+        initialVersions: {
+          "fixture-package": "1.0.0",
+          "versioned-app": "0.1.0",
+        },
+        changesets: ["one-change"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(
+    join(directory, ".changeset", "one-change.md"),
+    `---\n"fixture-package": minor\n---\n\nAdd a fixture feature.\n`,
+  );
+  await writeFile(
+    join(directory, "packages", "fixture", "package.json"),
+    `${JSON.stringify({ name: "fixture-package", version: "1.1.0-next.0" }, null, 2)}\n`,
+  );
+  const unversionedManifest = `${JSON.stringify(
+    { name: "unversioned-app", private: true },
+    null,
+    2,
+  )}\n`;
+  const versionedManifest = `${JSON.stringify(
+    { name: "versioned-app", version: "0.1.0", private: true },
+    null,
+    2,
+  )}\n`;
+  const versionedChangelog = "# Existing private app history\n";
+  await writeFile(join(directory, "apps", "unversioned", "package.json"), unversionedManifest);
+  await writeFile(join(directory, "apps", "versioned", "package.json"), versionedManifest);
+  await writeFile(join(directory, "apps", "versioned", "CHANGELOG.md"), versionedChangelog);
+
+  execFileSync("git", ["init", "-b", "main"], { cwd: directory });
+  execFileSync("git", ["add", "."], { cwd: directory });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=Calavera Test",
+      "-c",
+      "user.email=calavera@example.invalid",
+      "-c",
+      "commit.gpgsign=false",
+      "commit",
+      "-m",
+      "fixture",
+    ],
+    { cwd: directory },
+  );
+
+  versionPackages({
+    rootDir: directory,
+    changesetBin: join(root, "node_modules", ".bin", "changeset"),
+    formatterBin: join(root, "node_modules", ".bin", "oxfmt"),
+  });
+
+  const publicManifest = JSON.parse(
+    await readFile(join(directory, "packages", "fixture", "package.json"), "utf8"),
+  );
+  assert.equal(publicManifest.version, "1.1.0");
+  assert.equal(
+    await readFile(join(directory, "apps", "unversioned", "package.json"), "utf8"),
+    unversionedManifest,
+  );
+  assert.equal(
+    await readFile(join(directory, "apps", "versioned", "package.json"), "utf8"),
+    versionedManifest,
+  );
+  assert.equal(
+    await readFile(join(directory, "apps", "versioned", "CHANGELOG.md"), "utf8"),
+    versionedChangelog,
+  );
+  await assert.rejects(access(join(directory, "apps", "unversioned", "CHANGELOG.md")), /ENOENT/);
 });

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { extname, join, resolve } from "node:path";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = fileURLToPath(new URL("..", import.meta.url));
@@ -28,6 +28,43 @@ function capturePendingPaths(rootDir) {
   ];
 }
 
+function captureIgnoredPackages(rootDir) {
+  const config = JSON.parse(readFileSync(join(rootDir, ".changeset", "config.json"), "utf8"));
+  const ignoredPackages = new Set(config.ignore ?? []);
+
+  return captureGitPaths(rootDir, ["ls-files", "--", ":(glob)**/package.json"])
+    .map((manifestPath) => {
+      const manifestContents = readFileSync(join(rootDir, manifestPath));
+      const manifest = JSON.parse(manifestContents);
+      const changelogPath = join(dirname(manifestPath), "CHANGELOG.md");
+
+      return {
+        name: manifest.name,
+        manifestPath,
+        manifestContents,
+        changelogPath,
+        changelogContents: existsSync(join(rootDir, changelogPath))
+          ? readFileSync(join(rootDir, changelogPath))
+          : undefined,
+      };
+    })
+    .filter(({ name }) => ignoredPackages.has(name));
+}
+
+function restoreIgnoredPackages(rootDir, packages) {
+  for (const { manifestPath, manifestContents, changelogPath, changelogContents } of packages) {
+    writeFileSync(join(rootDir, manifestPath), manifestContents);
+
+    if (changelogContents === undefined) {
+      if (existsSync(join(rootDir, changelogPath))) {
+        unlinkSync(join(rootDir, changelogPath));
+      }
+    } else {
+      writeFileSync(join(rootDir, changelogPath), changelogContents);
+    }
+  }
+}
+
 export function versionPackages(options = {}) {
   const rootDir = options.rootDir ?? root;
   const changesetBin = options.changesetBin ?? join(root, "node_modules", ".bin", "changeset");
@@ -36,7 +73,12 @@ export function versionPackages(options = {}) {
   const pathsBeforeVersioning = new Map(
     capturePendingPaths(rootDir).map((path) => [path, readFileSync(join(rootDir, path))]),
   );
-  execFileSync(changesetBin, ["version"], { cwd: rootDir, stdio: "inherit" });
+  const ignoredPackages = captureIgnoredPackages(rootDir);
+  try {
+    execFileSync(changesetBin, ["version"], { cwd: rootDir, stdio: "inherit" });
+  } finally {
+    restoreIgnoredPackages(rootDir, ignoredPackages);
+  }
 
   const generatedPaths = capturePendingPaths(rootDir).filter((path) => {
     const previousContents = pathsBeforeVersioning.get(path);


### PR DESCRIPTION
## Summary

- snapshot Changesets-ignored workspace manifests and changelogs before version generation
- restore ignored private apps exactly after Changesets runs, including removing newly generated changelogs
- add prerelease-exit regression coverage for both unversioned and versioned private applications

## Validation

- `npm run release:contracts`
- `vp check`
- `npm run typecheck`
- `npm run knip`
- `git diff --check`

After this merges, the generated stable release PR must refresh without the private app `null` versions before the release gates restart.

fix #371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release versioning to preserve ignored package files during Changesets processing.
  * Ensured ignored private applications remain unversioned and do not receive changelogs.
  * Guaranteed ignored package files are restored even if versioning encounters an error.

* **Tests**
  * Added integration coverage for stable version generation and ignored package handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->