### PR TITLE
Capture release fixture subprocess output

### DIFF
--- a/scripts/release-orchestrator.test.mjs
+++ b/scripts/release-orchestrator.test.mjs
@@ -302,6 +302,7 @@ test("version generation formats one-item prerelease state deterministically", a
     rootDir: directory,
     changesetBin: join(root, "node_modules", ".bin", "changeset"),
     formatterBin: join(root, "node_modules", ".bin", "oxfmt"),
+    commandStdio: "pipe",
   };
   versionPackages(options);
 
@@ -434,6 +435,7 @@ test("stable version generation preserves ignored private applications", async (
     rootDir: directory,
     changesetBin: join(root, "node_modules", ".bin", "changeset"),
     formatterBin: join(root, "node_modules", ".bin", "oxfmt"),
+    commandStdio: "pipe",
   });
 
   const publicManifest = JSON.parse(

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -69,13 +69,14 @@ export function versionPackages(options = {}) {
   const rootDir = options.rootDir ?? root;
   const changesetBin = options.changesetBin ?? join(root, "node_modules", ".bin", "changeset");
   const formatterBin = options.formatterBin ?? join(root, "node_modules", ".bin", "oxfmt");
+  const commandStdio = options.commandStdio ?? "inherit";
 
   const pathsBeforeVersioning = new Map(
     capturePendingPaths(rootDir).map((path) => [path, readFileSync(join(rootDir, path))]),
   );
   const ignoredPackages = captureIgnoredPackages(rootDir);
   try {
-    execFileSync(changesetBin, ["version"], { cwd: rootDir, stdio: "inherit" });
+    execFileSync(changesetBin, ["version"], { cwd: rootDir, stdio: commandStdio });
   } finally {
     restoreIgnoredPackages(rootDir, ignoredPackages);
   }
@@ -93,7 +94,7 @@ export function versionPackages(options = {}) {
   if (formatPaths.length > 0) {
     execFileSync(formatterBin, ["--write", ...formatPaths], {
       cwd: rootDir,
-      stdio: "inherit",
+      stdio: commandStdio,
     });
   }
 }


### PR DESCRIPTION
## Summary

- allow release-version subprocess stdio to be configured while retaining visible production output by default
- capture Changesets and formatter output only in temporary release test fixtures
- remove misleading prerelease warnings from stable release rehearsals

## Validation

- `npm run release:contracts`
- `vp check`
- `npm run typecheck`
- `npm run knip`
- `git diff --check`

fix #373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release versioning reliability by allowing command output handling to be configured during automated version generation.
  * Preserved existing default behavior while ensuring versioning and formatting commands run consistently in test and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->