### PR TITLE
Add composer spacing tokens

### DIFF
--- a/apps/composer/styles.css
+++ b/apps/composer/styles.css
@@ -24,6 +24,8 @@
   --marigold: #f5c85b;
   --outline: #26324d;
   --muted: #6c594e;
+  --border-radius-default: 0.5rem;
+  --space-xxs: 0.25rem;
   --space-xs: 0.5rem;
   --space-sm: 0.625rem;
   --space-md: 0.75rem;
@@ -79,7 +81,8 @@ select {
   background: rgb(47 129 112 / 9%);
   border-inline-start: 0.25rem solid var(--teal);
   margin-block-start: var(--space-xl);
-  padding: var(--space-lg) var(--space-xl);
+  padding-block: var(--space-lg);
+  padding-inline: var(--space-xl);
 }
 
 .integration-options h2,
@@ -122,7 +125,7 @@ a:hover {
 .webmcp-banner {
   background: rgb(255 250 240 / 76%);
   border: 0.0625rem solid rgb(47 129 112 / 42%);
-  border-radius: 0.5rem;
+  border-radius: var(--border-radius-default);
   color: var(--teal-deep);
   font-size: 0.9rem;
   font-weight: 700;
@@ -182,7 +185,7 @@ h1 {
 .panel {
   background: linear-gradient(135deg, rgb(255 255 255 / 72%), rgb(255 244 216 / 86%)), var(--paper);
   border: 0.125rem solid var(--outline);
-  border-radius: 0.5rem;
+  border-radius: var(--border-radius-default);
   box-shadow: 0.5rem 0.5rem 0 rgb(22 25 47 / 14%);
   min-inline-size: 0;
   padding: var(--space-2xl);
@@ -201,7 +204,7 @@ fieldset {
   color: var(--muted);
   font-size: 0.9rem;
   line-height: 1.5;
-  margin-block: -0.25rem var(--space-md);
+  margin-block: calc(var(--space-xxs) * -1) var(--space-md);
   margin-inline: 0;
 }
 
@@ -260,7 +263,7 @@ select:focus-visible {
   font-size: 0.84rem;
   font-weight: 700;
   margin-block-start: var(--space-xs);
-  padding-inline-start: 1.35rem;
+  padding-inline-start: var(--space-2xl);
 }
 
 .artifact-target input {
@@ -270,7 +273,7 @@ select:focus-visible {
   color: var(--ink);
   display: block;
   inline-size: 100%;
-  margin-block-start: 0.25rem;
+  margin-block-start: var(--space-xxs);
   padding-block: 0.45rem;
   padding-inline: 0.55rem;
 }
@@ -289,7 +292,7 @@ select:focus-visible {
 .integration-group {
   background: rgb(255 250 240 / 72%);
   border: 0.0625rem solid rgb(38 50 77 / 28%);
-  border-radius: 0.5rem;
+  border-radius: var(--border-radius-default);
   min-inline-size: 0;
   padding: var(--space-lg);
 }
@@ -416,7 +419,7 @@ code {
 
 pre {
   background: linear-gradient(180deg, rgb(232 93 81 / 8%), transparent 34%), var(--ink);
-  border-radius: 0.5rem;
+  border-radius: var(--border-radius-default);
   box-shadow: inset 0 0 0 0.0625rem rgb(245 200 91 / 20%);
   color: #fff4d8;
   margin-block: 0;

--- a/apps/composer/styles.css
+++ b/apps/composer/styles.css
@@ -24,6 +24,12 @@
   --marigold: #f5c85b;
   --outline: #26324d;
   --muted: #6c594e;
+  --space-xs: 0.5rem;
+  --space-sm: 0.625rem;
+  --space-md: 0.75rem;
+  --space-lg: 0.875rem;
+  --space-xl: 1rem;
+  --space-2xl: 1.25rem;
 }
 
 * {
@@ -72,13 +78,13 @@ select {
 .integration-options {
   background: rgb(47 129 112 / 9%);
   border-inline-start: 0.25rem solid var(--teal);
-  margin-block-start: 1rem;
-  padding: 0.875rem 1rem;
+  margin-block-start: var(--space-xl);
+  padding: var(--space-lg) var(--space-xl);
 }
 
 .integration-options h2,
 .integration-options p {
-  margin-block: 0 0.5rem;
+  margin-block: 0 var(--space-xs);
 }
 
 .integration-options h2 {
@@ -88,7 +94,7 @@ select {
 
 .option-grid {
   display: grid;
-  gap: 0.75rem;
+  gap: var(--space-md);
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
@@ -121,10 +127,10 @@ a:hover {
   font-size: 0.9rem;
   font-weight: 700;
   line-height: 1.4;
-  margin-block: 0 1.25rem;
+  margin-block: 0 var(--space-2xl);
   margin-inline: 0;
-  padding-block: 0.625rem;
-  padding-inline: 0.875rem;
+  padding-block: var(--space-sm);
+  padding-inline: var(--space-lg);
 }
 
 [hidden] {
@@ -141,7 +147,7 @@ a:hover {
   font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.12em;
-  margin-block: 0 0.5rem;
+  margin-block: 0 var(--space-xs);
   margin-inline: 0;
   text-transform: uppercase;
 }
@@ -168,7 +174,7 @@ h1 {
 .workspace {
   align-items: start;
   display: grid;
-  gap: 1.25rem;
+  gap: var(--space-2xl);
   grid-template-columns: minmax(0, 1.1fr) minmax(20rem, 0.9fr);
   min-inline-size: 0;
 }
@@ -179,7 +185,7 @@ h1 {
   border-radius: 0.5rem;
   box-shadow: 0.5rem 0.5rem 0 rgb(22 25 47 / 14%);
   min-inline-size: 0;
-  padding: 1.25rem;
+  padding: var(--space-2xl);
 }
 
 fieldset {
@@ -195,7 +201,7 @@ fieldset {
   color: var(--muted);
   font-size: 0.9rem;
   line-height: 1.5;
-  margin-block: -0.25rem 0.75rem;
+  margin-block: -0.25rem var(--space-md);
   margin-inline: 0;
 }
 
@@ -204,13 +210,13 @@ legend,
   color: var(--teal-deep);
   display: block;
   font-weight: 700;
-  margin-block-end: 0.75rem;
+  margin-block-end: var(--space-md);
 }
 
 label {
   display: block;
   line-height: 1.4;
-  margin-block: 0.625rem;
+  margin-block: var(--space-sm);
   margin-inline: 0;
 }
 
@@ -229,9 +235,9 @@ select {
   color: var(--ink);
   display: block;
   inline-size: 100%;
-  margin-block-start: 0.5rem;
-  padding-block: 0.625rem;
-  padding-inline: 0.75rem;
+  margin-block-start: var(--space-xs);
+  padding-block: var(--space-sm);
+  padding-inline: var(--space-md);
 }
 
 input:focus-visible,
@@ -241,7 +247,7 @@ select:focus-visible {
 }
 
 .artifact-option {
-  margin-block: 0.625rem;
+  margin-block: var(--space-sm);
   margin-inline: 0;
 }
 
@@ -253,7 +259,7 @@ select:focus-visible {
   color: var(--muted);
   font-size: 0.84rem;
   font-weight: 700;
-  margin-block-start: 0.5rem;
+  margin-block-start: var(--space-xs);
   padding-inline-start: 1.35rem;
 }
 
@@ -275,7 +281,7 @@ select:focus-visible {
 
 .integrations {
   display: grid;
-  gap: 1rem;
+  gap: var(--space-xl);
   grid-template-columns: repeat(2, minmax(0, 1fr));
   min-inline-size: 0;
 }
@@ -285,13 +291,13 @@ select:focus-visible {
   border: 0.0625rem solid rgb(38 50 77 / 28%);
   border-radius: 0.5rem;
   min-inline-size: 0;
-  padding: 0.875rem;
+  padding: var(--space-lg);
 }
 
 .integration-group h2 {
   color: var(--ink);
   font-size: 0.94rem;
-  margin-block: 0 0.625rem;
+  margin-block: 0 var(--space-sm);
   margin-inline: 0;
 }
 
@@ -303,15 +309,15 @@ small {
 }
 
 .preview {
-  inset-block-start: 1.25rem;
+  inset-block-start: var(--space-2xl);
   position: sticky;
 }
 
 .actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.625rem;
-  margin-block-end: 1rem;
+  gap: var(--space-sm);
+  margin-block-end: var(--space-xl);
 }
 
 button {
@@ -323,7 +329,7 @@ button {
   cursor: pointer;
   min-block-size: 2.625rem;
   padding-block: 0;
-  padding-inline: 0.875rem;
+  padding-inline: var(--space-lg);
 }
 
 button + button {
@@ -349,14 +355,14 @@ code {
 
 .next-commands {
   border-block: 0.0625rem solid rgb(38 50 77 / 24%);
-  margin-block: 1rem;
-  padding-block: 1rem;
+  margin-block: var(--space-xl);
+  padding-block: var(--space-xl);
 }
 
 .next-commands h2 {
   color: var(--ink);
   font-size: 1rem;
-  margin-block: 0 0.5rem;
+  margin-block: 0 var(--space-xs);
   margin-inline: 0;
 }
 
@@ -364,13 +370,13 @@ code {
   color: var(--muted);
   font-size: 0.92rem;
   line-height: 1.45;
-  margin-block: 0 0.75rem;
+  margin-block: 0 var(--space-md);
   margin-inline: 0;
 }
 
 .next-commands ol {
   display: grid;
-  gap: 0.875rem;
+  gap: var(--space-lg);
   list-style-position: outside;
   list-style-type: decimal-leading-zero;
   margin-block: 0;
@@ -403,8 +409,8 @@ code {
   color: var(--ink);
   display: block;
   overflow-x: auto;
-  padding-block: 0.5rem;
-  padding-inline: 0.625rem;
+  padding-block: var(--space-xs);
+  padding-inline: var(--space-sm);
   white-space: nowrap;
 }
 
@@ -417,7 +423,7 @@ pre {
   margin-inline: 0;
   max-block-size: 72vh;
   overflow: auto;
-  padding: 1rem;
+  padding: var(--space-xl);
 }
 
 @media (width <= 53.75em) {


### PR DESCRIPTION
Introduces a small spacing scale for the composer and replaces recurring margin, padding, gap, and offset values without changing the layout.

Checks:
- `pnpm exec stylelint apps/composer/styles.css`
- `pnpm exec oxfmt --check apps/composer/styles.css`
- `pnpm --filter @calavera/composer test`
- `pnpm --filter @calavera/composer build`
- desktop and mobile browser checks

fix #177


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved and standardized spacing and corner rounding across the composer interface.
  * Updated layouts, panels, controls, buttons, code blocks, and previews for more consistent visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->