### PR TITLE
Restrict the technical devil's advocate to read-only planning

### DIFF
--- a/packages/artifacts/agent-technical-devils-advocate/payload/technical-devils-advocate.md
+++ b/packages/artifacts/agent-technical-devils-advocate/payload/technical-devils-advocate.md
@@ -2,6 +2,8 @@
 name: technical-devils-advocate
 model: opus
 effort: high
+permissionMode: plan
+tools: Read, Glob, Grep
 description: Technical devil's advocate that challenges feature plans, strategies, and implementation approaches. Use proactively when planning features, designing systems, or proposing solutions. ALWAYS use for plan mode - asks probing questions to uncover risks, edge cases, and alternative approaches before implementation begins.
 ---
 

--- a/packages/cli/scripts/check-config-schema.test.mjs
+++ b/packages/cli/scripts/check-config-schema.test.mjs
@@ -3571,6 +3571,43 @@ test("Codex agent adapter emits required TOML fields without Claude model metada
   assert.doesNotMatch(toml, /claude-4\.6-opus-high-thinking/);
 });
 
+test("Claude Code agent adapter preserves the read-only allowlist and payload hash", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-claude-agent-"));
+  const source = await readFile(artifactPayloadPath("agent-technical-devils-advocate"), "utf8");
+
+  try {
+    process.chdir(projectDirectory);
+    const result = await buildAiApplyResult(
+      {
+        ai: [
+          {
+            type: "agent",
+            src: "agents/technical-devils-advocate.md",
+            target: "claude-code",
+          },
+        ],
+      },
+      { dryRun: false },
+      createEmptyState(),
+    );
+    const installed = await readFile(
+      ".agents/agents/claude-code/technical-devils-advocate.md",
+      "utf8",
+    );
+
+    assert.equal(installed, source);
+    assert.match(installed, /^model: opus$/m);
+    assert.match(installed, /^permissionMode: plan$/m);
+    assert.match(installed, /^tools: Read, Glob, Grep$/m);
+    assert.doesNotMatch(installed, /^tools:.*(?:Write|Edit|Bash)/m);
+    assert.equal(result.artifacts[0].hash, textHash(source));
+  } finally {
+    process.chdir(originalDirectory);
+    await rm(projectDirectory, { force: true, recursive: true });
+  }
+});
+
 test("Codex-targeted agent recipes resolve to .codex custom-agent TOML", async () => {
   const result = await buildAiApplyResult(
     {

--- a/packages/cli/scripts/check-config-schema.test.mjs
+++ b/packages/cli/scripts/check-config-schema.test.mjs
@@ -5,6 +5,7 @@ import {
   cp,
   mkdir,
   mkdtemp,
+  mkdtempDisposable,
   readFile,
   rm,
   stat,
@@ -3573,11 +3574,11 @@ test("Codex agent adapter emits required TOML fields without Claude model metada
 
 test("Claude Code agent adapter preserves the read-only allowlist and payload hash", async () => {
   const originalDirectory = process.cwd();
-  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-claude-agent-"));
   const source = await readFile(artifactPayloadPath("agent-technical-devils-advocate"), "utf8");
+  await using projectDirectory = await mkdtempDisposable(join(tmpdir(), "calavera-claude-agent-"));
 
   try {
-    process.chdir(projectDirectory);
+    process.chdir(projectDirectory.path);
     const result = await buildAiApplyResult(
       {
         ai: [
@@ -3604,7 +3605,6 @@ test("Claude Code agent adapter preserves the read-only allowlist and payload ha
     assert.equal(result.artifacts[0].hash, textHash(source));
   } finally {
     process.chdir(originalDirectory);
-    await rm(projectDirectory, { force: true, recursive: true });
   }
 });
 


### PR DESCRIPTION
## Summary

- Configure the technical devil's advocate for plan-only execution.
- Restrict Claude Code access to Read, Glob, and Grep.
- Add coverage for the read-only allowlist and payload hash.

## Testing

- Added a unit test covering Claude Code artifact installation, permissions, tool access, and payload hashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The technical review agent now operates in plan mode.
  - Its capabilities are limited to reading and searching information, helping ensure it cannot modify project files.
  - Agent configuration now preserves its original source and records essential setup details for reliable installations.

- **Tests**
  - Added verification that installation preserves the original configuration and required read-only metadata.
  - Added checks confirming write-capable tools are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->