### PR TITLE
Add GitHub repository controls configuration

### DIFF
--- a/.changeset/gentle-dogs-govern.md
+++ b/.changeset/gentle-dogs-govern.md
@@ -1,0 +1,7 @@
+---
+"create-project-calavera": minor
+---
+
+Add an optional GitHub repository-controls integration that generates managed desired-state,
+Dependabot, audit/apply script, and documentation files without mutating GitHub during Calavera
+apply.

--- a/README.md
+++ b/README.md
@@ -227,10 +227,11 @@ the wrong remote:
 }
 ```
 
-`calavera apply` only writes local files and package scripts. Run `repo:controls:check` for a
-read-only GitHub drift report, then run `repo:controls:apply` separately after reviewing the plan.
-The apply command requires confirmation unless `--yes` is passed explicitly. GitHub features that
-are unavailable for the repository or plan are reported as unsupported rather than ordinary drift.
+`calavera apply` only writes local files and package scripts. Run `npm run repo:controls:check` for
+a read-only GitHub drift report, then run `npm run repo:controls:apply` separately after reviewing
+the plan. The apply command requires confirmation unless you pass `--yes` explicitly, for example
+`npm run repo:controls:apply -- --yes`. GitHub features that are unavailable for the repository or
+plan are reported as unsupported rather than ordinary drift.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Calavera includes curated integration packs grouped by outcome:
 - CSS property ordering
 - CSS property type validation
 - Environment variable schema and validation with [Varlock](https://varlock.dev)
+- GitHub repository governance, security settings, and drift checks
 
 React best-practice checks can include React Doctor, a deterministic scanner for
 React codebases that complements linting with security, performance,
@@ -204,6 +205,32 @@ uses that metadata when generating `.stylelintrc.json`.
 See
 [`docs/contributing-calavera-integration-varlock.md`](docs/contributing-calavera-integration-varlock.md)
 for a contributor walkthrough based on Theo Ephraim's Varlock integration.
+
+### GitHub repository controls
+
+The optional `github-repository-controls` integration generates a committed desired-state policy,
+Dependabot configuration, a portable Node.js administration script, and setup documentation. A
+recipe must identify the expected repository so the generated script can refuse to operate against
+the wrong remote:
+
+```json
+{
+  "integrations": ["github-repository-controls"],
+  "integrationOptions": {
+    "github-repository-controls": {
+      "repository": "octocat/example",
+      "requiredChecks": ["quality"],
+      "mergeMethods": ["squash"],
+      "codeqlLanguages": ["actions", "javascript-typescript"]
+    }
+  }
+}
+```
+
+`calavera apply` only writes local files and package scripts. Run `repo:controls:check` for a
+read-only GitHub drift report, then run `repo:controls:apply` separately after reviewing the plan.
+The apply command requires confirmation unless `--yes` is passed explicitly. GitHub features that
+are unavailable for the repository or plan are reported as unsupported rather than ordinary drift.
 
 ## CLI
 

--- a/apps/composer/index.html
+++ b/apps/composer/index.html
@@ -112,6 +112,33 @@
                 >.
               </p>
             </section>
+            <section id="repository-controls-options" class="integration-options" hidden>
+              <h2>GitHub repository controls</h2>
+              <div class="option-grid">
+                <label for="repository-controls-repository">
+                  Repository (owner/name)
+                  <input
+                    id="repository-controls-repository"
+                    name="repositoryControlsRepository"
+                    placeholder="octocat/example"
+                    autocomplete="off"
+                  />
+                </label>
+                <label for="repository-controls-required-checks">
+                  Required checks (comma-separated)
+                  <input
+                    id="repository-controls-required-checks"
+                    name="repositoryControlsRequiredChecks"
+                    placeholder="quality"
+                    autocomplete="off"
+                  />
+                </label>
+              </div>
+              <p>
+                Calavera generates local desired-state tooling only. Applying remote GitHub changes
+                remains a separate, confirmed command.
+              </p>
+            </section>
           </fieldset>
 
           <fieldset>

--- a/apps/composer/package.json
+++ b/apps/composer/package.json
@@ -12,6 +12,7 @@
     "semver": "7.8.5"
   },
   "devDependencies": {
+    "ajv": "8.20.0",
     "vite": "^8.1.5"
   }
 }

--- a/apps/composer/public/calavera.config.schema.json
+++ b/apps/composer/public/calavera.config.schema.json
@@ -43,6 +43,9 @@
       "properties": {
         "stylelint-baseline": {
           "$ref": "#/$defs/stylelintBaselineOptions"
+        },
+        "github-repository-controls": {
+          "$ref": "#/$defs/githubRepositoryControlsOptions"
         }
       }
     },
@@ -108,6 +111,49 @@
           }
         }
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "integrationOptions": {
+            "type": "object",
+            "required": ["github-repository-controls"]
+          }
+        },
+        "required": ["integrationOptions"]
+      },
+      "then": {
+        "properties": {
+          "integrations": {
+            "type": "array",
+            "contains": {
+              "const": "github-repository-controls"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "integrations": {
+            "type": "array",
+            "contains": {
+              "const": "github-repository-controls"
+            }
+          }
+        },
+        "required": ["integrations"]
+      },
+      "then": {
+        "required": ["integrationOptions"],
+        "properties": {
+          "integrationOptions": {
+            "type": "object",
+            "required": ["github-repository-controls"]
+          }
+        }
+      }
     }
   ],
   "$defs": {
@@ -136,6 +182,106 @@
         }
       }
     },
+    "githubRepositoryControlsOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "defaultBranch": {
+          "type": "string",
+          "minLength": 1,
+          "default": "main"
+        },
+        "requiredChecks": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 },
+          "default": []
+        },
+        "mergeMethods": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "enum": ["merge", "squash", "rebase"] },
+          "default": ["squash"]
+        },
+        "wiki": { "type": "boolean", "default": false },
+        "projects": { "type": "boolean", "default": false },
+        "autoMerge": { "type": "boolean", "default": true },
+        "deleteBranchOnMerge": { "type": "boolean", "default": true },
+        "updateBranch": { "type": "boolean", "default": true },
+        "dependabotEcosystems": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "enum": ["npm", "github-actions"] },
+          "default": ["npm", "github-actions"]
+        },
+        "codeqlLanguages": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "actions",
+              "c-cpp",
+              "csharp",
+              "go",
+              "java-kotlin",
+              "javascript-typescript",
+              "python",
+              "ruby",
+              "swift"
+            ]
+          },
+          "default": ["actions", "javascript-typescript"]
+        },
+        "codeqlQuerySuite": {
+          "type": "string",
+          "enum": ["default", "extended"],
+          "default": "default"
+        },
+        "releaseEnvironment": {
+          "oneOf": [
+            { "const": false },
+            { "type": "null" },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["reviewers"],
+              "properties": {
+                "name": { "type": "string", "minLength": 1, "default": "release" },
+                "reviewers": {
+                  "type": "array",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": { "type": "string", "minLength": 1 }
+                },
+                "waitTimer": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 43200,
+                  "default": 0
+                },
+                "preventSelfReview": { "type": "boolean", "default": false },
+                "branches": {
+                  "type": "array",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          ],
+          "default": false
+        }
+      }
+    },
     "integrationId": {
       "type": "string",
       "enum": [
@@ -144,6 +290,7 @@
         "knip",
         "html-validate",
         "varlock",
+        "github-repository-controls",
         "oxlint",
         "oxlint-eslint",
         "oxlint-typescript",

--- a/apps/composer/repository-controls-input-schema.js
+++ b/apps/composer/repository-controls-input-schema.js
@@ -1,0 +1,18 @@
+export const releaseEnvironmentInputSchema = {
+  oneOf: [
+    { const: false },
+    { type: "null" },
+    {
+      type: "object",
+      additionalProperties: false,
+      required: ["reviewers"],
+      properties: {
+        name: { type: "string" },
+        reviewers: { type: "array", items: { type: "string" } },
+        waitTimer: { type: "integer", minimum: 0, maximum: 43200 },
+        preventSelfReview: { type: "boolean" },
+        branches: { type: "array", items: { type: "string" } },
+      },
+    },
+  ],
+};

--- a/apps/composer/script.js
+++ b/apps/composer/script.js
@@ -47,6 +47,7 @@ const nextCommandsNote = document.querySelector("#next-commands-note");
 const webMcpBanner = document.querySelector("#webmcp-banner");
 const baselineOptions = document.querySelector("#baseline-options");
 const baselineAvailable = document.querySelector("#baseline-available");
+const repositoryControlsOptions = document.querySelector("#repository-controls-options");
 const cliCompatibilityNote = document.querySelector("#cli-compatibility");
 const profiles = profileIdsForRecipe();
 const packageManagers = packageManagerIdsForRecipe();
@@ -208,6 +209,16 @@ function syncIntegrationOptions() {
     form.querySelector('[name="integration"][value="stylelint-baseline"]:checked'),
   );
   baselineOptions.hidden = !enabled;
+  repositoryControlsOptions.hidden = !form.querySelector(
+    '[name="integration"][value="github-repository-controls"]:checked',
+  );
+}
+
+function commaSeparatedValues(value) {
+  return String(value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
 }
 
 function selectedAiItems() {
@@ -230,16 +241,32 @@ function recipe() {
   const packageManager = data.get("packageManager");
 
   const hasBaseline = data.getAll("integration").includes("stylelint-baseline");
-  const integrationOptions = hasBaseline
-    ? {
-        "stylelint-baseline": {
-          available: /^\d{4}$/.test(String(data.get("baselineAvailable")))
-            ? Number(data.get("baselineAvailable"))
-            : data.get("baselineAvailable"),
-          severity: data.get("baselineSeverity"),
-        },
-      }
-    : undefined;
+  const hasRepositoryControls = data.getAll("integration").includes("github-repository-controls");
+  const integrationOptions =
+    hasBaseline || hasRepositoryControls
+      ? {
+          ...(hasBaseline
+            ? {
+                "stylelint-baseline": {
+                  available: /^\d{4}$/.test(String(data.get("baselineAvailable")))
+                    ? Number(data.get("baselineAvailable"))
+                    : data.get("baselineAvailable"),
+                  severity: data.get("baselineSeverity"),
+                },
+              }
+            : {}),
+          ...(hasRepositoryControls
+            ? {
+                "github-repository-controls": {
+                  repository: data.get("repositoryControlsRepository"),
+                  requiredChecks: commaSeparatedValues(
+                    data.get("repositoryControlsRequiredChecks"),
+                  ),
+                },
+              }
+            : {}),
+        }
+      : undefined;
 
   return buildRecipe(
     String(data.get("profile") ?? ""),
@@ -275,7 +302,11 @@ function renderNextCommands() {
 }
 
 function render() {
-  output.textContent = JSON.stringify(recipe(), null, 2);
+  try {
+    output.textContent = JSON.stringify(recipe(), null, 2);
+  } catch (error) {
+    output.textContent = error instanceof Error ? error.message : String(error);
+  }
   renderNextCommands();
 }
 
@@ -587,6 +618,70 @@ function registerWebMcpTools() {
                     oneOf: [{ type: "string", enum: ["widely", "newly"] }, { type: "integer" }],
                   },
                   severity: { type: "string", enum: ["warning", "error"] },
+                },
+              },
+              "github-repository-controls": {
+                type: "object",
+                additionalProperties: false,
+                required: ["repository"],
+                properties: {
+                  repository: {
+                    type: "string",
+                    pattern: "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$",
+                  },
+                  requiredChecks: {
+                    type: "array",
+                    items: { type: "string" },
+                  },
+                  defaultBranch: { type: "string" },
+                  mergeMethods: {
+                    type: "array",
+                    items: { type: "string", enum: ["merge", "squash", "rebase"] },
+                  },
+                  wiki: { type: "boolean" },
+                  projects: { type: "boolean" },
+                  autoMerge: { type: "boolean" },
+                  deleteBranchOnMerge: { type: "boolean" },
+                  updateBranch: { type: "boolean" },
+                  dependabotEcosystems: {
+                    type: "array",
+                    items: { type: "string", enum: ["npm", "github-actions"] },
+                  },
+                  codeqlLanguages: {
+                    type: "array",
+                    items: {
+                      type: "string",
+                      enum: [
+                        "actions",
+                        "c-cpp",
+                        "csharp",
+                        "go",
+                        "java-kotlin",
+                        "javascript-typescript",
+                        "python",
+                        "ruby",
+                        "swift",
+                      ],
+                    },
+                  },
+                  codeqlQuerySuite: { type: "string", enum: ["default", "extended"] },
+                  releaseEnvironment: {
+                    oneOf: [
+                      { const: false },
+                      {
+                        type: "object",
+                        additionalProperties: false,
+                        required: ["reviewers"],
+                        properties: {
+                          name: { type: "string" },
+                          reviewers: { type: "array", items: { type: "string" } },
+                          waitTimer: { type: "integer", minimum: 0, maximum: 43200 },
+                          preventSelfReview: { type: "boolean" },
+                          branches: { type: "array", items: { type: "string" } },
+                        },
+                      },
+                    ],
+                  },
                 },
               },
             },

--- a/apps/composer/script.js
+++ b/apps/composer/script.js
@@ -37,6 +37,7 @@ import {
   loadPublishedCliCompatibility,
   SAFE_CLI_FALLBACK_VERSION,
 } from "./cli-compatibility.js";
+import { releaseEnvironmentInputSchema } from "./repository-controls-input-schema.js";
 
 const form = document.querySelector("#composer");
 const integrations = document.querySelector("#integrations");
@@ -665,23 +666,7 @@ function registerWebMcpTools() {
                     },
                   },
                   codeqlQuerySuite: { type: "string", enum: ["default", "extended"] },
-                  releaseEnvironment: {
-                    oneOf: [
-                      { const: false },
-                      {
-                        type: "object",
-                        additionalProperties: false,
-                        required: ["reviewers"],
-                        properties: {
-                          name: { type: "string" },
-                          reviewers: { type: "array", items: { type: "string" } },
-                          waitTimer: { type: "integer", minimum: 0, maximum: 43200 },
-                          preventSelfReview: { type: "boolean" },
-                          branches: { type: "array", items: { type: "string" } },
-                        },
-                      },
-                    ],
-                  },
+                  releaseEnvironment: releaseEnvironmentInputSchema,
                 },
               },
             },

--- a/apps/composer/test/cli-compatibility.test.mjs
+++ b/apps/composer/test/cli-compatibility.test.mjs
@@ -63,6 +63,14 @@ test("v2.2 compatibility excludes post-v2.2 integrations until v2.3 is published
   assert.equal(v230Ids.includes("varlock"), true);
 });
 
+test("repository controls require the Calavera 2.5 CLI contract", () => {
+  const before = filterIntegrationsForCli(integrationCatalog, "2.4.0").map(({ id }) => id);
+  const supported = filterIntegrationsForCli(integrationCatalog, "2.5.0").map(({ id }) => id);
+
+  assert.equal(before.includes("github-repository-controls"), false);
+  assert.equal(supported.includes("github-repository-controls"), true);
+});
+
 test("WebMCP catalog responses and recipes use the same published CLI boundary", () => {
   const response = integrationResponseForCli(
     { profile: "minimal", integrations: integrationCatalog },

--- a/apps/composer/test/cli-compatibility.test.mjs
+++ b/apps/composer/test/cli-compatibility.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import Ajv from "ajv";
 import { integrationCatalog } from "../../../packages/cli/src/catalog.js";
 import { aiArtifactCatalog } from "../../../packages/cli/src/ai/catalog.js";
 import {
@@ -18,6 +19,17 @@ import {
   versionMeetsMinimum,
 } from "../cli-compatibility.js";
 import viteConfig from "../vite.config.js";
+import { releaseEnvironmentInputSchema } from "../repository-controls-input-schema.js";
+
+test("WebMCP release-environment schema accepts every disabled representation", () => {
+  const validate = new Ajv({ strict: true }).compile(releaseEnvironmentInputSchema);
+
+  assert.equal(validate(false), true);
+  assert.equal(validate(null), true);
+  assert.equal(validate({ reviewers: ["octocat"] }), true);
+  assert.equal(validate({}), false);
+  assert.equal(validate({ reviewers: ["octocat"], waitTimer: 43_201 }), false);
+});
 
 test("version comparison keeps unreleased integrations behind their CLI release", () => {
   assert.equal(versionMeetsMinimum("2.2.0", "2.3.0"), false);

--- a/packages/cli/scripts/check-config-schema.test.mjs
+++ b/packages/cli/scripts/check-config-schema.test.mjs
@@ -274,6 +274,25 @@ test("config schema validates attached GitHub repository-control options", () =>
   );
 });
 
+test("recipe validation requires and normalizes selected repository-control options", () => {
+  const recipe = {
+    ...buildRecipe("minimal", [], "npm"),
+    integrations: ["github-repository-controls"],
+  };
+  assert.throws(
+    () => validateRecipe(recipe),
+    /integrationOptions\.github-repository-controls is required/,
+  );
+
+  recipe.integrationOptions = {
+    "github-repository-controls": { repository: "octocat/example" },
+  };
+  assert.equal(validateRecipe(recipe), recipe);
+  assert.deepEqual(recipe.integrationOptions["github-repository-controls"].mergeMethods, [
+    "squash",
+  ]);
+});
+
 test("config schema accepts package-backed artifact selections and legacy items", () => {
   const validate = ajv.compile(schema);
   assertValid(validate, {

--- a/packages/cli/scripts/check-config-schema.test.mjs
+++ b/packages/cli/scripts/check-config-schema.test.mjs
@@ -247,6 +247,33 @@ test("config schema rejects invalid or detached Stylelint Baseline options", () 
   );
 });
 
+test("config schema validates attached GitHub repository-control options", () => {
+  const validate = ajv.compile(schema);
+  const valid = buildRecipe("minimal", ["github-repository-controls"], "npm", [], {
+    "github-repository-controls": {
+      repository: "octocat/example",
+      requiredChecks: ["quality"],
+      mergeMethods: ["squash"],
+    },
+  });
+
+  assertValid(validate, valid);
+  assert.equal(
+    validate({ ...valid, integrations: ["editorconfig"] }),
+    false,
+    "repository-control options must reference a selected integration",
+  );
+  assert.equal(
+    validate({ ...valid, integrationOptions: undefined }),
+    false,
+    "the selected integration must include repository-control options",
+  );
+  assert.throws(
+    () => buildRecipe("minimal", ["github-repository-controls"], "npm"),
+    /integrationOptions\.github-repository-controls is required/,
+  );
+});
+
 test("config schema accepts package-backed artifact selections and legacy items", () => {
   const validate = ajv.compile(schema);
   assertValid(validate, {

--- a/packages/cli/scripts/github-repository-controls.test.mjs
+++ b/packages/cli/scripts/github-repository-controls.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtempDisposable, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -23,6 +23,7 @@ import {
   normalizeCodeqlDefaultSetup,
   normalizeDependabotSecurityUpdates,
   planRepositoryControlChanges,
+  readRepositoryControlState,
   repositorySettingsPayload,
   runRepositoryControls,
   waitForCodeql,
@@ -61,6 +62,14 @@ test("repository-control options normalize an explicit repository policy", () =>
       }),
     /must not be empty/,
   );
+  assert.throws(
+    () =>
+      normalizeGithubRepositoryControlsOptions({
+        repository: "octocat/example",
+        releaseEnvironment: { reviewers: ["octocat"], branches: [] },
+      }),
+    /branches must contain at least one branch/,
+  );
 });
 
 test("generated Dependabot YAML contains semantic npm and Actions entries", () => {
@@ -88,6 +97,24 @@ test("generated desired state keeps release protection optional", () => {
   );
   assert.equal(withRelease.releaseEnvironment.name, "release");
   assert.equal(withRelease.manualControls.disableEnvironmentAdminBypass, true);
+});
+
+test("generated repository-control documentation uses portable Node commands", () => {
+  const documentation = githubRepositoryControlManagedFiles(rawOptions).find(
+    ({ path }) => path === "docs/repository-controls.md",
+  ).contents;
+
+  assert.match(documentation, /node scripts\/repository-controls\.mjs\n/);
+  assert.match(documentation, /node scripts\/repository-controls\.mjs --apply/);
+  assert.doesNotMatch(documentation, /npm run repo:controls/);
+  assert.match(documentation, /add `--yes` to the apply command/);
+});
+
+test("README documents runnable check and confirmed apply package scripts", async () => {
+  const readme = await readFile(new URL("../../../README.md", import.meta.url), "utf8");
+
+  assert.match(readme, /npm run repo:controls:check/);
+  assert.match(readme, /npm run repo:controls:apply -- --yes/);
 });
 
 test("generated runtime handles 204 and 404 Dependabot alert responses", () => {
@@ -156,6 +183,131 @@ test("CodeQL normalization tolerates omitted optional response fields", () => {
   });
 });
 
+test("desired CodeQL state normalizes omitted defaults like the GitHub response", () => {
+  const config = createRepositoryControlsConfig(
+    normalizeGithubRepositoryControlsOptions({ repository: "octocat/example" }),
+  );
+  config.security.codeqlDefaultSetup = {
+    state: "configured",
+    languages: ["javascript-typescript"],
+  };
+
+  const desired = desiredState(config);
+  assert.deepEqual(desired.security.codeqlDefaultSetup, {
+    state: "configured",
+    languages: ["javascript-typescript"],
+    querySuite: "default",
+    threatModel: "remote",
+    runnerType: "standard",
+    runnerLabel: null,
+  });
+  const current = structuredClone(desired);
+  current.security.codeqlSupported = true;
+  current.rulesetsSupported = true;
+  assert.deepEqual(planRepositoryControlChanges(current, desired), []);
+});
+
+test("planner derives both Dependabot operations from the desired state", () => {
+  const config = createRepositoryControlsConfig(
+    normalizeGithubRepositoryControlsOptions({ repository: "octocat/example" }),
+  );
+  const desired = desiredState(config);
+  desired.security.dependabotAlerts = false;
+  desired.security.dependabotSecurityUpdates = false;
+  const current = structuredClone(desired);
+  current.security.dependabotAlerts = true;
+  current.security.dependabotSecurityUpdates = true;
+  current.security.dependabotSecurityUpdatesPaused = false;
+  current.security.codeqlSupported = true;
+  current.rulesetsSupported = true;
+
+  assert.deepEqual(planRepositoryControlChanges(current, desired), [
+    { control: "dependabot-alerts", operation: "disable", status: "drift" },
+    { control: "dependabot-security-updates", operation: "disable", status: "drift" },
+  ]);
+});
+
+test("GitHub API capability pagination retrieves rulesets after the first page", () => {
+  const api = new GitHubApi();
+  const endpoints = [];
+  api.request = (method, endpoint) => {
+    assert.equal(method, "GET");
+    endpoints.push(endpoint);
+    if (endpoint.endsWith("page=1")) {
+      return Array.from({ length: 100 }, (_, id) => ({ id, name: `ruleset-${id}` }));
+    }
+    return [{ id: 101, name: "protect-default-branch" }];
+  };
+
+  const result = api.capability("repos/octocat/example/rulesets", { paginate: true });
+  assert.equal(result.supported, true);
+  assert.equal(result.value.length, 101);
+  assert.equal(result.value.at(-1).name, "protect-default-branch");
+  assert.deepEqual(endpoints, [
+    "repos/octocat/example/rulesets?per_page=100&page=1",
+    "repos/octocat/example/rulesets?per_page=100&page=2",
+  ]);
+});
+
+test("repository-state reads update a matching ruleset returned after the first page", () => {
+  const config = createRepositoryControlsConfig(
+    normalizeGithubRepositoryControlsOptions({ repository: "octocat/example" }),
+  );
+  const desired = desiredState(config);
+  const api = {
+    request(method, endpoint) {
+      assert.equal(method, "GET");
+      if (endpoint === "repos/octocat/example") {
+        return {
+          default_branch: "main",
+          ...repositorySettingsPayload(desired.repositorySettings),
+        };
+      }
+      if (endpoint.endsWith("/actions/permissions/workflow")) {
+        return {
+          default_workflow_permissions: "read",
+          can_approve_pull_request_reviews: false,
+        };
+      }
+      if (endpoint.endsWith("/rulesets/101")) {
+        return { id: 101, ...mainRulesetPayload(desired.mainRuleset) };
+      }
+      throw new Error(`Unexpected GET: ${endpoint}`);
+    },
+    optional(endpoint) {
+      if (endpoint.endsWith("/immutable-releases")) return { enabled: true };
+      if (endpoint.endsWith("/vulnerability-alerts")) return undefined;
+      if (endpoint.endsWith("/automated-security-fixes")) {
+        return { enabled: true, paused: false };
+      }
+      throw new Error(`Unexpected optional GET: ${endpoint}`);
+    },
+    capability(endpoint, options) {
+      if (endpoint.endsWith("/code-scanning/default-setup")) {
+        return {
+          supported: true,
+          value: codeqlDefaultSetupPayload(desired.security.codeqlDefaultSetup),
+        };
+      }
+      if (endpoint.endsWith("/rulesets")) {
+        assert.deepEqual(options, { paginate: true });
+        return {
+          supported: true,
+          value: [
+            ...Array.from({ length: 100 }, (_, id) => ({ id, name: `ruleset-${id}` })),
+            { id: 101, name: desired.mainRuleset.name },
+          ],
+        };
+      }
+      throw new Error(`Unexpected capability GET: ${endpoint}`);
+    },
+  };
+
+  const current = readRepositoryControlState(api, config.repository, desired);
+  assert.equal(current.rulesetId, 101);
+  assert.deepEqual(current.state.mainRuleset, desired.mainRuleset);
+});
+
 test("CodeQL verification polling is bounded", async () => {
   let reads = 0;
   await assert.rejects(
@@ -217,7 +369,7 @@ test("generated check stays read-only and apply mutates only planned drift", asy
       }
       throw new Error(`Unexpected optional GET: ${endpoint}`);
     },
-    capability(endpoint) {
+    capability(endpoint, options) {
       if (endpoint.endsWith("/code-scanning/default-setup")) {
         return {
           supported: true,
@@ -225,6 +377,7 @@ test("generated check stays read-only and apply mutates only planned drift", asy
         };
       }
       if (endpoint.endsWith("/rulesets")) {
+        assert.deepEqual(options, { paginate: true });
         return { supported: true, value: [{ id: 1, name: desired.mainRuleset.name }] };
       }
       throw new Error(`Unexpected capability GET: ${endpoint}`);
@@ -249,14 +402,123 @@ test("generated check stays read-only and apply mutates only planned drift", asy
   );
 });
 
+test("apply uses DELETE for planned Dependabot disable operations", async () => {
+  const config = createRepositoryControlsConfig(
+    normalizeGithubRepositoryControlsOptions({ repository: "octocat/example" }),
+  );
+  config.security.dependabotAlerts = false;
+  config.security.dependabotSecurityUpdates = false;
+  const desired = desiredState(config);
+  let alertsEnabled = true;
+  let updatesEnabled = true;
+  const mutations = [];
+  const api = {
+    request(method, endpoint, body) {
+      if (method !== "GET") {
+        mutations.push({ method, endpoint, body });
+        if (method === "DELETE" && endpoint.endsWith("/vulnerability-alerts")) {
+          alertsEnabled = false;
+          return undefined;
+        }
+        if (method === "DELETE" && endpoint.endsWith("/automated-security-fixes")) {
+          updatesEnabled = false;
+          return undefined;
+        }
+        throw new Error(`Unexpected mutation: ${method} ${endpoint}`);
+      }
+      if (endpoint === "repos/octocat/example") {
+        return {
+          default_branch: "main",
+          ...repositorySettingsPayload(desired.repositorySettings),
+        };
+      }
+      if (endpoint.endsWith("/actions/permissions/workflow")) {
+        return {
+          default_workflow_permissions: "read",
+          can_approve_pull_request_reviews: false,
+        };
+      }
+      if (endpoint === "repos/octocat/example/rulesets/1") {
+        return { id: 1, ...mainRulesetPayload(desired.mainRuleset) };
+      }
+      throw new Error(`Unexpected GET: ${endpoint}`);
+    },
+    optional(endpoint) {
+      if (endpoint.endsWith("/immutable-releases")) return { enabled: true };
+      if (endpoint.endsWith("/vulnerability-alerts")) {
+        return alertsEnabled ? undefined : null;
+      }
+      if (endpoint.endsWith("/automated-security-fixes")) {
+        return { enabled: updatesEnabled, paused: false };
+      }
+      throw new Error(`Unexpected optional GET: ${endpoint}`);
+    },
+    capability(endpoint) {
+      if (endpoint.endsWith("/code-scanning/default-setup")) {
+        return {
+          supported: true,
+          value: codeqlDefaultSetupPayload(desired.security.codeqlDefaultSetup),
+        };
+      }
+      if (endpoint.endsWith("/rulesets")) {
+        return { supported: true, value: [{ id: 1, name: desired.mainRuleset.name }] };
+      }
+      throw new Error(`Unexpected capability GET: ${endpoint}`);
+    },
+  };
+
+  const result = await runRepositoryControls({
+    api,
+    config,
+    skipGhChecks: true,
+    apply: true,
+    yes: true,
+    log: () => {},
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(
+    mutations.map(({ method, endpoint }) => ({ method, endpoint })),
+    [
+      { method: "DELETE", endpoint: "repos/octocat/example/vulnerability-alerts" },
+      { method: "DELETE", endpoint: "repos/octocat/example/automated-security-fixes" },
+    ],
+  );
+});
+
+test("runtime rejects incomplete configuration and malformed repository paths before API reads", async () => {
+  const config = createRepositoryControlsConfig(
+    normalizeGithubRepositoryControlsOptions({ repository: "octocat/example" }),
+  );
+  const api = { request: () => assert.fail("API must not be called") };
+  const withoutManualControls = structuredClone(config);
+  delete withoutManualControls.manualControls;
+
+  await assert.rejects(
+    () => runRepositoryControls({ api, config: withoutManualControls, skipGhChecks: true }),
+    /configuration is incomplete/,
+  );
+  await assert.rejects(
+    () =>
+      runRepositoryControls({
+        api,
+        config: { ...config, repository: "octocat/example/extra" },
+        skipGhChecks: true,
+      }),
+    /owner\/name format/,
+  );
+});
+
 test("Calavera apply manages repository-control files and scripts without contacting GitHub", async () => {
   const originalDirectory = process.cwd();
-  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-repository-controls-"));
+  await using projectDirectory = await mkdtempDisposable(
+    join(tmpdir(), "calavera-repository-controls-"),
+  );
   const recipe = buildRecipe("minimal", ["github-repository-controls"], "npm", [], {
     "github-repository-controls": rawOptions,
   });
   try {
-    process.chdir(projectDirectory);
+    process.chdir(projectDirectory.path);
     await writeFile("package.json", `${JSON.stringify({ scripts: {} }, null, 2)}\n`);
 
     const dryRun = await applyRecipeObject(recipe, {
@@ -292,6 +554,5 @@ test("Calavera apply manages repository-control files and scripts without contac
     );
   } finally {
     process.chdir(originalDirectory);
-    await rm(projectDirectory, { recursive: true, force: true });
   }
 });

--- a/packages/cli/scripts/github-repository-controls.test.mjs
+++ b/packages/cli/scripts/github-repository-controls.test.mjs
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { parse as parseYaml } from "yaml";
+
+import {
+  createDependabotConfig,
+  createRepositoryControlsConfig,
+  githubRepositoryControlManagedFiles,
+  normalizeGithubRepositoryControlsOptions,
+} from "../src/github-repository-controls.js";
+import { applyRecipeObject } from "../src/index.js";
+import { buildRecipe } from "../src/recipe.js";
+import {
+  GitHubApi,
+  dependabotAlertsEnabled,
+  desiredState,
+  codeqlDefaultSetupPayload,
+  mainRulesetPayload,
+  normalizeCodeqlDefaultSetup,
+  normalizeDependabotSecurityUpdates,
+  planRepositoryControlChanges,
+  repositorySettingsPayload,
+  runRepositoryControls,
+  waitForCodeql,
+} from "../src/templates/repository-controls.mjs";
+
+const rawOptions = {
+  repository: "octocat/example",
+  requiredChecks: ["quality"],
+  mergeMethods: ["merge", "rebase"],
+  releaseEnvironment: {
+    reviewers: ["octocat"],
+  },
+};
+
+test("repository-control options normalize an explicit repository policy", () => {
+  const options = normalizeGithubRepositoryControlsOptions(rawOptions);
+  assert.deepEqual(options.mergeMethods, ["merge", "rebase"]);
+  assert.deepEqual(options.dependabotEcosystems, ["npm", "github-actions"]);
+  assert.deepEqual(options.codeqlLanguages, ["actions", "javascript-typescript"]);
+  assert.deepEqual(options.releaseEnvironment, {
+    name: "release",
+    reviewers: ["octocat"],
+    waitTimer: 0,
+    preventSelfReview: false,
+    branches: ["main"],
+  });
+  assert.throws(
+    () => normalizeGithubRepositoryControlsOptions({ repository: "not-a-repository" }),
+    /owner\/name/,
+  );
+  assert.throws(
+    () =>
+      normalizeGithubRepositoryControlsOptions({
+        repository: "octocat/example",
+        codeqlLanguages: [],
+      }),
+    /must not be empty/,
+  );
+});
+
+test("generated Dependabot YAML contains semantic npm and Actions entries", () => {
+  const configuration = parseYaml(createDependabotConfig(["npm", "github-actions"]));
+  assert.equal(configuration.version, 2);
+  assert.deepEqual(
+    configuration.updates.map((update) => update["package-ecosystem"]),
+    ["npm", "github-actions"],
+  );
+  assert.equal(
+    configuration.updates.every((update) => update.directory === "/"),
+    true,
+  );
+});
+
+test("generated desired state keeps release protection optional", () => {
+  const withoutRelease = createRepositoryControlsConfig(
+    normalizeGithubRepositoryControlsOptions({ repository: "octocat/example" }),
+  );
+  assert.equal(withoutRelease.releaseEnvironment, null);
+  assert.equal(withoutRelease.manualControls.disableEnvironmentAdminBypass, false);
+
+  const withRelease = createRepositoryControlsConfig(
+    normalizeGithubRepositoryControlsOptions(rawOptions),
+  );
+  assert.equal(withRelease.releaseEnvironment.name, "release");
+  assert.equal(withRelease.manualControls.disableEnvironmentAdminBypass, true);
+});
+
+test("generated runtime handles 204 and 404 Dependabot alert responses", () => {
+  const enabledApi = { optional: () => undefined };
+  const disabledApi = { optional: () => null };
+  assert.equal(dependabotAlertsEnabled(enabledApi, "octocat/example"), true);
+  assert.equal(dependabotAlertsEnabled(disabledApi, "octocat/example"), false);
+  assert.deepEqual(normalizeDependabotSecurityUpdates({ enabled: true, paused: true }), {
+    dependabotSecurityUpdates: false,
+    dependabotSecurityUpdatesPaused: true,
+  });
+});
+
+test("GitHub API capability reads distinguish unsupported CodeQL", () => {
+  const api = new GitHubApi();
+  api.request = () => {
+    const error = new Error("HTTP 403: GitHub Advanced Security is unavailable");
+    error.status = 403;
+    throw error;
+  };
+  assert.deepEqual(api.capability("repos/octocat/example/code-scanning/default-setup"), {
+    supported: false,
+    detail: "Error: HTTP 403: GitHub Advanced Security is unavailable",
+  });
+});
+
+test("planner separates drift, manual remediation, and unsupported controls", () => {
+  const config = createRepositoryControlsConfig(
+    normalizeGithubRepositoryControlsOptions({ repository: "octocat/example" }),
+  );
+  const desired = desiredState(config);
+  const current = structuredClone(desired);
+  current.immutableReleases = false;
+  current.security.dependabotSecurityUpdates = false;
+  current.security.dependabotSecurityUpdatesPaused = true;
+  current.security.codeqlSupported = false;
+  current.security.codeqlDetail = "GitHub Advanced Security is unavailable";
+  current.rulesetsSupported = true;
+  current.rulesetsDetail = null;
+
+  assert.deepEqual(planRepositoryControlChanges(current, desired), [
+    { control: "immutable-releases", operation: "enable", status: "drift" },
+    {
+      control: "dependabot-security-updates",
+      operation: "manual",
+      status: "manual",
+      detail: "Dependabot security updates are paused and require repository activity.",
+    },
+    {
+      control: "codeql-default-setup",
+      operation: "unsupported",
+      status: "unsupported",
+      detail: "GitHub Advanced Security is unavailable",
+    },
+  ]);
+});
+
+test("CodeQL normalization tolerates omitted optional response fields", () => {
+  assert.deepEqual(normalizeCodeqlDefaultSetup({ state: "not-configured" }), {
+    state: "not-configured",
+    languages: [],
+    querySuite: "default",
+    threatModel: "remote",
+    runnerType: "standard",
+    runnerLabel: null,
+  });
+});
+
+test("CodeQL verification polling is bounded", async () => {
+  let reads = 0;
+  await assert.rejects(
+    () =>
+      waitForCodeql(
+        async () => {
+          reads += 1;
+          return { state: "not-configured" };
+        },
+        { state: "configured" },
+        { attempts: 3, delayMs: 0, delay: async () => {} },
+      ),
+    /did not reach the desired state/,
+  );
+  assert.equal(reads, 3);
+});
+
+test("generated check stays read-only and apply mutates only planned drift", async () => {
+  const config = createRepositoryControlsConfig(
+    normalizeGithubRepositoryControlsOptions({ repository: "octocat/example" }),
+  );
+  const desired = desiredState(config);
+  let immutableEnabled = false;
+  const mutations = [];
+  const api = {
+    request(method, endpoint, body) {
+      if (method !== "GET") {
+        mutations.push({ method, endpoint, body });
+        if (method === "PUT" && endpoint.endsWith("/immutable-releases")) {
+          immutableEnabled = true;
+          return undefined;
+        }
+        throw new Error(`Unexpected mutation: ${method} ${endpoint}`);
+      }
+      if (endpoint === "repos/octocat/example") {
+        return {
+          default_branch: "main",
+          ...repositorySettingsPayload(desired.repositorySettings),
+        };
+      }
+      if (endpoint.endsWith("/actions/permissions/workflow")) {
+        return {
+          default_workflow_permissions: "read",
+          can_approve_pull_request_reviews: false,
+        };
+      }
+      if (endpoint === "repos/octocat/example/rulesets/1") {
+        return { id: 1, ...mainRulesetPayload(desired.mainRuleset) };
+      }
+      throw new Error(`Unexpected GET: ${endpoint}`);
+    },
+    optional(endpoint) {
+      if (endpoint.endsWith("/immutable-releases")) {
+        return immutableEnabled ? { enabled: true } : null;
+      }
+      if (endpoint.endsWith("/vulnerability-alerts")) return undefined;
+      if (endpoint.endsWith("/automated-security-fixes")) {
+        return { enabled: true, paused: false };
+      }
+      throw new Error(`Unexpected optional GET: ${endpoint}`);
+    },
+    capability(endpoint) {
+      if (endpoint.endsWith("/code-scanning/default-setup")) {
+        return {
+          supported: true,
+          value: codeqlDefaultSetupPayload(desired.security.codeqlDefaultSetup),
+        };
+      }
+      if (endpoint.endsWith("/rulesets")) {
+        return { supported: true, value: [{ id: 1, name: desired.mainRuleset.name }] };
+      }
+      throw new Error(`Unexpected capability GET: ${endpoint}`);
+    },
+  };
+  const check = await runRepositoryControls({ api, config, skipGhChecks: true, log: () => {} });
+  assert.equal(check.ok, false);
+  assert.deepEqual(mutations, []);
+
+  const apply = await runRepositoryControls({
+    api,
+    config,
+    skipGhChecks: true,
+    apply: true,
+    yes: true,
+    log: () => {},
+  });
+  assert.equal(apply.ok, true);
+  assert.deepEqual(
+    mutations.map(({ method, endpoint }) => ({ method, endpoint })),
+    [{ method: "PUT", endpoint: "repos/octocat/example/immutable-releases" }],
+  );
+});
+
+test("Calavera apply manages repository-control files and scripts without contacting GitHub", async () => {
+  const originalDirectory = process.cwd();
+  const projectDirectory = await mkdtemp(join(tmpdir(), "calavera-repository-controls-"));
+  const recipe = buildRecipe("minimal", ["github-repository-controls"], "npm", [], {
+    "github-repository-controls": rawOptions,
+  });
+  try {
+    process.chdir(projectDirectory);
+    await writeFile("package.json", `${JSON.stringify({ scripts: {} }, null, 2)}\n`);
+
+    const dryRun = await applyRecipeObject(recipe, {
+      dryRun: true,
+      json: true,
+      noInstall: true,
+      assumeYes: true,
+    });
+    const expectedPaths = githubRepositoryControlManagedFiles(rawOptions).map(({ path }) => path);
+    assert.deepEqual(
+      dryRun.changes.filter(({ type }) => type === "write").map(({ path }) => path),
+      expectedPaths,
+    );
+
+    await applyRecipeObject(recipe, {
+      json: true,
+      noInstall: true,
+      assumeYes: true,
+    });
+    const packageJson = JSON.parse(await readFile("package.json", "utf8"));
+    assert.equal(
+      packageJson.scripts["repo:controls:check"],
+      "node scripts/repository-controls.mjs",
+    );
+    assert.equal(
+      packageJson.scripts["repo:controls:apply"],
+      "node scripts/repository-controls.mjs --apply",
+    );
+    const state = JSON.parse(await readFile(".calavera/state.json", "utf8"));
+    assert.deepEqual(
+      state.managedFiles.filter(({ path }) => expectedPaths.includes(path)).map(({ path }) => path),
+      expectedPaths,
+    );
+  } finally {
+    process.chdir(originalDirectory);
+    await rm(projectDirectory, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/src/catalog.js
+++ b/packages/cli/src/catalog.js
@@ -47,6 +47,15 @@ export const integrationCatalog = [
     dependencies: ["varlock"],
   },
   {
+    id: "github-repository-controls",
+    label: "GitHub repository controls",
+    group: "Repository governance",
+    platform: "github",
+    status: "optional",
+    minimumCliVersion: "2.5.0",
+    dependencies: [],
+  },
+  {
     id: "oxlint",
     label: "Oxlint",
     group: "Modern JS/TS linting",

--- a/packages/cli/src/github-repository-controls-options.js
+++ b/packages/cli/src/github-repository-controls-options.js
@@ -1,0 +1,214 @@
+// @ts-check
+
+export const GITHUB_REPOSITORY_CONTROLS_ID = "github-repository-controls";
+
+const MERGE_METHODS = new Set(["merge", "squash", "rebase"]);
+const CODEQL_LANGUAGES = new Set([
+  "actions",
+  "c-cpp",
+  "csharp",
+  "go",
+  "java-kotlin",
+  "javascript-typescript",
+  "python",
+  "ruby",
+  "swift",
+]);
+const DEPENDABOT_ECOSYSTEMS = new Set(["npm", "github-actions"]);
+
+/**
+ * @param {string} name
+ * @param {unknown} value
+ * @returns {asserts value is Record<string, unknown>}
+ */
+function assertPlainObject(name, value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${name} must be an object.`);
+  }
+}
+
+/** @param {string} name @param {Record<string, unknown>} value @param {string[]} fields */
+function assertKnownFields(name, value, fields) {
+  const unknown = Object.keys(value).filter((field) => !fields.includes(field));
+  if (unknown.length > 0) throw new Error(`Unknown ${name} fields: ${unknown.join(", ")}.`);
+}
+
+/** @param {string} name @param {unknown} value @param {string} fallback */
+function normalizeString(name, value, fallback) {
+  const normalized = value === undefined ? fallback : value;
+  if (typeof normalized !== "string" || !normalized.trim()) {
+    throw new TypeError(`${name} must be a non-empty string.`);
+  }
+  return normalized.trim();
+}
+
+/** @param {string} name @param {unknown} value @param {boolean} fallback */
+function normalizeBoolean(name, value, fallback) {
+  const normalized = value === undefined ? fallback : value;
+  if (typeof normalized !== "boolean") throw new TypeError(`${name} must be a boolean.`);
+  return normalized;
+}
+
+/**
+ * @param {string} name
+ * @param {unknown} value
+ * @param {string[]} fallback
+ * @param {Set<string>} [allowed]
+ */
+function normalizeStringArray(name, value, fallback, allowed) {
+  const normalized = value === undefined ? fallback : value;
+  if (
+    !Array.isArray(normalized) ||
+    normalized.some((item) => typeof item !== "string" || !item.trim())
+  ) {
+    throw new TypeError(`${name} must be an array of non-empty strings.`);
+  }
+  const unique = [...new Set(normalized.map((item) => item.trim()))];
+  if (allowed) {
+    const unknown = unique.filter((item) => !allowed.has(item));
+    if (unknown.length > 0) throw new Error(`Invalid ${name}: ${unknown.join(", ")}.`);
+  }
+  return unique;
+}
+
+/** @param {unknown} value @param {string} defaultBranch */
+function normalizeReleaseEnvironment(value, defaultBranch) {
+  if (value === undefined || value === false || value === null) return null;
+  assertPlainObject("github-repository-controls.releaseEnvironment", value);
+  assertKnownFields("github-repository-controls.releaseEnvironment", value, [
+    "name",
+    "reviewers",
+    "waitTimer",
+    "preventSelfReview",
+    "branches",
+  ]);
+  const waitTimer = value.waitTimer ?? 0;
+  if (
+    typeof waitTimer !== "number" ||
+    !Number.isInteger(waitTimer) ||
+    waitTimer < 0 ||
+    waitTimer > 43_200
+  ) {
+    throw new Error(
+      "github-repository-controls.releaseEnvironment.waitTimer must be an integer from 0 to 43200.",
+    );
+  }
+  const reviewers = normalizeStringArray(
+    "github-repository-controls.releaseEnvironment.reviewers",
+    value.reviewers,
+    [],
+  );
+  if (reviewers.length === 0) {
+    throw new Error(
+      "github-repository-controls.releaseEnvironment.reviewers must contain at least one GitHub login.",
+    );
+  }
+  return {
+    name: normalizeString(
+      "github-repository-controls.releaseEnvironment.name",
+      value.name,
+      "release",
+    ),
+    reviewers,
+    waitTimer,
+    preventSelfReview: normalizeBoolean(
+      "github-repository-controls.releaseEnvironment.preventSelfReview",
+      value.preventSelfReview,
+      false,
+    ),
+    branches: normalizeStringArray(
+      "github-repository-controls.releaseEnvironment.branches",
+      value.branches,
+      [defaultBranch],
+    ),
+  };
+}
+
+/** @param {unknown} value */
+export function normalizeGithubRepositoryControlsOptions(value) {
+  assertPlainObject("integrationOptions.github-repository-controls", value);
+  assertKnownFields("integrationOptions.github-repository-controls", value, [
+    "repository",
+    "defaultBranch",
+    "requiredChecks",
+    "mergeMethods",
+    "wiki",
+    "projects",
+    "autoMerge",
+    "deleteBranchOnMerge",
+    "updateBranch",
+    "dependabotEcosystems",
+    "codeqlLanguages",
+    "codeqlQuerySuite",
+    "releaseEnvironment",
+  ]);
+
+  const repository = normalizeString("github-repository-controls.repository", value.repository, "");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error("github-repository-controls.repository must use owner/name format.");
+  }
+  const defaultBranch = normalizeString(
+    "github-repository-controls.defaultBranch",
+    value.defaultBranch,
+    "main",
+  );
+  const mergeMethods = normalizeStringArray(
+    "github-repository-controls.mergeMethods",
+    value.mergeMethods,
+    ["squash"],
+    MERGE_METHODS,
+  );
+  if (mergeMethods.length === 0) {
+    throw new Error("github-repository-controls.mergeMethods must contain at least one method.");
+  }
+  const codeqlQuerySuite = value.codeqlQuerySuite ?? "default";
+  if (codeqlQuerySuite !== "default" && codeqlQuerySuite !== "extended") {
+    throw new Error("github-repository-controls.codeqlQuerySuite must be default or extended.");
+  }
+  const dependabotEcosystems = normalizeStringArray(
+    "github-repository-controls.dependabotEcosystems",
+    value.dependabotEcosystems,
+    ["npm", "github-actions"],
+    DEPENDABOT_ECOSYSTEMS,
+  );
+  if (dependabotEcosystems.length === 0) {
+    throw new Error("github-repository-controls.dependabotEcosystems must not be empty.");
+  }
+  const codeqlLanguages = normalizeStringArray(
+    "github-repository-controls.codeqlLanguages",
+    value.codeqlLanguages,
+    ["actions", "javascript-typescript"],
+    CODEQL_LANGUAGES,
+  );
+  if (codeqlLanguages.length === 0) {
+    throw new Error("github-repository-controls.codeqlLanguages must not be empty.");
+  }
+
+  return {
+    repository,
+    defaultBranch,
+    requiredChecks: normalizeStringArray(
+      "github-repository-controls.requiredChecks",
+      value.requiredChecks,
+      [],
+    ),
+    mergeMethods,
+    wiki: normalizeBoolean("github-repository-controls.wiki", value.wiki, false),
+    projects: normalizeBoolean("github-repository-controls.projects", value.projects, false),
+    autoMerge: normalizeBoolean("github-repository-controls.autoMerge", value.autoMerge, true),
+    deleteBranchOnMerge: normalizeBoolean(
+      "github-repository-controls.deleteBranchOnMerge",
+      value.deleteBranchOnMerge,
+      true,
+    ),
+    updateBranch: normalizeBoolean(
+      "github-repository-controls.updateBranch",
+      value.updateBranch,
+      true,
+    ),
+    dependabotEcosystems,
+    codeqlLanguages,
+    codeqlQuerySuite,
+    releaseEnvironment: normalizeReleaseEnvironment(value.releaseEnvironment, defaultBranch),
+  };
+}

