### PR TITLE
Extend CodeQL verification and normalize empty runner labels

### DIFF
--- a/packages/cli/scripts/github-repository-controls.test.mjs
+++ b/packages/cli/scripts/github-repository-controls.test.mjs
@@ -15,6 +15,8 @@ import {
 import { applyRecipeObject } from "../src/index.js";
 import { buildRecipe } from "../src/recipe.js";
 import {
+  CODEQL_ATTEMPTS,
+  CODEQL_DELAY_MS,
   GitHubApi,
   dependabotAlertsEnabled,
   desiredState,
@@ -172,9 +174,17 @@ test("planner separates drift, manual remediation, and unsupported controls", ()
   ]);
 });
 
-test("CodeQL normalization tolerates omitted optional response fields", () => {
+test("CodeQL normalization tolerates omitted fields and empty runner labels", () => {
   assert.deepEqual(normalizeCodeqlDefaultSetup({ state: "not-configured" }), {
     state: "not-configured",
+    languages: [],
+    querySuite: "default",
+    threatModel: "remote",
+    runnerType: "standard",
+    runnerLabel: null,
+  });
+  assert.deepEqual(normalizeCodeqlDefaultSetup({ state: "configured", runner_label: "" }), {
+    state: "configured",
     languages: [],
     querySuite: "default",
     threatModel: "remote",
@@ -202,6 +212,10 @@ test("desired CodeQL state normalizes omitted defaults like the GitHub response"
     runnerLabel: null,
   });
   const current = structuredClone(desired);
+  current.security.codeqlDefaultSetup = normalizeCodeqlDefaultSetup({
+    ...codeqlDefaultSetupPayload(desired.security.codeqlDefaultSetup),
+    runner_label: "",
+  });
   current.security.codeqlSupported = true;
   current.rulesetsSupported = true;
   assert.deepEqual(planRepositoryControlChanges(current, desired), []);
@@ -309,6 +323,10 @@ test("repository-state reads update a matching ruleset returned after the first 
 });
 
 test("CodeQL verification polling is bounded", async () => {
+  assert.equal(CODEQL_ATTEMPTS, 36);
+  assert.equal(CODEQL_DELAY_MS, 5_000);
+  assert.equal((CODEQL_ATTEMPTS - 1) * CODEQL_DELAY_MS, 175_000);
+
   let reads = 0;
   await assert.rejects(
     () =>

--- a/packages/cli/src/templates/repository-controls.mjs
+++ b/packages/cli/src/templates/repository-controls.mjs
@@ -10,8 +10,8 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const API_VERSION = "2026-03-10";
 const CONFIG_LIMIT = 1024 * 1024;
 const API_RESPONSE_LIMIT = 20 * 1024 * 1024;
-const CODEQL_ATTEMPTS = 12;
-const CODEQL_DELAY_MS = 5_000;
+export const CODEQL_ATTEMPTS = 36;
+export const CODEQL_DELAY_MS = 5_000;
 const MAX_PAGES = 100;
 const root = fileURLToPath(new URL("..", import.meta.url));
 const configPath = fileURLToPath(new URL("../.github/repository-controls.json", import.meta.url));
@@ -230,7 +230,7 @@ export function normalizeCodeqlDefaultSetup(setup) {
     querySuite: setup.query_suite ?? "default",
     threatModel: setup.threat_model ?? "remote",
     runnerType: setup.runner_type ?? "standard",
-    runnerLabel: setup.runner_label ?? null,
+    runnerLabel: setup.runner_label || null,
   };
 }
 


### PR DESCRIPTION
## Summary

- Extend bounded CodeQL verification polling to 36 attempts.
- Normalize empty runner labels to `null`.
- Add unit coverage for normalization and polling bounds.

## Testing

- Not run (not requested)

fix #400