--- a/packages/cli/src/github-repository-controls-options.js
+++ b/packages/cli/src/github-repository-controls-options.js
@@ -103,6 +103,16 @@ function normalizeReleaseEnvironment(value, defaultBranch) {
       "github-repository-controls.releaseEnvironment.reviewers must contain at least one GitHub login.",
     );
   }
+  const branches = normalizeStringArray(
+    "github-repository-controls.releaseEnvironment.branches",
+    value.branches,
+    [defaultBranch],
+  );
+  if (branches.length === 0) {
+    throw new Error(
+      "github-repository-controls.releaseEnvironment.branches must contain at least one branch.",
+    );
+  }
   return {
     name: normalizeString(
       "github-repository-controls.releaseEnvironment.name",
@@ -116,11 +126,7 @@ function normalizeReleaseEnvironment(value, defaultBranch) {
       value.preventSelfReview,
       false,
     ),
-    branches: normalizeStringArray(
-      "github-repository-controls.releaseEnvironment.branches",
-      value.branches,
-      [defaultBranch],
-    ),
+    branches,
   };
 }
 

--- a/packages/cli/src/github-repository-controls.js
+++ b/packages/cli/src/github-repository-controls.js
@@ -102,16 +102,16 @@ Calavera generated a committed desired-state policy for \`${config.repository}\`
 Run the read-only drift check before applying any remote changes:
 
 \`\`\`sh
-npm run repo:controls:check
+node scripts/repository-controls.mjs
 \`\`\`
 
 Review the reported plan, then apply it interactively:
 
 \`\`\`sh
-npm run repo:controls:apply
+node scripts/repository-controls.mjs --apply
 \`\`\`
 
-For intentional unattended administration, pass \`--yes\` through your package manager.
+For intentional unattended administration, add \`--yes\` to the apply command.
 
 ## Manual controls
 

--- a/packages/cli/src/github-repository-controls.js
+++ b/packages/cli/src/github-repository-controls.js
@@ -1,0 +1,142 @@
+// @ts-check
+import { lstatSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { stringify as stringifyYaml } from "yaml";
+import {
+  GITHUB_REPOSITORY_CONTROLS_ID,
+  normalizeGithubRepositoryControlsOptions,
+} from "./github-repository-controls-options.js";
+
+export { GITHUB_REPOSITORY_CONTROLS_ID, normalizeGithubRepositoryControlsOptions };
+
+const TEMPLATE_LIMIT = 256 * 1024;
+const TEMPLATE_PATH = fileURLToPath(
+  new URL("./templates/repository-controls.mjs", import.meta.url),
+);
+
+function readBoundedTemplate() {
+  const before = lstatSync(TEMPLATE_PATH);
+  if (!before.isFile()) throw new Error("Repository-controls template must be a regular file.");
+  if (before.size > TEMPLATE_LIMIT) {
+    throw new Error(`Repository-controls template exceeds ${TEMPLATE_LIMIT} bytes.`);
+  }
+  const contents = readFileSync(TEMPLATE_PATH);
+  if (contents.byteLength > TEMPLATE_LIMIT) {
+    throw new Error(`Repository-controls template exceeded ${TEMPLATE_LIMIT} bytes while reading.`);
+  }
+  return contents.toString("utf8");
+}
+
+/** @param {ReturnType<typeof normalizeGithubRepositoryControlsOptions>} options */
+export function createRepositoryControlsConfig(options) {
+  return {
+    schemaVersion: 1,
+    repository: options.repository,
+    defaultBranch: options.defaultBranch,
+    repositorySettings: {
+      wiki: options.wiki,
+      projects: options.projects,
+      mergeMethods: options.mergeMethods,
+      autoMerge: options.autoMerge,
+      deleteBranchOnMerge: options.deleteBranchOnMerge,
+      updateBranch: options.updateBranch,
+    },
+    workflowPermissions: {
+      defaultWorkflowPermissions: "read",
+      canApprovePullRequestReviews: false,
+    },
+    security: {
+      dependabotAlerts: true,
+      dependabotSecurityUpdates: true,
+      codeqlDefaultSetup: {
+        state: "configured",
+        languages: options.codeqlLanguages,
+        querySuite: options.codeqlQuerySuite,
+        threatModel: "remote",
+        runnerType: "standard",
+        runnerLabel: null,
+      },
+    },
+    mainRuleset: {
+      name: "protect-default-branch",
+      requiredChecks: options.requiredChecks,
+      allowedMergeMethods: options.mergeMethods,
+    },
+    releaseEnvironment: options.releaseEnvironment
+      ? {
+          ...options.releaseEnvironment,
+          customBranchesOnly: true,
+          guardValue: "approved-release-environment-v1",
+        }
+      : null,
+    manualControls: {
+      dependabotMalwareAlerts: true,
+      disableEnvironmentAdminBypass: Boolean(options.releaseEnvironment),
+    },
+  };
+}
+
+/** @param {string[]} ecosystems */
+export function createDependabotConfig(ecosystems) {
+  return stringifyYaml({
+    version: 2,
+    updates: ecosystems.map((ecosystem) => ({
+      "package-ecosystem": ecosystem,
+      directory: "/",
+      schedule: { interval: "weekly" },
+      cooldown: { "default-days": 7, include: ["*"] },
+    })),
+  });
+}
+
+/** @param {ReturnType<typeof createRepositoryControlsConfig>} config */
+function createRepositoryControlsDocumentation(config) {
+  const release = config.releaseEnvironment
+    ? `\n- In **Settings → Environments → ${config.releaseEnvironment.name}**, disable administrator bypass.\n`
+    : "";
+  return `# Repository controls
+
+Calavera generated a committed desired-state policy for \`${config.repository}\`.
+
+Run the read-only drift check before applying any remote changes:
+
+\`\`\`sh
+npm run repo:controls:check
+\`\`\`
+
+Review the reported plan, then apply it interactively:
+
+\`\`\`sh
+npm run repo:controls:apply
+\`\`\`
+
+For intentional unattended administration, pass \`--yes\` through your package manager.
+
+## Manual controls
+
+- In **Settings → Advanced Security**, enable Dependabot malware alerts.${release}
+The generated script verifies the repository identity before planning or applying changes. Unsupported GitHub plan features are reported separately from drift.
+`;
+}
+
+/** @param {unknown} rawOptions */
+export function githubRepositoryControlManagedFiles(rawOptions) {
+  const options = normalizeGithubRepositoryControlsOptions(rawOptions);
+  const config = createRepositoryControlsConfig(options);
+  return [
+    {
+      path: ".github/repository-controls.json",
+      contents: `${JSON.stringify(config, null, 2)}\n`,
+    },
+    {
+      path: ".github/dependabot.yml",
+      contents: createDependabotConfig(options.dependabotEcosystems),
+    },
+    { path: "scripts/repository-controls.mjs", contents: readBoundedTemplate() },
+    {
+      path: "docs/repository-controls.md",
+      contents: createRepositoryControlsDocumentation(config),
+    },
+  ];
+}

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -21,6 +21,10 @@ import {
 import { execa } from "execa";
 import packageJson from "../package.json" with { type: "json" };
 import { lockedArtifactSources, runArtifactCommand } from "./artifact-lifecycle.js";
+import {
+  GITHUB_REPOSITORY_CONTROLS_ID,
+  githubRepositoryControlManagedFiles,
+} from "./github-repository-controls.js";
 
 import {
   aiArtifactOutputPaths,
@@ -625,6 +629,7 @@ function buildScripts(recipe, integrations, packageManager) {
   const usesKnip = has("knip");
   const usesHtmlValidate = has("html-validate");
   const usesVarlock = has("varlock");
+  const usesGithubRepositoryControls = has(GITHUB_REPOSITORY_CONTROLS_ID);
 
   const lintParts = [
     usesOxlint ? "oxlint ." : null,
@@ -711,6 +716,11 @@ function buildScripts(recipe, integrations, packageManager) {
 
   if (usesVarlock) {
     scripts["env:load"] = "varlock load";
+  }
+
+  if (usesGithubRepositoryControls) {
+    scripts["repo:controls:check"] = "node scripts/repository-controls.mjs";
+    scripts["repo:controls:apply"] = "node scripts/repository-controls.mjs --apply";
   }
 
   if (recipe.scripts?.quality) {
@@ -1512,6 +1522,12 @@ function plannedManagedFiles(integrations, integrationOptions = {}) {
     });
   }
 
+  if (integrations.some((integration) => integration.id === GITHUB_REPOSITORY_CONTROLS_ID)) {
+    plans.push(
+      ...githubRepositoryControlManagedFiles(integrationOptions[GITHUB_REPOSITORY_CONTROLS_ID]),
+    );
+  }
+
   return plans;
 }
 
@@ -1622,8 +1638,19 @@ export async function inspectProject(recipe, options = {}) {
   }
 
   const packageScripts = packageJSON.scripts ?? {};
-  for (const scriptName of ["lint", "lint:fix", "format", "format:check", "typecheck"]) {
-    if (recipe?.scripts?.[scriptName] && typeof packageScripts[scriptName] === "string") {
+  for (const scriptName of [
+    "lint",
+    "lint:fix",
+    "format",
+    "format:check",
+    "typecheck",
+    "repo:controls:check",
+    "repo:controls:apply",
+  ]) {
+    const managedByRecipe = scriptName.startsWith("repo:controls:")
+      ? integrationIds.has(GITHUB_REPOSITORY_CONTROLS_ID)
+      : recipe?.scripts?.[scriptName];
+    if (managedByRecipe && typeof packageScripts[scriptName] === "string") {
       findings.push({
         severity: "warning",
         kind: "existing-package-script",
@@ -1912,6 +1939,23 @@ export async function applyRecipeObject(recipe, options = {}) {
         reownManagedFiles,
       ),
     );
+  }
+
+  if (integrations.some((integration) => integration.id === GITHUB_REPOSITORY_CONTROLS_ID)) {
+    for (const file of githubRepositoryControlManagedFiles(
+      recipe.integrationOptions?.[GITHUB_REPOSITORY_CONTROLS_ID],
+    )) {
+      managedFiles.push(
+        await writeManagedFile(
+          file.path,
+          file.contents,
+          applyOptions.dryRun,
+          changes,
+          previousState,
+          reownManagedFiles,
+        ),
+      );
+    }
   }
 
   await applyVarlockProjectFiles(varlockFilePlans, applyOptions.dryRun, changes);

--- a/packages/cli/src/project-inspection.js
+++ b/packages/cli/src/project-inspection.js
@@ -8,6 +8,12 @@ export const packageManagerLockfiles = Object.freeze({
 export const integrationConfigFiles = Object.freeze({
   editorconfig: [".editorconfig"],
   eslint: ["eslint.config.js"],
+  "github-repository-controls": [
+    ".github/repository-controls.json",
+    ".github/dependabot.yml",
+    "scripts/repository-controls.mjs",
+    "docs/repository-controls.md",
+  ],
   "html-validate": [".htmlvalidate.json", ".htmlvalidateignore"],
   knip: ["knip.json"],
   oxlint: ["oxlint.json"],

--- a/packages/cli/src/recipe.js
+++ b/packages/cli/src/recipe.js
@@ -656,8 +656,14 @@ export function validateRecipe(recipe) {
 
   assertNoFormatterConflict(recipe.integrations);
 
-  if (Object.hasOwn(recipe, "integrationOptions")) {
-    normalizeIntegrationOptions(recipe.integrationOptions, recipe.integrations);
+  const normalizedIntegrationOptions = normalizeIntegrationOptions(
+    recipe.integrationOptions,
+    recipe.integrations,
+  );
+  if (normalizedIntegrationOptions !== undefined) {
+    recipe.integrationOptions = normalizedIntegrationOptions;
+  } else if (Object.hasOwn(recipe, "integrationOptions")) {
+    delete recipe.integrationOptions;
   }
 
   if (Object.hasOwn(recipe, "ai")) {

--- a/packages/cli/src/recipe.js
+++ b/packages/cli/src/recipe.js
@@ -3,6 +3,10 @@ import { normalizeAiItems } from "./ai/recipe-items.js";
 import { integrationCatalog } from "./catalog.js";
 import { normalizeBaselineTarget } from "@schalkneethling/calavera-baseline-core";
 import {
+  GITHUB_REPOSITORY_CONTROLS_ID,
+  normalizeGithubRepositoryControlsOptions,
+} from "./github-repository-controls-options.js";
+import {
   assertKnownValue,
   assertObjectArray,
   assertPlainObject,
@@ -162,7 +166,7 @@ export const recipeToolInputDescriptions = Object.freeze({
   aiArtifactTarget: "Optional target directory for hook and agent artifacts.",
   aiArtifacts: "Bundled AI skills, hooks, and agents to include in the recipe.",
   integrationOptions:
-    "Options keyed by selected integration ID. Stylelint Baseline accepts available and severity.",
+    "Options keyed by selected integration ID. Stylelint Baseline accepts availability and severity; GitHub repository controls require repository identity and accept governance policy overrides.",
   baselineTarget: "Baseline target: widely, newly, or a supported fixed year.",
   baselineQuery: "Text used to search the CSS-focused Baseline feature catalog.",
   baselineLimit: "Maximum number of Baseline feature search results.",
@@ -502,21 +506,26 @@ export function resolveRecipeIntegrations(recipe) {
 }
 
 export function normalizeIntegrationOptions(integrationOptions, integrationIds) {
+  const resolvedIds = new Set(
+    resolveRecipeIntegrations({ integrations: integrationIds }).map(({ id }) => id),
+  );
   if (integrationOptions === undefined) {
+    if (resolvedIds.has(GITHUB_REPOSITORY_CONTROLS_ID)) {
+      throw new Error(
+        "integrationOptions.github-repository-controls is required when the github-repository-controls integration is selected.",
+      );
+    }
     return undefined;
   }
 
   assertPlainObject("integrationOptions", integrationOptions);
-  const supportedIds = ["stylelint-baseline"];
+  const supportedIds = ["stylelint-baseline", GITHUB_REPOSITORY_CONTROLS_ID];
   const unknownIds = Object.keys(integrationOptions).filter((id) => !supportedIds.includes(id));
 
   if (unknownIds.length > 0) {
     throw new Error(`Unknown integrationOptions: ${unknownIds.join(", ")}.`);
   }
 
-  const resolvedIds = new Set(
-    resolveRecipeIntegrations({ integrations: integrationIds }).map(({ id }) => id),
-  );
   const normalized = {};
 
   if (Object.hasOwn(integrationOptions, "stylelint-baseline")) {
@@ -546,6 +555,21 @@ export function normalizeIntegrationOptions(integrationOptions, integrationIds) 
     }
 
     normalized["stylelint-baseline"] = { available, severity };
+  }
+
+  if (Object.hasOwn(integrationOptions, GITHUB_REPOSITORY_CONTROLS_ID)) {
+    if (!resolvedIds.has(GITHUB_REPOSITORY_CONTROLS_ID)) {
+      throw new Error(
+        "integrationOptions.github-repository-controls requires the github-repository-controls integration.",
+      );
+    }
+    normalized[GITHUB_REPOSITORY_CONTROLS_ID] = normalizeGithubRepositoryControlsOptions(
+      integrationOptions[GITHUB_REPOSITORY_CONTROLS_ID],
+    );
+  } else if (resolvedIds.has(GITHUB_REPOSITORY_CONTROLS_ID)) {
+    throw new Error(
+      "integrationOptions.github-repository-controls is required when the github-repository-controls integration is selected.",
+    );
   }
 
   return Object.keys(normalized).length > 0 ? normalized : undefined;

--- a/packages/cli/src/templates/repository-controls.mjs
+++ b/packages/cli/src/templates/repository-controls.mjs
@@ -1,0 +1,671 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+import { execFileSync } from "node:child_process";
+import { lstatSync, readFileSync } from "node:fs";
+import { createInterface } from "node:readline/promises";
+import { isDeepStrictEqual } from "node:util";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const API_VERSION = "2026-03-10";
+const CONFIG_LIMIT = 1024 * 1024;
+const API_RESPONSE_LIMIT = 20 * 1024 * 1024;
+const CODEQL_ATTEMPTS = 12;
+const CODEQL_DELAY_MS = 5_000;
+const root = fileURLToPath(new URL("..", import.meta.url));
+const configPath = fileURLToPath(new URL("../.github/repository-controls.json", import.meta.url));
+
+export function readBoundedJson(path, limit = CONFIG_LIMIT) {
+  const before = lstatSync(path);
+  if (!before.isFile()) throw new Error(`${path} must be a regular file.`);
+  if (before.size > limit) throw new Error(`${path} exceeds the ${limit}-byte safety limit.`);
+  const contents = readFileSync(path);
+  if (contents.byteLength > limit) {
+    throw new Error(`${path} exceeded the ${limit}-byte safety limit while being read.`);
+  }
+  try {
+    return JSON.parse(contents.toString("utf8"));
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`${path} is not valid JSON.`, { cause: error });
+    }
+    throw error;
+  }
+}
+
+export class GitHubApi {
+  request(method, endpoint, body) {
+    const args = [
+      "api",
+      "-H",
+      "Accept: application/vnd.github+json",
+      "-H",
+      `X-GitHub-Api-Version: ${API_VERSION}`,
+      "-X",
+      method,
+      endpoint,
+    ];
+    if (body !== undefined) args.push("--input", "-");
+    try {
+      const output = execFileSync("gh", args, {
+        encoding: "utf8",
+        input: body === undefined ? undefined : JSON.stringify(body),
+        maxBuffer: API_RESPONSE_LIMIT,
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim();
+      return output ? JSON.parse(output) : undefined;
+    } catch (error) {
+      const stderr = String(error?.stderr ?? "").trim();
+      const failure = new Error(
+        `GitHub API ${method} ${endpoint} failed${stderr ? `: ${stderr}` : ""}.`,
+        { cause: error },
+      );
+      failure.status = Number(stderr.match(/HTTP ([0-9]{3})/)?.[1] ?? 0);
+      throw failure;
+    }
+  }
+
+  optional(endpoint) {
+    try {
+      return this.request("GET", endpoint);
+    } catch (error) {
+      if (error.status === 404 || /HTTP 404|Not Found/i.test(String(error))) return null;
+      throw error;
+    }
+  }
+
+  capability(endpoint) {
+    try {
+      return { supported: true, value: this.request("GET", endpoint) };
+    } catch (error) {
+      if (
+        error.status === 403 ||
+        error.status === 404 ||
+        /HTTP 403|HTTP 404|Forbidden|Not Found/i.test(String(error))
+      ) {
+        return { supported: false, detail: String(error) };
+      }
+      throw error;
+    }
+  }
+}
+
+function run(command, args, options = {}) {
+  try {
+    return execFileSync(command, args, {
+      cwd: options.cwd,
+      encoding: "utf8",
+      maxBuffer: API_RESPONSE_LIMIT,
+      stdio: options.quiet ? ["pipe", "pipe", "pipe"] : ["pipe", "pipe", "inherit"],
+    }).trim();
+  } catch (error) {
+    const stderr = String(error?.stderr ?? "").trim();
+    throw new Error(`${command} ${args.join(" ")} failed${stderr ? `: ${stderr}` : ""}.`, {
+      cause: error,
+    });
+  }
+}
+
+export function desiredState(config, reviewerIds = []) {
+  const mergeMethods = new Set(config.repositorySettings.mergeMethods);
+  return {
+    defaultBranch: config.defaultBranch,
+    immutableReleases: true,
+    repositorySettings: {
+      wiki: config.repositorySettings.wiki,
+      projects: config.repositorySettings.projects,
+      squashMerge: mergeMethods.has("squash"),
+      mergeCommit: mergeMethods.has("merge"),
+      rebaseMerge: mergeMethods.has("rebase"),
+      autoMerge: config.repositorySettings.autoMerge,
+      deleteBranchOnMerge: config.repositorySettings.deleteBranchOnMerge,
+      updateBranch: config.repositorySettings.updateBranch,
+    },
+    workflowPermissions: config.workflowPermissions,
+    security: {
+      dependabotAlerts: config.security.dependabotAlerts,
+      dependabotSecurityUpdates: config.security.dependabotSecurityUpdates,
+      dependabotSecurityUpdatesPaused: false,
+      codeqlDefaultSetup: {
+        ...config.security.codeqlDefaultSetup,
+        languages: [...config.security.codeqlDefaultSetup.languages].sort(),
+      },
+    },
+    mainRuleset: {
+      name: config.mainRuleset.name,
+      enforcement: "active",
+      targetDefaultBranch: true,
+      requiredChecks: [...config.mainRuleset.requiredChecks].sort(),
+      strictStatusChecks: config.mainRuleset.requiredChecks.length > 0,
+      allowBranchCreationWithoutChecks: false,
+      requirePullRequest: true,
+      allowedMergeMethods: [...config.mainRuleset.allowedMergeMethods].sort(),
+      dismissStaleReviews: false,
+      requireCodeOwnerReview: false,
+      requireLastPushApproval: false,
+      requiredApprovals: 0,
+      requireConversationResolution: true,
+      blockForcePushes: true,
+      blockDeletion: true,
+    },
+    releaseEnvironment: config.releaseEnvironment
+      ? {
+          ...config.releaseEnvironment,
+          branches: [...config.releaseEnvironment.branches].sort(),
+          reviewers: [...reviewerIds]
+            .sort((left, right) => left - right)
+            .map((id) => ({ type: "User", id })),
+        }
+      : null,
+  };
+}
+
+export function normalizeRepositorySettings(repository) {
+  return {
+    wiki: repository.has_wiki,
+    projects: repository.has_projects,
+    squashMerge: repository.allow_squash_merge,
+    mergeCommit: repository.allow_merge_commit,
+    rebaseMerge: repository.allow_rebase_merge,
+    autoMerge: repository.allow_auto_merge,
+    deleteBranchOnMerge: repository.delete_branch_on_merge,
+    updateBranch: repository.allow_update_branch,
+  };
+}
+
+export function repositorySettingsPayload(control) {
+  return {
+    has_wiki: control.wiki,
+    has_projects: control.projects,
+    allow_squash_merge: control.squashMerge,
+    allow_merge_commit: control.mergeCommit,
+    allow_rebase_merge: control.rebaseMerge,
+    allow_auto_merge: control.autoMerge,
+    delete_branch_on_merge: control.deleteBranchOnMerge,
+    allow_update_branch: control.updateBranch,
+  };
+}
+
+export function normalizeDependabotSecurityUpdates(updates) {
+  return {
+    dependabotSecurityUpdates: Boolean(updates?.enabled && !updates.paused),
+    dependabotSecurityUpdatesPaused: Boolean(updates?.paused),
+  };
+}
+
+export function dependabotAlertsEnabled(api, repository) {
+  return api.optional(`repos/${repository}/vulnerability-alerts`) !== null;
+}
+
+export function normalizeCodeqlDefaultSetup(setup) {
+  const languages = new Set();
+  for (const language of setup.languages ?? []) {
+    if (
+      language === "javascript" ||
+      language === "typescript" ||
+      language === "javascript-typescript"
+    ) {
+      languages.add("javascript-typescript");
+    } else {
+      languages.add(language);
+    }
+  }
+  return {
+    state: setup.state,
+    languages: [...languages].sort(),
+    querySuite: setup.query_suite ?? "default",
+    threatModel: setup.threat_model ?? "remote",
+    runnerType: setup.runner_type ?? "standard",
+    runnerLabel: setup.runner_label ?? null,
+  };
+}
+
+export function codeqlDefaultSetupPayload(control) {
+  return {
+    state: control.state,
+    languages: control.languages,
+    query_suite: control.querySuite,
+    threat_model: control.threatModel,
+    runner_type: control.runnerType,
+    runner_label: control.runnerLabel,
+  };
+}
+
+export function normalizeMainRuleset(ruleset) {
+  if (!ruleset) return null;
+  const pullRequest = ruleset.rules.find((rule) => rule.type === "pull_request");
+  const statusChecks = ruleset.rules.find((rule) => rule.type === "required_status_checks");
+  const pullParameters = pullRequest?.parameters ?? {};
+  const checkParameters = statusChecks?.parameters ?? {};
+  return {
+    name: ruleset.name,
+    enforcement: ["active", "disabled", "evaluate"].includes(ruleset.enforcement)
+      ? ruleset.enforcement
+      : "disabled",
+    targetDefaultBranch:
+      ruleset.conditions?.ref_name?.include?.length === 1 &&
+      ruleset.conditions.ref_name.include[0] === "~DEFAULT_BRANCH" &&
+      (ruleset.conditions.ref_name.exclude?.length ?? 0) === 0,
+    requiredChecks: (checkParameters.required_status_checks ?? [])
+      .map((check) => check.context)
+      .sort(),
+    strictStatusChecks: Boolean(checkParameters.strict_required_status_checks_policy),
+    allowBranchCreationWithoutChecks: Boolean(checkParameters.do_not_enforce_on_create),
+    requirePullRequest: Boolean(pullRequest),
+    allowedMergeMethods: [...(pullParameters.allowed_merge_methods ?? [])].sort(),
+    dismissStaleReviews: Boolean(pullParameters.dismiss_stale_reviews_on_push),
+    requireCodeOwnerReview: Boolean(pullParameters.require_code_owner_review),
+    requireLastPushApproval: Boolean(pullParameters.require_last_push_approval),
+    requiredApprovals: Number(pullParameters.required_approving_review_count ?? 0),
+    requireConversationResolution: Boolean(pullParameters.required_review_thread_resolution),
+    blockForcePushes: ruleset.rules.some((rule) => rule.type === "non_fast_forward"),
+    blockDeletion: ruleset.rules.some((rule) => rule.type === "deletion"),
+  };
+}
+
+export function mainRulesetPayload(control, enforcement = control.enforcement) {
+  const rules = [
+    { type: "deletion" },
+    { type: "non_fast_forward" },
+    {
+      type: "pull_request",
+      parameters: {
+        allowed_merge_methods: control.allowedMergeMethods,
+        dismiss_stale_reviews_on_push: control.dismissStaleReviews,
+        require_code_owner_review: control.requireCodeOwnerReview,
+        require_last_push_approval: control.requireLastPushApproval,
+        required_approving_review_count: control.requiredApprovals,
+        required_review_thread_resolution: control.requireConversationResolution,
+      },
+    },
+  ];
+  if (control.requiredChecks.length > 0) {
+    rules.push({
+      type: "required_status_checks",
+      parameters: {
+        do_not_enforce_on_create: control.allowBranchCreationWithoutChecks,
+        required_status_checks: control.requiredChecks.map((context) => ({ context })),
+        strict_required_status_checks_policy: control.strictStatusChecks,
+      },
+    });
+  }
+  return {
+    name: control.name,
+    target: "branch",
+    enforcement,
+    bypass_actors: [],
+    conditions: { ref_name: { include: ["~DEFAULT_BRANCH"], exclude: [] } },
+    rules,
+  };
+}
+
+export function normalizeReleaseEnvironment(environment, policies, variables) {
+  if (!environment) return null;
+  const reviewRule = environment.protection_rules.find(
+    (rule) => rule.type === "required_reviewers",
+  );
+  const waitRule = environment.protection_rules.find((rule) => rule.type === "wait_timer");
+  return {
+    name: environment.name,
+    waitTimer: Number(waitRule?.wait_timer ?? 0),
+    preventSelfReview: Boolean(reviewRule?.prevent_self_review),
+    reviewers: (reviewRule?.reviewers ?? [])
+      .map(({ type, reviewer }) => ({ type, id: reviewer.id }))
+      .sort((left, right) => left.id - right.id),
+    branches: policies.map((policy) => policy.name).sort(),
+    customBranchesOnly: Boolean(
+      environment.deployment_branch_policy?.custom_branch_policies &&
+      !environment.deployment_branch_policy.protected_branches,
+    ),
+    guardValue: variables.find((variable) => variable.name === "RELEASE_GUARD")?.value ?? "",
+  };
+}
+
+function drift(control, operation) {
+  return { control, operation, status: "drift" };
+}
+
+export function planRepositoryControlChanges(current, desired) {
+  const changes = [];
+  if (current.defaultBranch !== desired.defaultBranch) {
+    changes.push({
+      control: "default-branch",
+      operation: "manual",
+      status: "manual",
+      detail: `Expected ${desired.defaultBranch}, found ${current.defaultBranch}.`,
+    });
+  }
+  if (current.immutableReleases !== desired.immutableReleases) {
+    changes.push(drift("immutable-releases", "enable"));
+  }
+  if (!isDeepStrictEqual(current.repositorySettings, desired.repositorySettings)) {
+    changes.push(drift("repository-settings", "update"));
+  }
+  if (!isDeepStrictEqual(current.workflowPermissions, desired.workflowPermissions)) {
+    changes.push(drift("workflow-permissions", "update"));
+  }
+  if (current.security.dependabotAlerts !== desired.security.dependabotAlerts) {
+    changes.push(drift("dependabot-alerts", "enable"));
+  }
+  if (current.security.dependabotSecurityUpdatesPaused) {
+    changes.push({
+      control: "dependabot-security-updates",
+      operation: "manual",
+      status: "manual",
+      detail: "Dependabot security updates are paused and require repository activity.",
+    });
+  } else if (
+    current.security.dependabotSecurityUpdates !== desired.security.dependabotSecurityUpdates
+  ) {
+    changes.push(drift("dependabot-security-updates", "enable"));
+  }
+  if (!current.security.codeqlSupported) {
+    changes.push({
+      control: "codeql-default-setup",
+      operation: "unsupported",
+      status: "unsupported",
+      detail: current.security.codeqlDetail,
+    });
+  } else if (
+    !isDeepStrictEqual(current.security.codeqlDefaultSetup, desired.security.codeqlDefaultSetup)
+  ) {
+    changes.push(drift("codeql-default-setup", "update"));
+  }
+  if (!current.rulesetsSupported) {
+    changes.push({
+      control: "main-ruleset",
+      operation: "unsupported",
+      status: "unsupported",
+      detail: current.rulesetsDetail,
+    });
+  } else if (!isDeepStrictEqual(current.mainRuleset, desired.mainRuleset)) {
+    changes.push(drift("main-ruleset", current.mainRuleset ? "update" : "create"));
+  }
+  if (!isDeepStrictEqual(current.releaseEnvironment, desired.releaseEnvironment)) {
+    changes.push(drift("release-environment", current.releaseEnvironment ? "update" : "create"));
+  }
+  return changes;
+}
+
+export async function waitForCodeql(read, desired, options = {}) {
+  const attempts = options.attempts ?? CODEQL_ATTEMPTS;
+  const delayMs = options.delayMs ?? CODEQL_DELAY_MS;
+  const delay =
+    options.delay ??
+    ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    if (isDeepStrictEqual(await read(), desired)) return;
+    if (attempt < attempts) await delay(delayMs);
+  }
+  throw new Error("CodeQL default setup did not reach the desired state in time.");
+}
+
+function validateConfig(config) {
+  if (config?.schemaVersion !== 1)
+    throw new Error("Unsupported repository-controls schema version.");
+  if (typeof config.repository !== "string" || !config.repository.includes("/")) {
+    throw new Error("Repository controls must declare repository in owner/name format.");
+  }
+  if (!config.repositorySettings || !config.security || !config.mainRuleset) {
+    throw new Error("Repository controls configuration is incomplete.");
+  }
+}
+
+function resolveReviewers(api, config) {
+  if (!config.releaseEnvironment) return [];
+  return config.releaseEnvironment.reviewers.map((login) => {
+    const reviewer = api.request("GET", `users/${login}`);
+    if (reviewer.login.toLowerCase() !== login.toLowerCase()) {
+      throw new Error(`Release reviewer ${login} could not be resolved.`);
+    }
+    return reviewer.id;
+  });
+}
+
+export function readRepositoryControlState(api, repository, desired) {
+  const repositorySettings = api.request("GET", `repos/${repository}`);
+  const immutable = api.optional(`repos/${repository}/immutable-releases`);
+  const workflow = api.request("GET", `repos/${repository}/actions/permissions/workflow`);
+  const dependabotAlerts = dependabotAlertsEnabled(api, repository);
+  const dependabotSecurityUpdates = api.optional(`repos/${repository}/automated-security-fixes`);
+  const codeql = api.capability(`repos/${repository}/code-scanning/default-setup`);
+  const rulesetsCapability = api.capability(`repos/${repository}/rulesets`);
+  const rulesets = rulesetsCapability.supported ? rulesetsCapability.value : [];
+  const rulesetSummary = rulesets.find((candidate) => candidate.name === desired.mainRuleset.name);
+  const ruleset = rulesetSummary
+    ? api.request("GET", `repos/${repository}/rulesets/${rulesetSummary.id}`)
+    : null;
+  const environment = desired.releaseEnvironment
+    ? api.optional(`repos/${repository}/environments/${desired.releaseEnvironment.name}`)
+    : null;
+  const policies = environment
+    ? api.request(
+        "GET",
+        `repos/${repository}/environments/${environment.name}/deployment-branch-policies?per_page=100`,
+      ).branch_policies
+    : [];
+  const variables = environment
+    ? api.request(
+        "GET",
+        `repos/${repository}/environments/${environment.name}/variables?per_page=100`,
+      ).variables
+    : [];
+
+  return {
+    state: {
+      defaultBranch: repositorySettings.default_branch,
+      immutableReleases: Boolean(immutable?.enabled),
+      repositorySettings: normalizeRepositorySettings(repositorySettings),
+      workflowPermissions: {
+        defaultWorkflowPermissions: workflow.default_workflow_permissions,
+        canApprovePullRequestReviews: workflow.can_approve_pull_request_reviews,
+      },
+      security: {
+        dependabotAlerts,
+        ...normalizeDependabotSecurityUpdates(dependabotSecurityUpdates),
+        codeqlSupported: codeql.supported,
+        codeqlDefaultSetup: codeql.supported ? normalizeCodeqlDefaultSetup(codeql.value) : null,
+        codeqlDetail: codeql.detail ?? null,
+      },
+      rulesetsSupported: rulesetsCapability.supported,
+      rulesetsDetail: rulesetsCapability.detail ?? null,
+      mainRuleset: normalizeMainRuleset(ruleset),
+      releaseEnvironment: normalizeReleaseEnvironment(environment, policies, variables),
+    },
+    rulesetId: ruleset?.id ?? null,
+  };
+}
+
+function printChanges(changes, log) {
+  if (changes.length === 0) {
+    log("Repository controls match the committed desired state.");
+    return;
+  }
+  log("Repository-control findings:");
+  for (const change of changes) {
+    log(
+      `- [${change.status}] ${change.operation} ${change.control}${change.detail ? `: ${change.detail}` : ""}`,
+    );
+  }
+}
+
+async function confirmApply() {
+  if (!process.stdin.isTTY) return false;
+  const prompt = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return (await prompt.question("Apply these repository-control changes? [y/N] ")).trim() === "y";
+  } finally {
+    prompt.close();
+  }
+}
+
+function applyReleaseEnvironment(api, repository, environment) {
+  api.request("PUT", `repos/${repository}/environments/${environment.name}`, {
+    wait_timer: environment.waitTimer,
+    prevent_self_review: environment.preventSelfReview,
+    reviewers: environment.reviewers,
+    deployment_branch_policy: {
+      protected_branches: false,
+      custom_branch_policies: environment.customBranchesOnly,
+    },
+  });
+  const policies =
+    api.optional(
+      `repos/${repository}/environments/${environment.name}/deployment-branch-policies?per_page=100`,
+    )?.branch_policies ?? [];
+  for (const branch of environment.branches) {
+    if (!policies.some((policy) => policy.name === branch)) {
+      api.request(
+        "POST",
+        `repos/${repository}/environments/${environment.name}/deployment-branch-policies`,
+        { name: branch },
+      );
+    }
+  }
+  for (const policy of policies) {
+    if (!environment.branches.includes(policy.name)) {
+      api.request(
+        "DELETE",
+        `repos/${repository}/environments/${environment.name}/deployment-branch-policies/${policy.id}`,
+      );
+    }
+  }
+  const variables = api.request(
+    "GET",
+    `repos/${repository}/environments/${environment.name}/variables?per_page=100`,
+  ).variables;
+  const guard = variables.find((variable) => variable.name === "RELEASE_GUARD");
+  const endpoint = `repos/${repository}/environments/${environment.name}/variables`;
+  if (!guard) {
+    api.request("POST", endpoint, { name: "RELEASE_GUARD", value: environment.guardValue });
+  } else if (guard.value !== environment.guardValue) {
+    api.request("PATCH", `${endpoint}/RELEASE_GUARD`, {
+      name: "RELEASE_GUARD",
+      value: environment.guardValue,
+    });
+  }
+}
+
+export async function runRepositoryControls(options = {}) {
+  const apply = options.apply ?? process.argv.includes("--apply");
+  const yes = options.yes ?? process.argv.includes("--yes");
+  const api = options.api ?? new GitHubApi();
+  const log = options.log ?? console.log;
+  const config = options.config ?? readBoundedJson(configPath);
+  validateConfig(config);
+
+  if (!options.skipGhChecks) {
+    run("gh", ["auth", "status"], { cwd: root, quiet: true });
+    const resolved = run(
+      "gh",
+      ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+      { cwd: root },
+    );
+    if (resolved.toLowerCase() !== config.repository.toLowerCase()) {
+      throw new Error(`Expected repository ${config.repository}, but gh resolved ${resolved}.`);
+    }
+  }
+
+  const reviewerIds = resolveReviewers(api, config);
+  const desired = desiredState(config, reviewerIds);
+  const current = readRepositoryControlState(api, config.repository, desired);
+  const changes = planRepositoryControlChanges(current.state, desired);
+  printChanges(changes, log);
+  if (config.manualControls.dependabotMalwareAlerts) {
+    log(
+      `Manual control: verify Dependabot malware alerts at https://github.com/${config.repository}/settings/security_analysis.`,
+    );
+  }
+  if (config.manualControls.disableEnvironmentAdminBypass && config.releaseEnvironment) {
+    log(
+      `Manual control: disable administrator bypass for the ${config.releaseEnvironment.name} environment.`,
+    );
+  }
+
+  if (!apply) return { ok: changes.length === 0, changes };
+  const blockers = changes.filter(({ status }) => status !== "drift");
+  if (blockers.length > 0) {
+    throw new Error("Manual or unsupported repository controls must be resolved before apply.");
+  }
+  if (changes.length === 0) return { ok: true, changes: [] };
+  if (!yes && !(await (options.confirmApply ?? confirmApply)())) {
+    throw new Error("Repository-control changes were not applied.");
+  }
+
+  for (const change of changes) {
+    if (change.control === "immutable-releases") {
+      api.request("PUT", `repos/${config.repository}/immutable-releases`);
+    } else if (change.control === "repository-settings") {
+      api.request(
+        "PATCH",
+        `repos/${config.repository}`,
+        repositorySettingsPayload(desired.repositorySettings),
+      );
+    } else if (change.control === "workflow-permissions") {
+      api.request("PUT", `repos/${config.repository}/actions/permissions/workflow`, {
+        default_workflow_permissions: desired.workflowPermissions.defaultWorkflowPermissions,
+        can_approve_pull_request_reviews: desired.workflowPermissions.canApprovePullRequestReviews,
+      });
+    } else if (change.control === "dependabot-alerts") {
+      api.request("PUT", `repos/${config.repository}/vulnerability-alerts`);
+    } else if (change.control === "dependabot-security-updates") {
+      api.request("PUT", `repos/${config.repository}/automated-security-fixes`);
+    } else if (change.control === "codeql-default-setup") {
+      api.request(
+        "PATCH",
+        `repos/${config.repository}/code-scanning/default-setup`,
+        codeqlDefaultSetupPayload(desired.security.codeqlDefaultSetup),
+      );
+    } else if (change.control === "main-ruleset") {
+      let rulesetId = current.rulesetId;
+      if (rulesetId === null) {
+        rulesetId = api.request(
+          "POST",
+          `repos/${config.repository}/rulesets`,
+          mainRulesetPayload(desired.mainRuleset, "disabled"),
+        ).id;
+      }
+      api.request(
+        "PUT",
+        `repos/${config.repository}/rulesets/${rulesetId}`,
+        mainRulesetPayload(desired.mainRuleset),
+      );
+    } else if (change.control === "release-environment" && desired.releaseEnvironment) {
+      applyReleaseEnvironment(api, config.repository, desired.releaseEnvironment);
+    }
+  }
+
+  if (changes.some(({ control }) => control === "codeql-default-setup")) {
+    await waitForCodeql(
+      () =>
+        normalizeCodeqlDefaultSetup(
+          api.request("GET", `repos/${config.repository}/code-scanning/default-setup`),
+        ),
+      desired.security.codeqlDefaultSetup,
+      options.polling,
+    );
+  }
+  const remaining = planRepositoryControlChanges(
+    readRepositoryControlState(api, config.repository, desired).state,
+    desired,
+  );
+  if (remaining.length > 0) {
+    throw new Error("Repository controls still differ after apply.");
+  }
+  log("Repository controls were applied and verified.");
+  return { ok: true, changes };
+}
+
+const isEntryPoint = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isEntryPoint) {
+  runRepositoryControls()
+    .then((result) => {
+      if (!result.ok) process.exitCode = 1;
+    })
+    .catch((error) => {
+      console.error(
+        error instanceof Error ? error.message : "Repository-control operation failed.",
+      );
+      process.exitCode = 1;
+    });
+}

--- a/packages/cli/src/templates/repository-controls.mjs
+++ b/packages/cli/src/templates/repository-controls.mjs
@@ -12,6 +12,7 @@ const CONFIG_LIMIT = 1024 * 1024;
 const API_RESPONSE_LIMIT = 20 * 1024 * 1024;
 const CODEQL_ATTEMPTS = 12;
 const CODEQL_DELAY_MS = 5_000;
+const MAX_PAGES = 100;
 const root = fileURLToPath(new URL("..", import.meta.url));
 const configPath = fileURLToPath(new URL("../.github/repository-controls.json", import.meta.url));
 
@@ -74,9 +75,22 @@ export class GitHubApi {
     }
   }
 
-  capability(endpoint) {
+  capability(endpoint, options = {}) {
     try {
-      return { supported: true, value: this.request("GET", endpoint) };
+      if (!options.paginate) {
+        return { supported: true, value: this.request("GET", endpoint) };
+      }
+      const value = [];
+      const separator = endpoint.includes("?") ? "&" : "?";
+      for (let page = 1; page <= MAX_PAGES; page += 1) {
+        const response = this.request("GET", `${endpoint}${separator}per_page=100&page=${page}`);
+        if (!Array.isArray(response)) {
+          throw new Error(`GitHub API GET ${endpoint} did not return a paginated array.`);
+        }
+        value.push(...response);
+        if (response.length < 100) return { supported: true, value };
+      }
+      throw new Error(`GitHub API GET ${endpoint} exceeded ${MAX_PAGES} pages.`);
     } catch (error) {
       if (
         error.status === 403 ||
@@ -108,6 +122,7 @@ function run(command, args, options = {}) {
 
 export function desiredState(config, reviewerIds = []) {
   const mergeMethods = new Set(config.repositorySettings.mergeMethods);
+  const codeqlDefaultSetup = config.security.codeqlDefaultSetup ?? {};
   return {
     defaultBranch: config.defaultBranch,
     immutableReleases: true,
@@ -126,10 +141,9 @@ export function desiredState(config, reviewerIds = []) {
       dependabotAlerts: config.security.dependabotAlerts,
       dependabotSecurityUpdates: config.security.dependabotSecurityUpdates,
       dependabotSecurityUpdatesPaused: false,
-      codeqlDefaultSetup: {
-        ...config.security.codeqlDefaultSetup,
-        languages: [...config.security.codeqlDefaultSetup.languages].sort(),
-      },
+      codeqlDefaultSetup: normalizeCodeqlDefaultSetup(
+        codeqlDefaultSetupPayload(codeqlDefaultSetup),
+      ),
     },
     mainRuleset: {
       name: config.mainRuleset.name,
@@ -220,7 +234,7 @@ export function normalizeCodeqlDefaultSetup(setup) {
   };
 }
 
-export function codeqlDefaultSetupPayload(control) {
+export function codeqlDefaultSetupPayload(control = {}) {
   return {
     state: control.state,
     languages: control.languages,
@@ -345,7 +359,9 @@ export function planRepositoryControlChanges(current, desired) {
     changes.push(drift("workflow-permissions", "update"));
   }
   if (current.security.dependabotAlerts !== desired.security.dependabotAlerts) {
-    changes.push(drift("dependabot-alerts", "enable"));
+    changes.push(
+      drift("dependabot-alerts", desired.security.dependabotAlerts ? "enable" : "disable"),
+    );
   }
   if (current.security.dependabotSecurityUpdatesPaused) {
     changes.push({
@@ -357,7 +373,12 @@ export function planRepositoryControlChanges(current, desired) {
   } else if (
     current.security.dependabotSecurityUpdates !== desired.security.dependabotSecurityUpdates
   ) {
-    changes.push(drift("dependabot-security-updates", "enable"));
+    changes.push(
+      drift(
+        "dependabot-security-updates",
+        desired.security.dependabotSecurityUpdates ? "enable" : "disable",
+      ),
+    );
   }
   if (!current.security.codeqlSupported) {
     changes.push({
@@ -403,10 +424,18 @@ export async function waitForCodeql(read, desired, options = {}) {
 function validateConfig(config) {
   if (config?.schemaVersion !== 1)
     throw new Error("Unsupported repository-controls schema version.");
-  if (typeof config.repository !== "string" || !config.repository.includes("/")) {
+  if (
+    typeof config.repository !== "string" ||
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(config.repository)
+  ) {
     throw new Error("Repository controls must declare repository in owner/name format.");
   }
-  if (!config.repositorySettings || !config.security || !config.mainRuleset) {
+  if (
+    !config.repositorySettings ||
+    !config.security ||
+    !config.mainRuleset ||
+    !config.manualControls
+  ) {
     throw new Error("Repository controls configuration is incomplete.");
   }
 }
@@ -429,7 +458,7 @@ export function readRepositoryControlState(api, repository, desired) {
   const dependabotAlerts = dependabotAlertsEnabled(api, repository);
   const dependabotSecurityUpdates = api.optional(`repos/${repository}/automated-security-fixes`);
   const codeql = api.capability(`repos/${repository}/code-scanning/default-setup`);
-  const rulesetsCapability = api.capability(`repos/${repository}/rulesets`);
+  const rulesetsCapability = api.capability(`repos/${repository}/rulesets`, { paginate: true });
   const rulesets = rulesetsCapability.supported ? rulesetsCapability.value : [];
   const rulesetSummary = rulesets.find((candidate) => candidate.name === desired.mainRuleset.name);
   const ruleset = rulesetSummary
@@ -607,9 +636,15 @@ export async function runRepositoryControls(options = {}) {
         can_approve_pull_request_reviews: desired.workflowPermissions.canApprovePullRequestReviews,
       });
     } else if (change.control === "dependabot-alerts") {
-      api.request("PUT", `repos/${config.repository}/vulnerability-alerts`);
+      api.request(
+        change.operation === "enable" ? "PUT" : "DELETE",
+        `repos/${config.repository}/vulnerability-alerts`,
+      );
     } else if (change.control === "dependabot-security-updates") {
-      api.request("PUT", `repos/${config.repository}/automated-security-fixes`);
+      api.request(
+        change.operation === "enable" ? "PUT" : "DELETE",
+        `repos/${config.repository}/automated-security-fixes`,
+      );
     } else if (change.control === "codeql-default-setup") {
       api.request(
         "PATCH",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
         specifier: 7.8.5
         version: 7.8.5
     devDependencies:
+      ajv:
+        specifier: 8.20.0
+        version: 8.20.0
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)(yaml@2.9.0)


### PR DESCRIPTION
## Summary

- Add configurable GitHub repository controls to the CLI and Composer.
- Add repository-controls template generation and config schema support.
- Document the new configuration and include compatibility coverage.

## Testing

- Added and updated CLI, schema, and Composer compatibility tests.
- Tests not run (not requested).

fix #391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional GitHub repository governance integration.
  * Generates repository policies, Dependabot settings, security configuration, documentation, and check/apply scripts.
  * Supports branch protection, merge rules, CodeQL, release environments, and required checks.
  * Provides read-only drift checks and a separately confirmed command for applying supported GitHub changes.
  * Added Composer configuration and validation for repository controls.

* **Documentation**
  * Documented setup, generated files, drift checks, apply workflow, and unsupported features.

* **Bug Fixes**
  * Composer now displays recipe errors instead of failing silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->